### PR TITLE
fix: port monitor validation

### DIFF
--- a/internal/provider/monitor_crud_create.go
+++ b/internal/provider/monitor_crud_create.go
@@ -23,6 +23,10 @@ func (r *monitorResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
+	if !validateCreateHighLevel(plan, resp) {
+		return
+	}
+
 	// Build API request from plan
 	createReq, effMethod := r.buildCreateRequest(ctx, plan, resp)
 	if resp.Diagnostics.HasError() {
@@ -58,6 +62,22 @@ func (r *monitorResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, final)...)
+}
+
+// High level validate create plan
+
+func validateCreateHighLevel(plan monitorResourceModel, resp *resource.CreateResponse) bool {
+	t := strings.ToUpper(plan.Type.ValueString())
+
+	if t == MonitorTypePORT && (plan.Port.IsNull() || plan.Port.IsUnknown()) {
+		resp.Diagnostics.AddError(
+			"Port required for PORT monitor",
+			"Port must be specified and known for PORT monitor type.",
+		)
+		return false
+	}
+
+	return true
 }
 
 // Build request

--- a/internal/provider/monitor_crud_update.go
+++ b/internal/provider/monitor_crud_update.go
@@ -102,8 +102,11 @@ func validateUpdateHighLevel(plan monitorResourceModel, resp *resource.UpdateRes
 	t := plan.Type.ValueString()
 
 	// PORT requires port to be set
-	if t == MonitorTypePORT && plan.Port.IsNull() {
-		resp.Diagnostics.AddError("Port required for PORT monitor", "Port must be specified for PORT monitor type")
+	if t == MonitorTypePORT && (plan.Port.IsNull() || plan.Port.IsUnknown()) {
+		resp.Diagnostics.AddError(
+			"Port required for PORT monitor",
+			"Port must be specified and known for PORT monitor type",
+		)
 		return false
 	}
 

--- a/internal/provider/monitor_schema.go
+++ b/internal/provider/monitor_schema.go
@@ -211,6 +211,9 @@ func (r *monitorResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"port": schema.Int64Attribute{
 				Description: "The port to monitor",
 				Optional:    true,
+				Validators: []validator.Int64{
+					int64validator.Between(1, 65535),
+				},
 			},
 			"grace_period": schema.Int64Attribute{
 				Description: "The grace period (in seconds). Only for HEARTBEAT monitors",

--- a/internal/provider/monitor_validate.go
+++ b/internal/provider/monitor_validate.go
@@ -309,7 +309,7 @@ func validatePortMonitor(
 		return
 	}
 
-	if monitorType == MonitorTypePORT && (data.Port.IsNull() || data.Port.IsUnknown()) {
+	if monitorType == MonitorTypePORT && data.Port.IsNull() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("port"),
 			"Port required for PORT monitor",

--- a/internal/provider/monitor_validate_test.go
+++ b/internal/provider/monitor_validate_test.go
@@ -1,0 +1,76 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestValidatePortMonitor_PortType_AllowsUnknownPort(t *testing.T) {
+	resp := &resource.ValidateConfigResponse{}
+	data := &monitorResourceModel{Port: types.Int64Unknown()}
+
+	validatePortMonitor(context.TODO(), MonitorTypePORT, data, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected no errors for unknown port value, got: %v", resp.Diagnostics)
+	}
+}
+
+func TestValidatePortMonitor_PortType_RequiresPortWhenNull(t *testing.T) {
+	resp := &resource.ValidateConfigResponse{}
+	data := &monitorResourceModel{Port: types.Int64Null()}
+
+	validatePortMonitor(context.TODO(), MonitorTypePORT, data, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected an error for null port value, got: %v", resp.Diagnostics)
+	}
+}
+
+func TestValidatePortMonitor_NonPortType_ErrsOnKnownPort(t *testing.T) {
+	resp := &resource.ValidateConfigResponse{}
+	data := &monitorResourceModel{Port: types.Int64Value(1234)}
+
+	validatePortMonitor(context.TODO(), MonitorTypeHTTP, data, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected an error for port set on non-PORT monitor, got: %v", resp.Diagnostics)
+	}
+}
+
+func TestValidateCreateHighLevel_PortType_RejectsUnknownPort(t *testing.T) {
+	resp := &resource.CreateResponse{}
+	plan := monitorResourceModel{
+		Type: types.StringValue(MonitorTypePORT),
+		Port: types.Int64Unknown(),
+	}
+
+	ok := validateCreateHighLevel(plan, resp)
+
+	if ok {
+		t.Fatalf("expected ok=false for unknown port")
+	}
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected diagnostics error for unknown port")
+	}
+}
+
+func TestValidateUpdateHighLevel_PortType_RejectsUnknownPort(t *testing.T) {
+	resp := &resource.UpdateResponse{}
+	plan := monitorResourceModel{
+		Type: types.StringValue(MonitorTypePORT),
+		Port: types.Int64Unknown(),
+	}
+
+	ok := validateUpdateHighLevel(plan, resp)
+
+	if ok {
+		t.Fatalf("expected ok=false for unknown port")
+	}
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected diagnostics error for unknown port")
+	}
+}


### PR DESCRIPTION
resolves #130 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced port validation for monitors; port values must now fall within 1–65535 range
  * Improved error handling during monitor creation and updates to prevent invalid configurations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->