### PR TITLE
fix: webhookURL for requests instead of value for slack integration

### DIFF
--- a/internal/client/integration.go
+++ b/internal/client/integration.go
@@ -7,6 +7,7 @@ type Integration struct {
 	Type                   string `json:"type"`
 	Status                 string `json:"status"`
 	Value                  string `json:"value"`
+	WebhookURL             string `json:"webhookURL,omitempty"`
 	CustomValue            string `json:"customValue,omitempty"`
 	EnableNotificationsFor string `json:"enableNotificationsFor"`
 	SSLExpirationReminder  bool   `json:"sslExpirationReminder"`
@@ -26,7 +27,7 @@ type CreateIntegrationRequest struct {
 // SlackIntegrationData represents the data structure for Slack integrations.
 type SlackIntegrationData struct {
 	FriendlyName           string `json:"friendlyName,omitempty"`
-	Value                  string `json:"value"`
+	WebhookURL             string `json:"webhookURL,omitempty"`
 	CustomValue            string `json:"customValue,omitempty"`
 	EnableNotificationsFor string `json:"enableNotificationsFor,omitempty"`
 	SSLExpirationReminder  bool   `json:"sslExpirationReminder,omitempty"`

--- a/internal/provider/integration_resource.go
+++ b/internal/provider/integration_resource.go
@@ -286,7 +286,7 @@ func (r *integrationResource) Create(ctx context.Context, req resource.CreateReq
 	case "slack":
 		integrationData = &client.SlackIntegrationData{
 			FriendlyName:           plan.Name.ValueString(),
-			Value:                  plan.Value.ValueString(),
+			WebhookURL:             plan.Value.ValueString(),
 			CustomValue:            plan.CustomValue.ValueString(),
 			EnableNotificationsFor: convertNotificationsForToString(plan.EnableNotificationsFor.ValueInt64()),
 			SSLExpirationReminder:  plan.SSLExpirationReminder.ValueBool(),
@@ -370,7 +370,13 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 	// Map response body to schema and populate Computed attribute values
 	state.Name = types.StringValue(integration.Name)
 	state.Type = types.StringValue(TransformIntegrationTypeFromAPI(integration.Type))
-	state.Value = types.StringValue(integration.Value)
+
+	if integration.WebhookURL != "" {
+		state.Value = types.StringValue(integration.WebhookURL)
+	} else {
+		state.Value = types.StringValue(integration.Value)
+	}
+
 	state.EnableNotificationsFor = types.Int64Value(convertNotificationsForFromString(integration.EnableNotificationsFor))
 	state.SSLExpirationReminder = types.BoolValue(integration.SSLExpirationReminder)
 
@@ -439,7 +445,7 @@ func (r *integrationResource) Update(ctx context.Context, req resource.UpdateReq
 	case "slack":
 		integrationData = &client.SlackIntegrationData{
 			FriendlyName:           plan.Name.ValueString(),
-			Value:                  plan.Value.ValueString(),
+			WebhookURL:             plan.Value.ValueString(),
 			CustomValue:            plan.CustomValue.ValueString(),
 			EnableNotificationsFor: convertNotificationsForToString(plan.EnableNotificationsFor.ValueInt64()),
 			SSLExpirationReminder:  plan.SSLExpirationReminder.ValueBool(),


### PR DESCRIPTION
resolves #34 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated webhook URL field for Slack and webhook integrations for easier webhook URL management and clearer configuration options.
  * Better handling of webhook-specific settings (send as JSON/query string/post parameters).

* **Bug Fixes**
  * Improved consistency in how Slack webhook URLs and related webhook settings are stored, displayed, and updated across create/read/update flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->