### PR TITLE
Fix: alert contacts

### DIFF
--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -205,7 +205,7 @@ Common monitoring intervals:
 
 ### Optional
 
-- `assigned_alert_contacts` (List of String) Alert contact IDs to assign to the monitor
+- `assigned_alert_contacts` (Attributes Set) Alert contacts to assign. threshold/recurrence are minutes. Free plan uses 0. (see [below for nested schema](#nestedatt--assigned_alert_contacts))
 - `auth_type` (String) The authentication type (HTTP_BASIC)
 - `custom_http_headers` (Map of String) Custom HTTP headers
 - `domain_expiration_reminder` (Boolean) Whether to enable domain expiration reminders
@@ -233,3 +233,15 @@ Common monitoring intervals:
 - `id` (String) Monitor ID
 - `post_value_type` (String) Computed body type used by UptimeRobot when sending the monitor request. Set automatically to RAW_JSON or KEY_VALUE.
 - `status` (String) Status of the monitor
+
+<a id="nestedatt--assigned_alert_contacts"></a>
+### Nested Schema for `assigned_alert_contacts`
+
+Required:
+
+- `alert_contact_id` (String)
+
+Optional:
+
+- `recurrence` (Number)
+- `threshold` (Number)

--- a/internal/client/monitor.go
+++ b/internal/client/monitor.go
@@ -19,68 +19,68 @@ const (
 
 // CreateMonitorRequest represents the request to create a new monitor.
 type CreateMonitorRequest struct {
-	Name                     string            `json:"friendlyName"`
-	URL                      string            `json:"url"`
-	Type                     MonitorType       `json:"type"`
-	Interval                 int               `json:"interval"`
-	Timeout                  *int              `json:"timeout,omitempty"`
-	HTTPAuthType             string            `json:"authType,omitempty"`
-	HTTPMethodType           string            `json:"httpMethodType,omitempty"`
-	HTTPUsername             string            `json:"httpUsername,omitempty"`
-	HTTPPassword             string            `json:"httpPassword,omitempty"`
-	Port                     int               `json:"port,omitempty"`
-	KeywordType              string            `json:"keywordType,omitempty"`
-	KeywordValue             string            `json:"keywordValue,omitempty"`
-	KeywordCaseType          int               `json:"keywordCaseType,omitempty"`
-	AssignedAlertContacts    []interface{}     `json:"assignedAlertContacts"`
-	CheckSSLErrors           bool              `json:"checkSSLErrors"`
-	SSLCheckEnabled          bool              `json:"sslCheckEnabled,omitempty"`
-	CustomHTTPHeaders        map[string]string `json:"customHttpHeaders,omitempty"`
-	SuccessHTTPResponseCodes []string          `json:"successHttpResponseCodes,omitempty"`
-	MaintenanceWindowIDs     []int64           `json:"maintenanceWindowsIds,omitempty"`
-	Tags                     []string          `json:"tagNames"`
-	GracePeriod              *int              `json:"gracePeriod,omitempty"`
-	PostValueType            string            `json:"postValueType,omitempty"`
-	PostValueData            interface{}       `json:"postValueData,omitempty"`
-	SSLExpirationReminder    bool              `json:"sslExpirationReminder"`
-	DomainExpirationReminder bool              `json:"domainExpirationReminder"`
-	FollowRedirections       bool              `json:"followRedirections"`
-	ResponseTimeThreshold    int               `json:"responseTimeThreshold,omitempty"`
-	RegionalData             string            `json:"regionalData,omitempty"`
-	Config                   map[string]any    `json:"config,omitempty"` // DNS config field
+	Name                     string                `json:"friendlyName"`
+	URL                      string                `json:"url"`
+	Type                     MonitorType           `json:"type"`
+	Interval                 int                   `json:"interval"`
+	Timeout                  *int                  `json:"timeout,omitempty"`
+	HTTPAuthType             string                `json:"authType,omitempty"`
+	HTTPMethodType           string                `json:"httpMethodType,omitempty"`
+	HTTPUsername             string                `json:"httpUsername,omitempty"`
+	HTTPPassword             string                `json:"httpPassword,omitempty"`
+	Port                     int                   `json:"port,omitempty"`
+	KeywordType              string                `json:"keywordType,omitempty"`
+	KeywordValue             string                `json:"keywordValue,omitempty"`
+	KeywordCaseType          int                   `json:"keywordCaseType,omitempty"`
+	AssignedAlertContacts    []AlertContactRequest `json:"assignedAlertContacts"`
+	CheckSSLErrors           bool                  `json:"checkSSLErrors"`
+	SSLCheckEnabled          bool                  `json:"sslCheckEnabled,omitempty"`
+	CustomHTTPHeaders        map[string]string     `json:"customHttpHeaders,omitempty"`
+	SuccessHTTPResponseCodes []string              `json:"successHttpResponseCodes,omitempty"`
+	MaintenanceWindowIDs     []int64               `json:"maintenanceWindowsIds,omitempty"`
+	Tags                     []string              `json:"tagNames"`
+	GracePeriod              *int                  `json:"gracePeriod,omitempty"`
+	PostValueType            string                `json:"postValueType,omitempty"`
+	PostValueData            interface{}           `json:"postValueData,omitempty"`
+	SSLExpirationReminder    bool                  `json:"sslExpirationReminder"`
+	DomainExpirationReminder bool                  `json:"domainExpirationReminder"`
+	FollowRedirections       bool                  `json:"followRedirections"`
+	ResponseTimeThreshold    int                   `json:"responseTimeThreshold,omitempty"`
+	RegionalData             string                `json:"regionalData,omitempty"`
+	Config                   map[string]any        `json:"config,omitempty"` // DNS config field
 }
 
 // UpdateMonitorRequest represents the request to update an existing monitor.
 type UpdateMonitorRequest struct {
-	Name                     string             `json:"friendlyName"`
-	URL                      string             `json:"url"`
-	Type                     MonitorType        `json:"type"`
-	Interval                 int                `json:"interval"`
-	Timeout                  *int               `json:"timeout,omitempty"`
-	HTTPAuthType             string             `json:"authType,omitempty"`
-	HTTPMethodType           string             `json:"httpMethodType,omitempty"`
-	HTTPUsername             string             `json:"httpUsername,omitempty"`
-	HTTPPassword             string             `json:"httpPassword,omitempty"`
-	Port                     int                `json:"port,omitempty"`
-	KeywordType              string             `json:"keywordType,omitempty"`
-	KeywordValue             string             `json:"keywordValue,omitempty"`
-	KeywordCaseType          int                `json:"keywordCaseType,omitempty"`
-	AssignedAlertContacts    []interface{}      `json:"assignedAlertContacts"`
-	CheckSSLErrors           bool               `json:"checkSSLErrors"`
-	SSLCheckEnabled          bool               `json:"sslCheckEnabled,omitempty"`
-	CustomHTTPHeaders        *map[string]string `json:"customHttpHeaders,omitempty"`
-	SuccessHTTPResponseCodes []string           `json:"successHttpResponseCodes,omitempty"`
-	MaintenanceWindowIDs     []int64            `json:"maintenanceWindowsIds,omitempty"`
-	Tags                     []string           `json:"tagNames"`
-	GracePeriod              *int               `json:"gracePeriod,omitempty"`
-	PostValueType            string             `json:"postValueType,omitempty"`
-	PostValueData            interface{}        `json:"postValueData,omitempty"`
-	SSLExpirationReminder    bool               `json:"sslExpirationReminder"`
-	DomainExpirationReminder bool               `json:"domainExpirationReminder"`
-	FollowRedirections       bool               `json:"followRedirections"`
-	ResponseTimeThreshold    *int               `json:"responseTimeThreshold,omitempty"`
-	RegionalData             *string            `json:"regionalData,omitempty"`
-	Config                   map[string]any     `json:"config,omitempty"` // DNS config field
+	Name                     string                `json:"friendlyName"`
+	URL                      string                `json:"url"`
+	Type                     MonitorType           `json:"type"`
+	Interval                 int                   `json:"interval"`
+	Timeout                  *int                  `json:"timeout,omitempty"`
+	HTTPAuthType             string                `json:"authType,omitempty"`
+	HTTPMethodType           string                `json:"httpMethodType,omitempty"`
+	HTTPUsername             string                `json:"httpUsername,omitempty"`
+	HTTPPassword             string                `json:"httpPassword,omitempty"`
+	Port                     int                   `json:"port,omitempty"`
+	KeywordType              string                `json:"keywordType,omitempty"`
+	KeywordValue             string                `json:"keywordValue,omitempty"`
+	KeywordCaseType          int                   `json:"keywordCaseType,omitempty"`
+	AssignedAlertContacts    []AlertContactRequest `json:"assignedAlertContacts"`
+	CheckSSLErrors           bool                  `json:"checkSSLErrors"`
+	SSLCheckEnabled          bool                  `json:"sslCheckEnabled,omitempty"`
+	CustomHTTPHeaders        *map[string]string    `json:"customHttpHeaders,omitempty"`
+	SuccessHTTPResponseCodes []string              `json:"successHttpResponseCodes,omitempty"`
+	MaintenanceWindowIDs     []int64               `json:"maintenanceWindowsIds,omitempty"`
+	Tags                     []string              `json:"tagNames"`
+	GracePeriod              *int                  `json:"gracePeriod,omitempty"`
+	PostValueType            string                `json:"postValueType,omitempty"`
+	PostValueData            interface{}           `json:"postValueData,omitempty"`
+	SSLExpirationReminder    bool                  `json:"sslExpirationReminder"`
+	DomainExpirationReminder bool                  `json:"domainExpirationReminder"`
+	FollowRedirections       bool                  `json:"followRedirections"`
+	ResponseTimeThreshold    *int                  `json:"responseTimeThreshold,omitempty"`
+	RegionalData             *string               `json:"regionalData,omitempty"`
+	Config                   map[string]any        `json:"config,omitempty"` // DNS config field
 }
 
 // Monitor represents a monitor.
@@ -134,10 +134,17 @@ type Tag struct {
 	Monitors []Monitor `json:"monitors,omitempty"`
 }
 
+// AlertContactRequest used in requests and should support omitted values
+type AlertContactRequest struct {
+	AlertContactID string `json:"alertContactId"`
+	Threshold      *int64 `json:"threshold,omitempty"`
+	Recurrence     *int64 `json:"recurrence,omitempty"`
+}
+
 type AlertContact struct {
-	AlertContactID int64 `json:"alertContactId"`
-	Threshold      int   `json:"threshold"`
-	Recurrence     int   `json:"recurrence"`
+	AlertContactID string `json:"alertContactId"`
+	Threshold      int64  `json:"threshold"`
+	Recurrence     int64  `json:"recurrence"`
 }
 
 type Incident struct {

--- a/internal/client/monitor.go
+++ b/internal/client/monitor.go
@@ -135,7 +135,7 @@ type Tag struct {
 	Monitors []Monitor `json:"monitors,omitempty"`
 }
 
-// AlertContactRequest used in requests and should support omitted values
+// AlertContactRequest used in requests and should support omitted values.
 type AlertContactRequest struct {
 	AlertContactID string `json:"alertContactId"`
 	Threshold      *int64 `json:"threshold,omitempty"`

--- a/internal/client/monitor.go
+++ b/internal/client/monitor.go
@@ -259,7 +259,7 @@ func (s *StringOrNumberID) UnmarshalJSON(b []byte) error {
 		*s = StringOrNumberID(v)
 		return nil
 	}
-	// elase treat it as a number and stringify
+	// else treat it as a number and stringify
 	var n json.Number
 	dec := json.NewDecoder(bytes.NewReader(b))
 	dec.UseNumber()

--- a/internal/provider/monitor_resource.go
+++ b/internal/provider/monitor_resource.go
@@ -1016,7 +1016,7 @@ func (r *monitorResource) Read(ctx context.Context, req resource.ReadRequest, re
 		elts := make([]alertContactTF, 0, len(monitor.AssignedAlertContacts))
 		for _, ac := range monitor.AssignedAlertContacts {
 			elts = append(elts, alertContactTF{
-				AlertContactID: types.StringValue(ac.AlertContactID),
+				AlertContactID: types.StringValue(string(ac.AlertContactID)),
 				Threshold:      types.Int64Value(ac.Threshold),
 				Recurrence:     types.Int64Value(ac.Recurrence),
 			})
@@ -1411,7 +1411,7 @@ func (r *monitorResource) Update(ctx context.Context, req resource.UpdateRequest
 		elts := make([]alertContactTF, 0, len(updatedMonitor.AssignedAlertContacts))
 		for _, ac := range updatedMonitor.AssignedAlertContacts {
 			elts = append(elts, alertContactTF{
-				AlertContactID: types.StringValue(ac.AlertContactID),
+				AlertContactID: types.StringValue(string(ac.AlertContactID)),
 				Threshold:      types.Int64Value(ac.Threshold),
 				Recurrence:     types.Int64Value(ac.Recurrence),
 			})

--- a/internal/provider/monitor_resource.go
+++ b/internal/provider/monitor_resource.go
@@ -1270,6 +1270,9 @@ func (r *monitorResource) Update(ctx context.Context, req resource.UpdateRequest
 			return
 		}
 		updateReq.Tags = tags
+	} else {
+		// clear on server
+		updateReq.Tags = []string{}
 	}
 
 	if !plan.AssignedAlertContacts.IsNull() && !plan.AssignedAlertContacts.IsUnknown() {

--- a/internal/provider/monitor_resource_acc_test.go
+++ b/internal/provider/monitor_resource_acc_test.go
@@ -462,7 +462,7 @@ func TestAccMonitorResource_MaintenanceWindows(t *testing.T) {
 					resource.TestCheckNoResourceAttr("uptimerobot_monitor.test", "maintenance_window_ids"),
 				),
 			},
-			// explicit empty list should normalize to null without diff
+			// explicit empty list should be accepted with no invalid plan. A plan is expected here.
 			{
 				Config: testAccProviderConfig() + `
 resource "uptimerobot_monitor" "test" {

--- a/internal/provider/monitor_resource_acc_test.go
+++ b/internal/provider/monitor_resource_acc_test.go
@@ -499,7 +499,7 @@ resource "uptimerobot_monitor" "test" {
 			},
 			// Idempotency re-plan
 			{
-				Config:             testAccMonitorResourceConfigWithAlertContactObjects("test-monitor-maintenance", nil),
+				Config:             testAccMonitorResourceConfigWithMaintenanceWindows("test-monitor-maintenance", nil),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},

--- a/internal/provider/monitor_resource_acc_test.go
+++ b/internal/provider/monitor_resource_acc_test.go
@@ -51,6 +51,7 @@ resource "uptimerobot_monitor" "test" {
 `, name, tagsStr)
 }
 
+//nolint:unparam // name kept for symmetry with other helpers & future reuse
 func testAccMonitorResourceConfigWithMaintenanceWindows(name string, maintenanceWindowIDs []int) string {
 	maintenanceWindowsStr := ""
 	if len(maintenanceWindowIDs) > 0 {
@@ -203,6 +204,7 @@ resource "uptimerobot_monitor" "test" {
 `, name)
 }
 
+//nolint:unparam // name kept for symmetry with other helpers & future reuse
 func testAccMonitorResourceConfigWithAlertContactObjects(name string, ids []string) string {
 	ac := ""
 	if len(ids) > 0 {

--- a/internal/provider/monitor_upgrade.go
+++ b/internal/provider/monitor_upgrade.go
@@ -96,6 +96,9 @@ func upgradeMonitorFromV0(ctx context.Context, prior monitorV0Model) (monitorRes
 		}
 	}
 
+	acSet, d := acListToObjectSet(ctx, prior.AssignedAlertContacts)
+	diags.Append(d...)
+
 	up := monitorResourceModel{
 		Type:                     prior.Type,
 		Interval:                 prior.Interval,
@@ -122,10 +125,12 @@ func upgradeMonitorFromV0(ctx context.Context, prior monitorV0Model) (monitorRes
 		Status:                   prior.Status,
 		URL:                      prior.URL,
 		Tags:                     toSet(prior.Tags), // list -> set
-		AssignedAlertContacts:    prior.AssignedAlertContacts,
+		AssignedAlertContacts:    acSet,
 		ResponseTimeThreshold:    prior.ResponseTimeThreshold,
 		RegionalData:             prior.RegionalData,
 	}
+
+	up.PostValueKV = types.MapNull(types.StringType)
 
 	return up, diags
 }
@@ -348,7 +353,7 @@ func priorSchemaV1() *schema.Schema {
 }
 
 // Converter: v1 (String) -> v2 (jsontypes.Normalized).
-func upgradeMonitorFromV1(_ context.Context, prior monitorV1Model) (monitorResourceModel, diag.Diagnostics) {
+func upgradeMonitorFromV1(ctx context.Context, prior monitorV1Model) (monitorResourceModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	// Convert post_value_data
@@ -370,6 +375,9 @@ func upgradeMonitorFromV1(_ context.Context, prior monitorV1Model) (monitorResou
 			normalized = jsontypes.NewNormalizedNull()
 		}
 	}
+
+	acSet, d := acListToObjectSet(ctx, prior.AssignedAlertContacts)
+	diags.Append(d...)
 
 	// Only difference is in PostValueData type
 	up := monitorResourceModel{
@@ -398,10 +406,320 @@ func upgradeMonitorFromV1(_ context.Context, prior monitorV1Model) (monitorResou
 		Status:                   prior.Status,
 		URL:                      prior.URL,
 		Tags:                     prior.Tags,
-		AssignedAlertContacts:    prior.AssignedAlertContacts,
+		AssignedAlertContacts:    acSet,
 		ResponseTimeThreshold:    prior.ResponseTimeThreshold,
 		RegionalData:             prior.RegionalData,
 	}
 
+	up.PostValueKV = types.MapNull(types.StringType)
+
 	return up, diags
+}
+
+// v2 -> v3
+
+type monitorV2Model struct {
+	Type                     types.String `tfsdk:"type"`
+	Interval                 types.Int64  `tfsdk:"interval"`
+	SSLExpirationReminder    types.Bool   `tfsdk:"ssl_expiration_reminder"`
+	DomainExpirationReminder types.Bool   `tfsdk:"domain_expiration_reminder"`
+	FollowRedirections       types.Bool   `tfsdk:"follow_redirections"`
+	AuthType                 types.String `tfsdk:"auth_type"`
+	HTTPUsername             types.String `tfsdk:"http_username"`
+	HTTPPassword             types.String `tfsdk:"http_password"`
+	CustomHTTPHeaders        types.Map    `tfsdk:"custom_http_headers"`
+	HTTPMethodType           types.String `tfsdk:"http_method_type"`
+	SuccessHTTPResponseCodes types.List   `tfsdk:"success_http_response_codes"`
+	Timeout                  types.Int64  `tfsdk:"timeout"`
+	PostValueData            types.String `tfsdk:"post_value_data"`
+	PostValueType            types.String `tfsdk:"post_value_type"`
+	Port                     types.Int64  `tfsdk:"port"`
+	GracePeriod              types.Int64  `tfsdk:"grace_period"`
+	KeywordValue             types.String `tfsdk:"keyword_value"`
+	KeywordCaseType          types.String `tfsdk:"keyword_case_type"`
+	KeywordType              types.String `tfsdk:"keyword_type"`
+	MaintenanceWindowIDs     types.List   `tfsdk:"maintenance_window_ids"`
+	ID                       types.String `tfsdk:"id"`
+	Name                     types.String `tfsdk:"name"`
+	Status                   types.String `tfsdk:"status"`
+	URL                      types.String `tfsdk:"url"`
+	Tags                     types.Set    `tfsdk:"tags"`
+	AssignedAlertContacts    types.List   `tfsdk:"assigned_alert_contacts"`
+	ResponseTimeThreshold    types.Int64  `tfsdk:"response_time_threshold"`
+	RegionalData             types.String `tfsdk:"regional_data"`
+}
+
+func priorSchemaV2() *schema.Schema {
+	s := &schema.Schema{
+		Version:     2,
+		Description: "Manages an UptimeRobot monitor.",
+		Attributes: map[string]schema.Attribute{
+			"type": schema.StringAttribute{
+				Description: "Type of the monitor (HTTP, KEYWORD, PING, PORT, HEARTBEAT, DNS)",
+				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("HTTP", "KEYWORD", "PING", "PORT", "HEARTBEAT", "DNS"),
+				},
+			},
+			"interval": schema.Int64Attribute{
+				Description: "Interval for the monitoring check (in seconds)",
+				Required:    true,
+			},
+			"ssl_expiration_reminder": schema.BoolAttribute{
+				Description: "Whether to enable SSL expiration reminders",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+			},
+			"domain_expiration_reminder": schema.BoolAttribute{
+				Description: "Whether to enable domain expiration reminders",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+			},
+			"follow_redirections": schema.BoolAttribute{
+				Description: "Whether to follow redirections",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+			},
+			"auth_type": schema.StringAttribute{
+				Description: "The authentication type (HTTP_BASIC)",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("HTTP_BASIC"),
+			},
+			"http_username": schema.StringAttribute{
+				Description: "The username for HTTP authentication",
+				Optional:    true,
+			},
+			"http_password": schema.StringAttribute{
+				Description: "The password for HTTP authentication",
+				Optional:    true,
+				Sensitive:   true,
+			},
+			"custom_http_headers": schema.MapAttribute{
+				Description: "Custom HTTP headers",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"http_method_type": schema.StringAttribute{
+				Description: "The HTTP method type (HEAD, GET, POST, PUT, PATCH, DELETE, OPTIONS)",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("GET"),
+				Validators: []validator.String{
+					stringvalidator.OneOf("HEAD", "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"),
+				},
+			},
+			"success_http_response_codes": schema.ListAttribute{
+				Description: "The expected HTTP response codes",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				Default:     listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{types.StringValue("2xx"), types.StringValue("3xx")})),
+			},
+			"timeout": schema.Int64Attribute{
+				Description: "Timeout for the check (in seconds). Not applicable for HEARTBEAT; ignored for DNS/PING. If omitted, default value 30 is used",
+				Optional:    true,
+				Computed:    true,
+				Validators: []validator.Int64{
+					int64validator.Between(0, 60),
+				},
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
+			},
+			"post_value_type": schema.StringAttribute{
+				Description: "The type of data to send with POST request. Server value is RAW_JSON when body is present",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"post_value_data": schema.StringAttribute{
+				Description: "JSON payload body as a string. Use jsonencode.",
+				Optional:    true,
+			},
+			"port": schema.Int64Attribute{
+				Description: "The port to monitor",
+				Optional:    true,
+			},
+			"grace_period": schema.Int64Attribute{
+				Description: "The grace period (in seconds). Only for HEARTBEAT monitors",
+				Optional:    true,
+				Validators: []validator.Int64{
+					int64validator.Between(0, 86400),
+				},
+			},
+			"keyword_value": schema.StringAttribute{
+				Description: "The keyword to search for",
+				Optional:    true,
+			},
+			"keyword_case_type": schema.StringAttribute{
+				Description: "The case sensitivity for keyword (CaseSensitive or CaseInsensitive). Default: CaseInsensitive",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("CaseInsensitive"),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"keyword_type": schema.StringAttribute{
+				Description: "The type of keyword check (ALERT_EXISTS, ALERT_NOT_EXISTS)",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("ALERT_EXISTS", "ALERT_NOT_EXISTS"),
+				},
+			},
+			"maintenance_window_ids": schema.ListAttribute{
+				Description: "The maintenance window IDs",
+				Optional:    true,
+				ElementType: types.Int64Type,
+			},
+			"id": schema.StringAttribute{
+				Description: "Monitor ID",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Description: "Name of the monitor",
+				Required:    true,
+			},
+			// Status may change its values quickly due to changes on the API side.
+			// On create after operation it should be a known value.
+			// On update use state's value.
+			// On read it will always be set because read is used for after-apply sync as well.
+			"status": schema.StringAttribute{
+				Description: "Status of the monitor",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"url": schema.StringAttribute{
+				Description: "URL to monitor",
+				Required:    true,
+			},
+			"tags": schema.SetAttribute{
+				Description: "Tags for the monitor",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"assigned_alert_contacts": schema.ListAttribute{
+				Description: "Alert contact IDs to assign to the monitor",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"response_time_threshold": schema.Int64Attribute{
+				Description: "Response time threshold in milliseconds. Response time over this threshold will trigger an incident",
+				Optional:    true,
+			},
+			"regional_data": schema.StringAttribute{
+				Description: "Region for monitoring: na (North America), eu (Europe), as (Asia), oc (Oceania)",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("na", "eu", "as", "oc"),
+				},
+			},
+		},
+	}
+
+	return s
+}
+
+// v2 -> v3
+func upgradeMonitorFromV2(ctx context.Context, prior monitorV2Model) (monitorResourceModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var normalized jsontypes.Normalized
+	if prior.PostValueData.IsNull() || prior.PostValueData.IsUnknown() ||
+		strings.TrimSpace(prior.PostValueData.ValueString()) == "" {
+		normalized = jsontypes.NewNormalizedNull()
+	} else {
+		raw := prior.PostValueData.ValueString()
+		if json.Valid([]byte(raw)) {
+			normalized = jsontypes.NewNormalizedValue(raw)
+		} else {
+			diags.AddWarning(
+				"Invalid JSON in prior state for post_value_data",
+				"The previous state stored a non-JSON string. The value has been cleared. "+
+					"Please set a valid JSON value using jsonencode(...) in configuration.",
+			)
+			normalized = jsontypes.NewNormalizedNull()
+		}
+	}
+
+	acSet, d := acListToObjectSet(ctx, prior.AssignedAlertContacts)
+	diags.Append(d...)
+
+	up := monitorResourceModel{
+		Type:                     prior.Type,
+		Interval:                 prior.Interval,
+		SSLExpirationReminder:    prior.SSLExpirationReminder,
+		DomainExpirationReminder: prior.DomainExpirationReminder,
+		FollowRedirections:       prior.FollowRedirections,
+		AuthType:                 prior.AuthType,
+		HTTPUsername:             prior.HTTPUsername,
+		HTTPPassword:             prior.HTTPPassword,
+		CustomHTTPHeaders:        prior.CustomHTTPHeaders,
+		HTTPMethodType:           prior.HTTPMethodType,
+		SuccessHTTPResponseCodes: prior.SuccessHTTPResponseCodes,
+		Timeout:                  prior.Timeout,
+		PostValueData:            normalized,
+		PostValueType:            prior.PostValueType,
+		Port:                     prior.Port,
+		GracePeriod:              prior.GracePeriod,
+		KeywordValue:             prior.KeywordValue,
+		KeywordCaseType:          prior.KeywordCaseType,
+		KeywordType:              prior.KeywordType,
+		MaintenanceWindowIDs:     prior.MaintenanceWindowIDs,
+		ID:                       prior.ID,
+		Name:                     prior.Name,
+		Status:                   prior.Status,
+		URL:                      prior.URL,
+		Tags:                     prior.Tags,
+		AssignedAlertContacts:    acSet, // converted
+		ResponseTimeThreshold:    prior.ResponseTimeThreshold,
+		RegionalData:             prior.RegionalData,
+	}
+
+	up.PostValueKV = types.MapNull(types.StringType)
+
+	return up, diags
+}
+
+// helper: List[string] -> Set[object{alert_contact_id, threshold, recurrence}]
+func acListToObjectSet(ctx context.Context, l types.List) (types.Set, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if l.IsNull() || l.IsUnknown() {
+		return types.SetNull(alertContactObjectType()), diags
+	}
+	var ids []string
+	diags.Append(l.ElementsAs(ctx, &ids, false)...)
+	if diags.HasError() {
+		return types.SetNull(alertContactObjectType()), diags
+	}
+	seen := map[string]struct{}{}
+	elts := make([]alertContactTF, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		elts = append(elts, alertContactTF{
+			AlertContactID: types.StringValue(id),
+			// match schema defaults to avoid diffs
+			Threshold:  types.Int64Value(0),
+			Recurrence: types.Int64Value(0),
+		})
+	}
+	v, d := types.SetValueFrom(ctx, alertContactObjectType(), elts)
+	diags.Append(d...)
+	return v, diags
 }

--- a/internal/provider/monitor_upgrade.go
+++ b/internal/provider/monitor_upgrade.go
@@ -631,6 +631,7 @@ func priorSchemaV2() *schema.Schema {
 }
 
 // v2 -> v3
+
 func upgradeMonitorFromV2(ctx context.Context, prior monitorV2Model) (monitorResourceModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 


### PR DESCRIPTION
Resolves #30 Resolves #85 Resolves #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - assigned_alert_contacts is now a structured set (alert_contact_id, threshold, recurrence), accepts numeric or string IDs, and includes migration/upgrade handling to preserve state across schema versions.

- **Bug Fixes**
  - Validates alert contact entries, detects missing/duplicate IDs, and enforces numeric threshold/recurrence consistency to avoid spurious diffs.

- **Documentation**
  - Updated docs with nested schema, minute-based semantics, and cross-reference anchors.

- **Tests**
  - Acceptance tests use environment-driven alert contact IDs, new test helpers, and add plan-only create coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->