### PR TITLE
Fix/78 missed validation post data

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@ default: testacc
 # Run acceptance tests
 .PHONY: testacc
 testacc:
-	set -a; [ -f .env ] && source .env; set +a && TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 5m
+	set -a; [ -f .env ] && source .env; set +a && TF_ACC=1 go test ./internal/provider -run TestAcc -v $(TESTARGS) -timeout 45m
 
 # Run unit tests
 .PHONY: test

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -221,7 +221,6 @@ Common monitoring intervals:
 - `port` (Number) The port to monitor
 - `post_value_data` (String) JSON body (use jsonencode). Mutually exclusive with post_value_kv.
 - `post_value_kv` (Map of String) Key/Value body for application/x-www-form-urlencoded. Mutually exclusive with post_value_data.
-- `post_value_type` (String) Computed body type used by UptimeRobot when sending the monitor request. Set automatically to RAW_JSON or KEY_VALUE.
 - `regional_data` (String) Region for monitoring: na (North America), eu (Europe), as (Asia), oc (Oceania)
 - `response_time_threshold` (Number) Response time threshold in milliseconds. Response time over this threshold will trigger an incident
 - `ssl_expiration_reminder` (Boolean) Whether to enable SSL expiration reminders
@@ -232,4 +231,5 @@ Common monitoring intervals:
 ### Read-Only
 
 - `id` (String) Monitor ID
+- `post_value_type` (String) Computed body type used by UptimeRobot when sending the monitor request. Set automatically to RAW_JSON or KEY_VALUE.
 - `status` (String) Status of the monitor

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -219,16 +219,16 @@ Common monitoring intervals:
 - `keyword_value` (String) The keyword to search for
 - `maintenance_window_ids` (List of Number) The maintenance window IDs
 - `port` (Number) The port to monitor
-- `post_value_data` (String) The data to send with POST request
-- `post_value_type` (String) The type of data to send with POST request
+- `post_value_data` (String) JSON payload body as a string. Use jsonencode.
 - `regional_data` (String) Region for monitoring: na (North America), eu (Europe), as (Asia), oc (Oceania)
 - `response_time_threshold` (Number) Response time threshold in milliseconds. Response time over this threshold will trigger an incident
 - `ssl_expiration_reminder` (Boolean) Whether to enable SSL expiration reminders
 - `success_http_response_codes` (List of String) The expected HTTP response codes
 - `tags` (Set of String) Tags for the monitor
-- `timeout` (Number) Timeout for the check (in seconds). Not applicable for HEARTBEAT; ignored for DNS/PING. If omitted, API default is used
+- `timeout` (Number) Timeout for the check (in seconds). Not applicable for HEARTBEAT; ignored for DNS/PING. If omitted, default value 30 is used.
 
 ### Read-Only
 
 - `id` (String) Monitor ID
+- `post_value_type` (String) The type of data to send with POST request. Server value is RAW_JSON when body is present.
 - `status` (String) Status of the monitor

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -219,7 +219,9 @@ Common monitoring intervals:
 - `keyword_value` (String) The keyword to search for
 - `maintenance_window_ids` (List of Number) The maintenance window IDs
 - `port` (Number) The port to monitor
-- `post_value_data` (String) JSON payload body as a string. Use jsonencode.
+- `post_value_data` (String) JSON body (use jsonencode). Mutually exclusive with post_value_kv.
+- `post_value_kv` (Map of String) Key/Value body for application/x-www-form-urlencoded. Mutually exclusive with post_value_data.
+- `post_value_type` (String) Computed body type used by UptimeRobot when sending the monitor request. Set automatically to RAW_JSON or KEY_VALUE.
 - `regional_data` (String) Region for monitoring: na (North America), eu (Europe), as (Asia), oc (Oceania)
 - `response_time_threshold` (Number) Response time threshold in milliseconds. Response time over this threshold will trigger an incident
 - `ssl_expiration_reminder` (Boolean) Whether to enable SSL expiration reminders
@@ -230,5 +232,4 @@ Common monitoring intervals:
 ### Read-Only
 
 - `id` (String) Monitor ID
