### PR TITLE
Remove tests on push, increase timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,6 @@
 name: Test
 
 on:
-  push:
-    branches:
-      - 'main'
-    paths:
-      - '**'
-      - '!**/.gitignore'
-      - '!**/*.md'
-      - '!LICENSE'
-      - '!.github/**'
-      - '.github/workflows/test.yml'
-
   pull_request:
     paths:
       - '**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
         run: git diff --compact-summary --exit-code || (echo -e "\nDocumentation is out of sync. Run 'go generate ./...' to update and commit the changes." && exit 1)
 
   acceptance:
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to run tests only on pull requests and manual triggers.
  * Increased the timeout for the acceptance test job to 30 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->