### PR TITLE
Changed field types of Incident.ID and Monitor.LastIncidentID to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
-- No changes yet.
+### Fixed
+- Changed field types of `Incident.ID` and `Monitor.LastIncidentID` to string
 
 ## 1.3.2 — 2025-12-09
 

--- a/internal/client/monitor.go
+++ b/internal/client/monitor.go
@@ -118,7 +118,7 @@ type Monitor struct {
 	Status                   string              `json:"status"`
 	URL                      string              `json:"url"`
 	CurrentStateDuration     int                 `json:"currentStateDuration"`
-	LastIncidentID           *int64              `json:"lastIncidentId"`
+	LastIncidentID           *string             `json:"lastIncidentId"`
 	UserID                   int64               `json:"userId"`
 	Tags                     []Tag               `json:"tags"`
 	AssignedAlertContacts    []AlertContact      `json:"assignedAlertContacts"`
@@ -174,7 +174,7 @@ type DNSRecords struct {
 }
 
 type Incident struct {
-	ID        int64       `json:"id"`
+	ID        string      `json:"id"`
 	Status    interface{} `json:"status"`
 	Cause     int         `json:"cause"`
 	Reason    string      `json:"reason"`


### PR DESCRIPTION
Resolves #134 

Fixes the types of the LastIncidentId field of the Monitor type and Id field of the Incident type. The API returns a string while the provider expected an integer. These ID's aren't used by the provider so changing their types doesn't break anything.

I couldn't run all acceptance test because of the plan I'm on.

My guess is the definition of the API has been changed without notification. Acceptance tests probably didn't catch this because they only retrieved monitors that have just been created, without incidents. If you run the acceptance tests against an environment that already contains existing monitors with incidents, the tests would have failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Identifier fields for incidents and related monitoring data have been updated to use string type representation instead of numeric values. This change improves overall data consistency throughout the system, enhances API compatibility with external integrations and third-party services, and ensures more reliable and robust data handling across all system components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->