### PR TITLE
feat: support provider env vars

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -32,11 +32,11 @@ func NewClient(apiKey string) *Client {
 	}
 }
 
-func (c *Client) GetApiKey() string {
+func (c *Client) ApiKey() string {
 	return c.apiKey
 }
 
-func (c *Client) GetBaseURL() string {
+func (c *Client) BaseURL() string {
 	return c.baseURL
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -32,6 +32,14 @@ func NewClient(apiKey string) *Client {
 	}
 }
 
+func (c *Client) GetApiKey() string {
+	return c.apiKey
+}
+
+func (c *Client) GetBaseURL() string {
+	return c.baseURL
+}
+
 // SetBaseURL sets the base URL for the client.
 func (c *Client) SetBaseURL(url string) {
 	c.baseURL = url

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -37,13 +37,12 @@ func (p *UptimeRobotProvider) Schema(ctx context.Context, req provider.SchemaReq
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"api_key": schema.StringAttribute{
-				MarkdownDescription: "API key for authentication.",
-				Required:            true,
-
-				Sensitive: true,
+				MarkdownDescription: "API key for authentication. Can also be set via the `UPTIMEROBOT_API_KEY` environment variable.",
+				Optional:            true,
+				Sensitive:           true,
 			},
 			"api_url": schema.StringAttribute{
-				MarkdownDescription: "Optional API endpoint URL. If not specified, the default endpoint will be used.",
+				MarkdownDescription: "Optional API endpoint URL. If not specified, the default endpoint will be used. Can also be set via the `UPTIMEROBOT_API_URL` environment variable.",
 				Optional:            true,
 			},
 		},
@@ -55,40 +54,39 @@ func (p *UptimeRobotProvider) Configure(ctx context.Context, req provider.Config
 	apiURL := os.Getenv("UPTIMEROBOT_API_URL")
 
 	var config UptimeRobotProviderModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
-	if resp.Diagnostics.HasError() {
-		return
+
+	// Only try to read config if Terraform actually provided something
+	if !req.Config.Raw.IsNull() {
+		resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
-	// Check configuration data, which should take precedence over
-	// environment variable data, if found.
-	if config.APIKey.ValueString() != "" {
+	// Config values take precedence over env vars
+	if !config.APIKey.IsNull() && !config.APIKey.IsUnknown() {
 		apiKey = config.APIKey.ValueString()
 	}
-
-	if config.APIURL.ValueString() != "" {
+	if !config.APIURL.IsNull() && !config.APIURL.IsUnknown() {
 		apiURL = config.APIURL.ValueString()
 	}
 
 	if apiKey == "" {
 		resp.Diagnostics.AddError(
 			"Missing API Key Configuration",
-			"While configuring the provider, the API key was not found in the configuration. Please ensure the api_key argument is set in the provider configuration.",
+			"While configuring the provider, the API key was not found in the configuration or the UPTIMEROBOT_API_KEY environment variable.",
 		)
-
+		return
 	}
 
-	// Create a new client using the configuration
 	client := client.NewClient(apiKey)
 
 	// Override the default endpoint if specified in config or environment
 	if apiURL == "" {
 		apiURL = "https://api.uptimerobot.com/v3"
 	}
-
 	client.SetBaseURL(apiURL)
 
-	// Make the client available during DataSource and Resource Configure methods
 	resp.DataSourceData = client
 	resp.ResourceData = client
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -51,7 +51,7 @@ func (p *UptimeRobotProvider) Schema(ctx context.Context, req provider.SchemaReq
 }
 
 func (p *UptimeRobotProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
-	apiKey := os.Getenv("UPTIMEROBOT_API_TOKEN")
+	apiKey := os.Getenv("UPTIMEROBOT_API_KEY")
 	apiURL := os.Getenv("UPTIMEROBOT_API_URL")
 
 	var config UptimeRobotProviderModel

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -38,10 +38,7 @@ func testAccPreCheck() {
 	}
 }
 
-// New test to verify provider configuration using environment variables.
 func TestProviderConfigure_EnvironmentVariables(t *testing.T) {
-	// Use t.Setenv() to set environment variables for the duration of this test.
-	// This automatically cleans them up after the test completes.
 	const testAPIKey = "test-api-key-from-env"
 	const testAPIURL = "http://test-api-url.com"
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -42,7 +42,7 @@ func TestProviderConfigure_EnvironmentVariables(t *testing.T) {
 	const testAPIKey = "test-api-key-from-env"
 	const testAPIURL = "http://test-api-url.com"
 
-	t.Setenv("UPTIMEROBOT_API_TOKEN", testAPIKey)
+	t.Setenv("UPTIMEROBOT_API_KEY", testAPIKey)
 	t.Setenv("UPTIMEROBOT_API_URL", testAPIURL)
 
 	p := New("test")()


### PR DESCRIPTION
This change allows a user to configure the provider using env vars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider now supports reading API key and API URL from environment variables, with configuration values taking precedence if set.
  * Added read-only access to API key and base URL in client settings.

* **Bug Fixes**
  * Ensured that the provider correctly falls back to the default API URL when the environment variable is not set.

* **Tests**
  * Added tests to verify provider configuration using environment variables.
  * Improved test coverage for provider setup and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->