-- `post_value_type` (String) The type of data to send with POST request. Server value is RAW_JSON when body is present.
 - `status` (String) Status of the monitor

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,8 @@ go 1.24.4
 
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.23.0
-	github.com/hashicorp/terraform-plugin-framework v1.16.0
+	github.com/hashicorp/terraform-plugin-framework v1.16.1
+	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0
 	github.com/hashicorp/terraform-plugin-go v0.29.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
@@ -75,13 +76,13 @@ require (
 	golang.org/x/crypto v0.42.0 // indirect
 	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8 // indirect
 	golang.org/x/mod v0.27.0 // indirect
-	golang.org/x/net v0.43.0 // indirect
+	golang.org/x/net v0.44.0 // indirect
 	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.29.0 // indirect
 	golang.org/x/tools v0.36.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250929231259-57b25ae835d4 // indirect
 	google.golang.org/grpc v1.75.1 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,10 @@ github.com/hashicorp/terraform-json v0.27.1 h1:zWhEracxJW6lcjt/JvximOYyc12pS/gaK
 github.com/hashicorp/terraform-json v0.27.1/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
 github.com/hashicorp/terraform-plugin-docs v0.23.0 h1:sipnfD4/9EJBg9zekym+s1H6qmLAKJHhGWBwvN9v/hE=
 github.com/hashicorp/terraform-plugin-docs v0.23.0/go.mod h1:J4b5AtMRgJlDrwCQz+G4hKABgHY5m56PnsRmdAzBwW8=
-github.com/hashicorp/terraform-plugin-framework v1.16.0 h1:tP0f+yJg0Z672e7levixDe5EpWwrTrNryPM9kDMYIpE=
-github.com/hashicorp/terraform-plugin-framework v1.16.0/go.mod h1:0xFOxLy5lRzDTayc4dzK/FakIgBhNf/lC4499R9cV4Y=
+github.com/hashicorp/terraform-plugin-framework v1.16.1 h1:1+zwFm3MEqd/0K3YBB2v9u9DtyYHyEuhVOfeIXbteWA=
+github.com/hashicorp/terraform-plugin-framework v1.16.1/go.mod h1:0xFOxLy5lRzDTayc4dzK/FakIgBhNf/lC4499R9cV4Y=
+github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0 h1:SJXL5FfJJm17554Kpt9jFXngdM6fXbnUnZ6iT2IeiYA=
+github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0/go.mod h1:p0phD0IYhsu9bR4+6OetVvvH59I6LwjXGnTVEr8ox6E=
 github.com/hashicorp/terraform-plugin-framework-validators v0.18.0 h1:OQnlOt98ua//rCw+QhBbSqfW3QbwtVrcdWeQN5gI3Hw=
 github.com/hashicorp/terraform-plugin-framework-validators v0.18.0/go.mod h1:lZvZvagw5hsJwuY7mAY6KUz45/U6fiDR0CzQAwWD0CA=
 github.com/hashicorp/terraform-plugin-go v0.29.0 h1:1nXKl/nSpaYIUBU1IG/EsDOX0vv+9JxAltQyDMpq5mU=
@@ -241,8 +243,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
-golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=
-golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=
+golang.org/x/net v0.44.0 h1:evd8IRDyfNBMBTTY5XRF1vaZlD+EmWx6x8PkhR04H/I=
+golang.org/x/net v0.44.0/go.mod h1:ECOoLqd5U3Lhyeyo/QDCEVQ4sNgYsqvCZ722XogGieY=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -286,8 +288,8 @@ gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAsM=
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 h1:pFyd6EwwL2TqFf8emdthzeX+gZE1ElRq3iM8pui4KBY=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20250929231259-57b25ae835d4 h1:i8QOKZfYg6AbGVZzUAY3LrNWCKF8O6zFisU9Wl9RER4=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20250929231259-57b25ae835d4/go.mod h1:HSkG/KdJWusxU1F6CNrwNDjBMgisKxGnc5dAZfT0mjQ=
 google.golang.org/grpc v1.75.1 h1:/ODCNEuf9VghjgO3rqLcfg8fiOP0nSluljWFlDxELLI=
 google.golang.org/grpc v1.75.1/go.mod h1:JtPAzKiq4v1xcAB2hydNlWI2RnF85XXcV0mhKXr2ecQ=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/internal/client/monitor.go
+++ b/internal/client/monitor.go
@@ -40,8 +40,8 @@ type CreateMonitorRequest struct {
 	MaintenanceWindowIDs     []int64           `json:"maintenanceWindowsIds,omitempty"`
 	Tags                     []string          `json:"tagNames"`
 	GracePeriod              *int              `json:"gracePeriod,omitempty"`
-	PostValueData            interface{}       `json:"postValueData,omitempty"`
 	PostValueType            string            `json:"postValueType,omitempty"`
+	PostValueData            interface{}       `json:"postValueData,omitempty"`
 	SSLExpirationReminder    bool              `json:"sslExpirationReminder"`
 	DomainExpirationReminder bool              `json:"domainExpirationReminder"`
 	FollowRedirections       bool              `json:"followRedirections"`
@@ -73,8 +73,8 @@ type UpdateMonitorRequest struct {
 	MaintenanceWindowIDs     []int64            `json:"maintenanceWindowsIds,omitempty"`
 	Tags                     []string           `json:"tagNames"`
 	GracePeriod              *int               `json:"gracePeriod,omitempty"`
-	PostValueData            interface{}        `json:"postValueData,omitempty"`
 	PostValueType            string             `json:"postValueType,omitempty"`
+	PostValueData            interface{}        `json:"postValueData,omitempty"`
 	SSLExpirationReminder    bool               `json:"sslExpirationReminder"`
 	DomainExpirationReminder bool               `json:"domainExpirationReminder"`
 	FollowRedirections       bool               `json:"followRedirections"`
@@ -101,8 +101,8 @@ type Monitor struct {
 	HTTPMethodType           string              `json:"httpMethodType"`
 	SuccessHTTPResponseCodes []string            `json:"successHttpResponseCodes"`
 	Timeout                  int                 `json:"timeout"`
-	PostValueData            *string             `json:"postValueData"`
 	PostValueType            *string             `json:"postValueType"`
+	PostValueData            json.RawMessage     `json:"postValueData"`
 	Port                     *int                `json:"port"`
 	GracePeriod              int                 `json:"gracePeriod"`
 	KeywordValue             string              `json:"keywordValue"`

--- a/internal/provider/monitor_resource.go
+++ b/internal/provider/monitor_resource.go
@@ -1361,19 +1361,20 @@ func (r *monitorResource) Update(ctx context.Context, req resource.UpdateRequest
 		updatedState.PostValueData = jsontypes.NewNormalizedNull()
 		updatedState.PostValueKV = types.MapNull(types.StringType)
 	} else {
-		if !plan.PostValueData.IsUnknown() && !plan.PostValueData.IsNull() {
+		switch {
+		case !plan.PostValueData.IsNull():
 			updatedState.PostValueType = types.StringValue(PostTypeRawJSON)
 			updatedState.PostValueData = plan.PostValueData
 			updatedState.PostValueKV = types.MapNull(types.StringType)
-		} else if !plan.PostValueKV.IsUnknown() && !plan.PostValueKV.IsNull() {
+		case !plan.PostValueKV.IsNull():
 			updatedState.PostValueType = types.StringValue(PostTypeKeyValue)
 			updatedState.PostValueData = jsontypes.NewNormalizedNull()
 			updatedState.PostValueKV = plan.PostValueKV
-		} else {
-			// user didn’t change body -> preserve previous state
-			updatedState.PostValueType = state.PostValueType
-			updatedState.PostValueData = state.PostValueData
-			updatedState.PostValueKV = state.PostValueKV
+		default:
+			// plan provided no body, clear state as well
+			updatedState.PostValueType = types.StringNull()
+			updatedState.PostValueData = jsontypes.NewNormalizedNull()
+			updatedState.PostValueKV = types.MapNull(types.StringType)
 		}
 	}
 
@@ -1502,9 +1503,9 @@ func (r *monitorResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 		resp.Plan.SetAttribute(ctx, path.Root("post_value_data"), jsontypes.NewNormalizedNull())
 	default:
 		// none provided -> let server echo values by keeping Unknowns
-		resp.Plan.SetAttribute(ctx, path.Root("post_value_data"), jsontypes.NewNormalizedUnknown())
-		resp.Plan.SetAttribute(ctx, path.Root("post_value_kv"), types.MapUnknown(types.StringType))
-		resp.Plan.SetAttribute(ctx, path.Root("post_value_type"), types.StringUnknown())
+		resp.Plan.SetAttribute(ctx, path.Root("post_value_data"), jsontypes.NewNormalizedNull())
+		resp.Plan.SetAttribute(ctx, path.Root("post_value_kv"), types.MapNull(types.StringType))
+		resp.Plan.SetAttribute(ctx, path.Root("post_value_type"), types.StringNull())
 	}
 
 }

--- a/internal/provider/monitor_resource.go
+++ b/internal/provider/monitor_resource.go
@@ -195,12 +195,12 @@ func (r *monitorResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				},
 			},
 			"post_value_data_json": schema.StringAttribute{
-				Description: "JSON string payload used when post_value_type = RAW_JSON.",
+				Description: "JSON payload body as a string (use jsonencode). Mutually exclusive with post_value_data_kv. Used when post_value_type = RAW_JSON.",
 				Optional:    true,
 			},
-
+			// API always echoes post value data as object, so KV is canonical and json is just a convenience
 			"post_value_data_kv": schema.MapAttribute{
-				Description: "Key/Value payload used when post_value_type = KEY_VALUE.",
+				Description: "Key/Value payload body. Mutually exclusive with post_value_data_json. Used when post_value_type = KEY_VALUE.",
 				Optional:    true,
 				ElementType: types.StringType,
 			},

--- a/internal/provider/monitor_resource_acc_test.go
+++ b/internal/provider/monitor_resource_acc_test.go
@@ -502,12 +502,20 @@ func TestAccMonitorResource_SuccessHTTPResponseCodes(t *testing.T) {
 					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "success_http_response_codes.2", "202"),
 				),
 			},
-			// Step 3: Set to empty list (we accept empty and round-trip it as empty)
+			// Step 3: Remove the attribute. Back to defaults
 			{
-				Config: testAccMonitorResourceConfigWithSuccessHTTPResponseCodes("test-monitor-response-codes", []string{}),
+				Config: testAccMonitorResourceConfigWithSuccessHTTPResponseCodes("test-monitor-response-codes", nil),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "success_http_response_codes.#", "0"),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "success_http_response_codes.#", "2"),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "success_http_response_codes.0", "2xx"),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "success_http_response_codes.1", "3xx"),
 				),
