### PR TITLE
docs: add issue templates and CONTRIBUTING instructions for local dev

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,101 @@
+name: "🐞 Bug report"
+description: Problem with the provider, a resource, or a data source
+title: "[Bug]: <short summary>"
+labels: ["bug", "triage"]
+body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected component
+      options:
+        - "Provider (authentication/configuration)"
+        - "Resource: Monitor"
+        - "Resource: Integration"
+        - "Resource: Public Status Page (PSP)"
+        - "Resource: Maintenance Window"
+        - "Data Source"
+        - "Import"
+        - "Plan/State"
+        - "Documentation"
+        - "Other / Unsure"
+    validations:
+      required: true
+
+  - type: input
+    id: other_component
+    attributes:
+      label: If "Other / Unsure", briefly describe
+      placeholder: e.g., acceptance tests, registry docs page, examples
+
+  - type: input
+    id: resource_name
+    attributes:
+      label: Resource/Data Source name (if applicable)
+      placeholder: "e.g., uptimerobot_monitor / data.uptimerobot_account / uptimerobot_integration (e.g., Slack)"
+  
+  - type: input
+    id: tf_or_tofu_version
+    attributes:
+      label: Terraform/OpenTofu version
+      placeholder: "Terraform 1.9.5 or OpenTofu 1.7.3"
+    validations:
+      required: true
+
+  - type: input
+    id: provider_version
+    attributes:
+      label: Provider version
+      placeholder: "v1.1.1"
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Minimal reproducible config
+      description: Redact secrets; keep it as small as possible.
+      render: terraform
+      placeholder: |
+        resource "uptimerobot_monitor" "example" {
+          friendly_name = "API"
+          url           = "https://example.com/healthz"
+          type          = "HTTP"
+        }
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. terraform init
+        2. terraform apply
+        3. observe error …
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior / logs
+      description: Paste relevant error output or logs (redact secrets).
+      render: bash
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues/PRs
+          required: true
+        - label: I can reproduce with the latest provider release
+          required: true
+        - label: Also reproduces with the other CLI (Terraform/OpenTofu)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & usage help
+    url: https://github.com/uptimerobot/terraform-provider-uptimerobot/discussions
+    about: Please use Discussions for “how do I…?” questions.
+  # - name: Security vulnerability
+  #   url: https://github.com/<org>/<repo>/security/policy
+  #   about: Report security issues privately.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,67 @@
+name: "📚 Docs improvement"
+description: Fix or improve provider documentation
+title: "[Docs]: <page or concept>"
+labels: ["documentation", "triage"]
+body:
+  - type: dropdown
+    id: doc_area
+    attributes:
+      label: Area
+      options:
+        - "Resource docs"
+        - "Data source docs"
+        - "Provider docs (authentication/configuration)"
+        - "Examples"
+        - "README"
+        - "Changelog"
+        - "Other / Unsure"
+    validations:
+      required: true
+
+  - type: input
+    id: page
+    attributes:
+      label: Page/URL (if applicable)
+      placeholder: "e.g., docs/resources/monitor.md or a link to the page"
+
+  - type: textarea
+    id: issue
+    attributes:
+      label: What’s wrong or missing?
+      description: Be specific—typos, outdated flags, missing argument, unclear behavior, etc.
+      placeholder: "The `method` argument is missing from the monitor docs; import example still shows v1; etc."
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested change (optional)
+      description: Provide the fixed text or example if you can.
+      render: markdown
+      placeholder: |
+        **Proposed snippet**
+        ```terraform
+        resource "uptimerobot_monitor" "api" {
+          name   = "API"
+          url    = "https://example.com/healthz"
+          type   = "HTTP"
+          method = "HEAD"
+        }
+        ```
+        - Add `method` argument (GET, HEAD, POST…)
+        - Update import example to v1.1.1
+
+  - type: input
+    id: versions
+    attributes:
+      label: Terraform/OpenTofu + provider versions (optional)
+      placeholder: "Terraform 1.9.5 / OpenTofu 1.7.3; provider v1.1.1"
+
+  - type: checkboxes
+    id: flags
+    attributes:
+      label: Flags
+      options:
+        - label: This is a quick fix (typo/wording)
+        - label: I can provide exact wording here or open a PR (maintainers will review; please reference this issue)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,102 @@
+name: "✨ Feature request"
+description: Improve existing provider behavior (not a new resource)
+title: "[Feat]: <short summary>"
+labels: ["enhancement", "triage"]
+body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected component (if applicable)
+      options:
+        - "Provider (authentication/configuration)"
+        - "Resource: Monitor"
+        - "Resource: Integration"
+        - "Resource: Public Status Page (PSP)"
+        - "Resource: Maintenance Window"
+        - "Data Source"
+        - "Import"
+        - "Plan/State"
+        - "Documentation"
+        - "Other / Unsure"
+
+  - type: input
+    id: resource_name
+    attributes:
+      label: Resource/Data Source name (if applicable)
+      placeholder: "e.g., uptimerobot_monitor / data.uptimerobot_account / uptimerobot_integration"
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What is the pain or limitation today?
+      placeholder: "E.g., Updating 'interval' forces replacement but should be in-place; missing 'method' on HTTP monitor; etc."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Be specific (new arguments, env vars, diff rules, import, docs).
+      placeholder: "Add 'method' argument to uptimerobot_monitor, default GET; mark as ForceNew=false; validate against allowed values."
+    validations:
+      required: true
+
+  - type: textarea
+    id: config_example
+    attributes:
+      label: Example config (optional)
+      description: Minimal snippet showing the proposed change.
+      render: terraform
+      placeholder: |
+        resource "uptimerobot_monitor" "api" {
+          name     = "API"
+          url      = "https://example.com/healthz"
+          type     = "HTTP"
+          # proposal: method support
+          method   = "HEAD"
+        }
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives/workarounds tried
+      placeholder: "Workarounds, external scripts, manual steps, etc."
+
+  - type: input
+    id: tf_or_tofu_version
+    attributes:
+      label: Terraform/OpenTofu version (optional)
+      placeholder: "Terraform 1.9.5 or OpenTofu 1.7.3"
+
+  - type: input
+    id: provider_version
+    attributes:
+      label: Provider version (optional)
+      placeholder: "v1.1.1"
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Impact / Priority (self-assessed)
+      options:
+        - Nice to have
+        - Important
+        - Critical
+
+  - type: checkboxes
+    id: flags
+    attributes:
+      label: Flags
+      description: "Note: maintainers will assess and decide whether a change is actually breaking."
+      options:
+        - label: This may be a breaking change (needs migration or could change plan behavior)
+        - label: I'm willing to help test a PR/build
+
+  - type: textarea
+    id: docs_tests
+    attributes:
+      label: Docs/tests impact (optional)
+      description: Docs pages to update, acceptance tests to add/adjust, import format details, etc. If you're unsure, leave blank.
+      placeholder: "Docs: monitor resource page; Tests: add update test for 'method'; Import: unchanged"