+			},
+			// Idempotency
+			{
+				Config:             testAccMonitorResourceConfigWithSuccessHTTPResponseCodes("test-monitor-response-codes", nil),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})

--- a/internal/provider/monitor_resource_acc_test.go
+++ b/internal/provider/monitor_resource_acc_test.go
@@ -86,6 +86,7 @@ resource "uptimerobot_monitor" "test" {
 `, name, maintenanceWindowsStr)
 }
 
+// nolint:unparam // kept for symmetry with other helpers & future reuse
 func testAccMonitorResourceConfigWithSuccessHTTPResponseCodes(name string, responseCodes []string) string {
 	var responseCodesStr string
 	if responseCodes != nil {

--- a/internal/provider/monitor_resource_acc_test.go
+++ b/internal/provider/monitor_resource_acc_test.go
@@ -87,19 +87,23 @@ resource "uptimerobot_monitor" "test" {
 }
 
 func testAccMonitorResourceConfigWithSuccessHTTPResponseCodes(name string, responseCodes []string) string {
-	responseCodesStr := ""
-	if len(responseCodes) > 0 {
-		responseCodesStr = fmt.Sprintf(`
+	var responseCodesStr string
+	if responseCodes != nil {
+		if len(responseCodes) == 0 {
+			responseCodesStr = `
+    success_http_response_codes = []`
+		} else {
+			responseCodesStr = fmt.Sprintf(`
     success_http_response_codes = [%s]`, joinQuotedStrings(responseCodes))
+		}
 	}
-
 	return testAccProviderConfig() + fmt.Sprintf(`
 resource "uptimerobot_monitor" "test" {
     name         = %q
     url          = "https://example.com"
     type         = "HTTP"
     interval     = 300%s
-	timeout      = 30
+    timeout      = 30
 }
 `, name, responseCodesStr)
 }