--- a/.github/ISSUE_TEMPLATE/new_resource.yml
+++ b/.github/ISSUE_TEMPLATE/new_resource.yml
@@ -1,0 +1,82 @@
+name: "🧩 New resource / data source"
+description: Propose adding a new Terraform resource or data source
+title: "[New]: <service>:<thing>"
+labels: ["enhancement", "new-resource", "triage"]
+body:
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind
+      options:
+        - "Resource"
+        - "Data Source"
+    validations:
+      required: true
+
+  - type: input
+    id: name
+    attributes:
+      label: Proposed name
+      placeholder: "uptimerobot_monitor_http / uptimerobot_integration / data.uptimerobot_account"
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case
+      description: What real workflows does this unlock?
+      placeholder: |
+        Create specialized HTTP monitors with extra checks; manage Slack/PagerDuty/email integrations per team; fetch account limits; etc.
+    validations:
+      required: true
+
+  - type: textarea
+    id: schema
+    attributes:
+      label: Rough schema (optional)
+      render: terraform
+      placeholder: |
+        # Example: new/extended monitor resource
+        resource "uptimerobot_monitor_http" "api" {
+          name      = "API Health"
+          url       = "https://example.com/healthz"
+          interval  = 60
+          timeout   = 10
+          method    = "GET"
+          # new fields you want to propose go here...
+        }
+
+        # Example: integration
+        resource "uptimerobot_integration" "slack" {
+          name  = "Team Slack"
+          type  = "slack"
+          value = "https://hooks.slack.com/services/XXXXX/YYYYY/ZZZZZ"
+        }
+
+        # Example: data source
+        # data "uptimerobot_account" "current" {}
+
+  - type: textarea
+    id: api
+    attributes:
+      label: API references (optional)
+      description: Links to endpoints/docs if you have them.
+      placeholder: |
+        POST /v3/monitors
+        GET  /v3/monitors/{id}
+        POST /v3/integrations
+        GET  /v3/integrations/{id}
+
+  - type: textarea
+    id: plan_behavior
+    attributes:
+      label: Plan/Apply semantics & import (optional)
+      description: ForceNew fields, import ID format, expected diffs, etc.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Reporter checks (optional)
+      options:
+        - label: I found public API docs that appear to support create/read/update/delete

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+## Local dev build & Terraform/OpenTofu override
+
+1. **Build the provider**
+   ```bash
+   make build
+   # or: go build -o terraform-provider-uptimerobot_v0.0.0-dev
+   ```
+
+2. **Create override config**
+Create ```~/.terraformrc``` (UNIX/MacOS) or ```%APPDATA%\terraform.rc```(Windows).
+You can also set TF_CLI_CONFIG_FILE to a custom path (works for Terraform and OpenTofu):
+
+    ```
+    # ~/.terraformrc (example)
+    provider_installation {
+    dev_overrides {
+        "uptimerobot/uptimerobot" = "/ABSOLUTE/PATH/TO/local/build/dir"
+    }
+    direct {}
+    }
+    ```
+
+3. **Use dev version in your config**
+    ```
+    terraform {
+      required_providers {
+        uptimerobot = {
+          source  = "uptimerobot/uptimerobot"
+          # version intentionally omitted for local dev with dev_overrides
+        }
+      }
+    }
+    ```
+    Then run
+    ```bash
+    terraform init -upgrade
+    terraform apply
+    ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added standardized GitHub issue templates for bugs, feature requests, docs improvements, and new resource/data source proposals — each includes guided fields, validation, and suggested inputs.
  * Disabled blank issues and added a Discussions contact link for questions and usage help.

* **Documentation**
  * Expanded CONTRIBUTING with local dev build steps, CLI override setup, and instructions to test a development provider with Terraform/OpenTofu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->