--- a/internal/provider/monitor_resource_acc_test.go
+++ b/internal/provider/monitor_resource_acc_test.go
@@ -184,13 +184,6 @@ func joinInts(ints []int) string {
 	return result
 }
 
-func testCheckNoPostBody(addr string) resource.TestCheckFunc {
-	return resource.ComposeAggregateTestCheckFunc(
-		resource.TestCheckNoResourceAttr(addr, "post_value_data"),
-		resource.TestCheckNoResourceAttr(addr, "post_value_type"),
-	)
-}
-
 // Acceptance tests ------------------------------------------------
 
 func TestAccMonitorResource(t *testing.T) {

--- a/internal/provider/monitor_upgrade.go
+++ b/internal/provider/monitor_upgrade.go
@@ -347,8 +347,8 @@ func priorSchemaV1() *schema.Schema {
 	return s
 }
 
-// Converter: v1 (String) -> v2 (jsontypes.Normalized)
-func upgradeMonitorFromV1(ctx context.Context, prior monitorV1Model) (monitorResourceModel, diag.Diagnostics) {
+// Converter: v1 (String) -> v2 (jsontypes.Normalized).
+func upgradeMonitorFromV1(_ context.Context, prior monitorV1Model) (monitorResourceModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	// Convert post_value_data
@@ -361,7 +361,7 @@ func upgradeMonitorFromV1(ctx context.Context, prior monitorV1Model) (monitorRes
 		if json.Valid([]byte(raw)) {
 			normalized = jsontypes.NewNormalizedValue(raw)
 		} else {
-			// Best-effort safety: if state held non-JSON, clear it with a warning.
+			// if state held non-JSON, clear it with a warning
 			diags.AddWarning(
 				"Invalid JSON in prior state for post_value_data",
 				"The previous state stored a non-JSON string. The value has been cleared. "+
@@ -371,7 +371,7 @@ func upgradeMonitorFromV1(ctx context.Context, prior monitorV1Model) (monitorRes
 		}
 	}
 
-	// Map everything over; only difference is PostValueData type.
+	// Only difference is in PostValueData type
 	up := monitorResourceModel{
 		Type:                     prior.Type,
 		Interval:                 prior.Interval,
@@ -385,8 +385,8 @@ func upgradeMonitorFromV1(ctx context.Context, prior monitorV1Model) (monitorRes
 		HTTPMethodType:           prior.HTTPMethodType,
 		SuccessHTTPResponseCodes: prior.SuccessHTTPResponseCodes,
 		Timeout:                  prior.Timeout,
-		PostValueData:            normalized,          // <-- converted
-		PostValueType:            prior.PostValueType, // unchanged
+		PostValueData:            normalized, // converted to json
+		PostValueType:            prior.PostValueType,
 		Port:                     prior.Port,
 		GracePeriod:              prior.GracePeriod,
 		KeywordValue:             prior.KeywordValue,

--- a/internal/provider/monitor_upgrade.go
+++ b/internal/provider/monitor_upgrade.go
@@ -2,11 +2,26 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+// V0 -> to V1
 
 type monitorV0Model struct {
 	Type                     types.String `tfsdk:"type"`
@@ -63,6 +78,24 @@ func upgradeMonitorFromV0(ctx context.Context, prior monitorV0Model) (monitorRes
 		return types.SetValueMust(types.StringType, vals)
 	}
 
+	var normalized jsontypes.Normalized
+	if prior.PostValueData.IsNull() || prior.PostValueData.IsUnknown() ||
+		strings.TrimSpace(prior.PostValueData.ValueString()) == "" {
+		normalized = jsontypes.NewNormalizedNull()
+	} else {
+		raw := prior.PostValueData.ValueString()
+		if json.Valid([]byte(raw)) {
+			normalized = jsontypes.NewNormalizedValue(raw)
+		} else {
+			diags.AddWarning(
+				"Invalid JSON in prior state for post_value_data",
+				"The previous state stored a non-JSON string. The value has been cleared. "+
+					"Please set a valid JSON value using jsonencode(...) in configuration.",
+			)
+			normalized = jsontypes.NewNormalizedNull()
+		}
+	}
+
 	up := monitorResourceModel{
 		Type:                     prior.Type,
 		Interval:                 prior.Interval,
@@ -76,7 +109,7 @@ func upgradeMonitorFromV0(ctx context.Context, prior monitorV0Model) (monitorRes
 		HTTPMethodType:           prior.HTTPMethodType,
 		SuccessHTTPResponseCodes: prior.SuccessHTTPResponseCodes,
 		Timeout:                  prior.Timeout,
-		PostValueData:            prior.PostValueData,
+		PostValueData:            normalized, // string -> json
 		PostValueType:            prior.PostValueType,
 		Port:                     prior.Port,
 		GracePeriod:              prior.GracePeriod,
@@ -89,6 +122,282 @@ func upgradeMonitorFromV0(ctx context.Context, prior monitorV0Model) (monitorRes
 		Status:                   prior.Status,
 		URL:                      prior.URL,
 		Tags:                     toSet(prior.Tags), // list -> set
+		AssignedAlertContacts:    prior.AssignedAlertContacts,
+		ResponseTimeThreshold:    prior.ResponseTimeThreshold,
+		RegionalData:             prior.RegionalData,
+	}
+
+	return up, diags
+}
+
+// V1 -> to V2
+
+type monitorV1Model struct {
+	Type                     types.String `tfsdk:"type"`
+	Interval                 types.Int64  `tfsdk:"interval"`
+	SSLExpirationReminder    types.Bool   `tfsdk:"ssl_expiration_reminder"`
+	DomainExpirationReminder types.Bool   `tfsdk:"domain_expiration_reminder"`
+	FollowRedirections       types.Bool   `tfsdk:"follow_redirections"`
+	AuthType                 types.String `tfsdk:"auth_type"`
+	HTTPUsername             types.String `tfsdk:"http_username"`
+	HTTPPassword             types.String `tfsdk:"http_password"`
+	CustomHTTPHeaders        types.Map    `tfsdk:"custom_http_headers"`
+	HTTPMethodType           types.String `tfsdk:"http_method_type"`
+	SuccessHTTPResponseCodes types.List   `tfsdk:"success_http_response_codes"`
+	Timeout                  types.Int64  `tfsdk:"timeout"`
+
+	// v1 used a plain String here:
+	PostValueData types.String `tfsdk:"post_value_data"`
+
+	PostValueType         types.String `tfsdk:"post_value_type"`
+	Port                  types.Int64  `tfsdk:"port"`
+	GracePeriod           types.Int64  `tfsdk:"grace_period"`
+	KeywordValue          types.String `tfsdk:"keyword_value"`
+	KeywordCaseType       types.String `tfsdk:"keyword_case_type"`
+	KeywordType           types.String `tfsdk:"keyword_type"`
+	MaintenanceWindowIDs  types.List   `tfsdk:"maintenance_window_ids"`
+	ID                    types.String `tfsdk:"id"`
+	Name                  types.String `tfsdk:"name"`
+	Status                types.String `tfsdk:"status"`
+	URL                   types.String `tfsdk:"url"`
+	Tags                  types.Set    `tfsdk:"tags"`
+	AssignedAlertContacts types.List   `tfsdk:"assigned_alert_contacts"`
+	ResponseTimeThreshold types.Int64  `tfsdk:"response_time_threshold"`
+	RegionalData          types.String `tfsdk:"regional_data"`
+}
+
+func priorSchemaV1() *schema.Schema {
+	s := &schema.Schema{
+		Version:     1,
+		Description: "Manages an UptimeRobot monitor.",
+		Attributes: map[string]schema.Attribute{
+			"type": schema.StringAttribute{
+				Description: "Type of the monitor (HTTP, KEYWORD, PING, PORT, HEARTBEAT, DNS)",
+				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("HTTP", "KEYWORD", "PING", "PORT", "HEARTBEAT", "DNS"),
+				},
+			},
+			"interval": schema.Int64Attribute{
+				Description: "Interval for the monitoring check (in seconds)",
+				Required:    true,
+			},
+			"ssl_expiration_reminder": schema.BoolAttribute{
+				Description: "Whether to enable SSL expiration reminders",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+			},
+			"domain_expiration_reminder": schema.BoolAttribute{
+				Description: "Whether to enable domain expiration reminders",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+			},
+			"follow_redirections": schema.BoolAttribute{
+				Description: "Whether to follow redirections",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+			},
+			"auth_type": schema.StringAttribute{
+				Description: "The authentication type (HTTP_BASIC)",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("HTTP_BASIC"),
+			},
+			"http_username": schema.StringAttribute{
+				Description: "The username for HTTP authentication",
+				Optional:    true,
+			},
+			"http_password": schema.StringAttribute{
+				Description: "The password for HTTP authentication",
+				Optional:    true,
+				Sensitive:   true,
+			},
+			"custom_http_headers": schema.MapAttribute{
+				Description: "Custom HTTP headers",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"http_method_type": schema.StringAttribute{
+				Description: "The HTTP method type (HEAD, GET, POST, PUT, PATCH, DELETE, OPTIONS)",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("GET"),
+				Validators: []validator.String{
+					stringvalidator.OneOf("HEAD", "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"),
+				},
+			},
+			"success_http_response_codes": schema.ListAttribute{
+				Description: "The expected HTTP response codes",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				Default:     listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{types.StringValue("2xx"), types.StringValue("3xx")})),
+			},
+			"timeout": schema.Int64Attribute{
+				Description: "Timeout for the check (in seconds). Not applicable for HEARTBEAT; ignored for DNS/PING. If omitted, default value 30 is used",
+				Optional:    true,
+				Computed:    true,
+				Validators: []validator.Int64{
+					int64validator.Between(0, 60),
+				},
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
+			},
+			"post_value_type": schema.StringAttribute{
+				Description: "The type of data to send with POST request. Server value is RAW_JSON when body is present",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"post_value_data": schema.StringAttribute{
+				Description: "JSON payload body as a string. Use jsonencode.",
+				Optional:    true,
+			},
+			"port": schema.Int64Attribute{
+				Description: "The port to monitor",
+				Optional:    true,
+			},
+			"grace_period": schema.Int64Attribute{
+				Description: "The grace period (in seconds). Only for HEARTBEAT monitors",
+				Optional:    true,
+				Validators: []validator.Int64{
+					int64validator.Between(0, 86400),
+				},
+			},
+			"keyword_value": schema.StringAttribute{
+				Description: "The keyword to search for",
+				Optional:    true,
+			},
+			"keyword_case_type": schema.StringAttribute{
+				Description: "The case sensitivity for keyword (CaseSensitive or CaseInsensitive). Default: CaseInsensitive",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("CaseInsensitive"),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"keyword_type": schema.StringAttribute{
+				Description: "The type of keyword check (ALERT_EXISTS, ALERT_NOT_EXISTS)",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("ALERT_EXISTS", "ALERT_NOT_EXISTS"),
+				},
+			},
+			"maintenance_window_ids": schema.ListAttribute{
+				Description: "The maintenance window IDs",
+				Optional:    true,
+				ElementType: types.Int64Type,
+			},
+			"id": schema.StringAttribute{
+				Description: "Monitor ID",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Description: "Name of the monitor",
+				Required:    true,
+			},
+			// Status may change its values quickly due to changes on the API side.
+			// On create after operation it should be a known value.
+			// On update use state's value.
+			// On read it will always be set because read is used for after-apply sync as well.
+			"status": schema.StringAttribute{
+				Description: "Status of the monitor",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"url": schema.StringAttribute{
+				Description: "URL to monitor",
+				Required:    true,
+			},
+			"tags": schema.SetAttribute{
+				Description: "Tags for the monitor",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"assigned_alert_contacts": schema.ListAttribute{
+				Description: "Alert contact IDs to assign to the monitor",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"response_time_threshold": schema.Int64Attribute{
+				Description: "Response time threshold in milliseconds. Response time over this threshold will trigger an incident",
+				Optional:    true,
+			},
+			"regional_data": schema.StringAttribute{
+				Description: "Region for monitoring: na (North America), eu (Europe), as (Asia), oc (Oceania)",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("na", "eu", "as", "oc"),
+				},
+			},
+		},
+	}
+
+	return s
+}
+
+// Converter: v1 (String) -> v2 (jsontypes.Normalized)
+func upgradeMonitorFromV1(ctx context.Context, prior monitorV1Model) (monitorResourceModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Convert post_value_data
+	var normalized jsontypes.Normalized
+	if prior.PostValueData.IsNull() || prior.PostValueData.IsUnknown() ||
+		strings.TrimSpace(prior.PostValueData.ValueString()) == "" {
+		normalized = jsontypes.NewNormalizedNull()
+	} else {
+		raw := prior.PostValueData.ValueString()
+		if json.Valid([]byte(raw)) {
+			normalized = jsontypes.NewNormalizedValue(raw)
+		} else {
+			// Best-effort safety: if state held non-JSON, clear it with a warning.
+			diags.AddWarning(
+				"Invalid JSON in prior state for post_value_data",
+				"The previous state stored a non-JSON string. The value has been cleared. "+
+					"Please set a valid JSON value using jsonencode(...) in configuration.",
+			)
+			normalized = jsontypes.NewNormalizedNull()
+		}
+	}
+
+	// Map everything over; only difference is PostValueData type.
+	up := monitorResourceModel{
+		Type:                     prior.Type,
+		Interval:                 prior.Interval,
+		SSLExpirationReminder:    prior.SSLExpirationReminder,
+		DomainExpirationReminder: prior.DomainExpirationReminder,
+		FollowRedirections:       prior.FollowRedirections,
+		AuthType:                 prior.AuthType,
+		HTTPUsername:             prior.HTTPUsername,
+		HTTPPassword:             prior.HTTPPassword,
+		CustomHTTPHeaders:        prior.CustomHTTPHeaders,
+		HTTPMethodType:           prior.HTTPMethodType,
+		SuccessHTTPResponseCodes: prior.SuccessHTTPResponseCodes,
+		Timeout:                  prior.Timeout,
+		PostValueData:            normalized,          // <-- converted
+		PostValueType:            prior.PostValueType, // unchanged
+		Port:                     prior.Port,
+		GracePeriod:              prior.GracePeriod,
+		KeywordValue:             prior.KeywordValue,
+		KeywordCaseType:          prior.KeywordCaseType,
+		KeywordType:              prior.KeywordType,
+		MaintenanceWindowIDs:     prior.MaintenanceWindowIDs,
+		ID:                       prior.ID,
+		Name:                     prior.Name,
+		Status:                   prior.Status,
+		URL:                      prior.URL,
+		Tags:                     prior.Tags,
 		AssignedAlertContacts:    prior.AssignedAlertContacts,
 		ResponseTimeThreshold:    prior.ResponseTimeThreshold,
 		RegionalData:             prior.RegionalData,


### PR DESCRIPTION
Resolves #78 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - HTTP monitor bodies now support RAW_JSON or KEY_VALUE; post_value_type is computed and mutually exclusive with KV input.
- Validation / Bug Fixes
  - GET/HEAD disallow bodies; method switches clear/adjust body state; improved keyword-monitor validation.
- Documentation
  - Clarified post_value_data (use jsonencode), added post_value_kv, noted default timeout is 30s.
- Tests
  - Expanded acceptance tests for JSON/KV round-trips, clearing bodies, method transitions, and no-body enforcement.
- Chores
  - Dependency bumps, schema version increment, state upgrade/normalization with warnings, and narrowed test runner with longer timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->