### PR TITLE
fix: preserve heartbeat URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+## 1.4.3 — 2026-04-29
+
+### Fixed
+- Preserved server-generated heartbeat monitor URLs by omitting heartbeat `url` values from provider create/update requests.
+- Fixed webhook integration refresh to parse `postValue` whether the API returns it as a JSON object or a JSON-encoded string.
+- Preserved webhook send options and post value during refresh when the API omits webhook config fields, preventing false `send_as_json` drift.
+- Stabilized monitor update settling for `response_time_threshold` when the API accepts the update but omits the threshold from the immediate read response.
+
 ## 1.4.2 — 2026-04-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.4.3 — 2026-04-29
 
 ### Fixed
+
 - Preserved server-generated heartbeat monitor URLs by omitting heartbeat `url` values from provider create/update requests.
 - Fixed webhook integration refresh to parse `postValue` whether the API returns it as a JSON object or a JSON-encoded string.
 - Preserved webhook send options and post value during refresh when the API omits webhook config fields, preventing false `send_as_json` drift.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -85,6 +85,32 @@ func TestClient_Headers_SameHostRedirect(t *testing.T) {
 	}
 }
 
+func TestIntegrationWebhookBooleansTrackPresence(t *testing.T) {
+	t.Parallel()
+
+	var omitted Integration
+	if err := json.Unmarshal([]byte(`{}`), &omitted); err != nil {
+		t.Fatalf("unmarshal omitted fields: %v", err)
+	}
+	if omitted.SendAsJSON != nil || omitted.SendAsQueryString != nil || omitted.SendAsPostParameters != nil {
+		t.Fatalf("expected omitted webhook booleans to be nil")
+	}
+
+	var explicitFalse Integration
+	if err := json.Unmarshal([]byte(`{"sendAsJSON":false,"sendAsQueryString":false,"sendAsPostParameters":false}`), &explicitFalse); err != nil {
+		t.Fatalf("unmarshal explicit false fields: %v", err)
+	}
+	if explicitFalse.SendAsJSON == nil || *explicitFalse.SendAsJSON {
+		t.Fatalf("expected explicit sendAsJSON=false to be preserved")
+	}
+	if explicitFalse.SendAsQueryString == nil || *explicitFalse.SendAsQueryString {
+		t.Fatalf("expected explicit sendAsQueryString=false to be preserved")
+	}
+	if explicitFalse.SendAsPostParameters == nil || *explicitFalse.SendAsPostParameters {
+		t.Fatalf("expected explicit sendAsPostParameters=false to be preserved")
+	}
+}
+
 func TestSanitizeValue_RedactsSensitiveKeysNested(t *testing.T) {
 	v := any(map[string]any{
 		"password": "abc",

--- a/internal/client/integration.go
+++ b/internal/client/integration.go
@@ -21,9 +21,10 @@ type Integration struct {
 	SSLExpirationReminder  bool   `json:"sslExpirationReminder"`
 
 	// Webhook specific fields
-	SendAsJSON        bool   `json:"sendAsJSON,omitempty"`
-	SendAsQueryString bool   `json:"sendAsQueryString,omitempty"`
-	PostValue         string `json:"postValue,omitempty"`
+	SendAsJSON           *bool  `json:"sendAsJSON,omitempty"`
+	SendAsQueryString    *bool  `json:"sendAsQueryString,omitempty"`
+	SendAsPostParameters *bool  `json:"sendAsPostParameters,omitempty"`
+	PostValue            string `json:"postValue,omitempty"`
 
 	// Pushover specific field
 	Priority string `json:"priority,omitempty"`

--- a/internal/client/monitor.go
+++ b/internal/client/monitor.go
@@ -25,7 +25,7 @@ const (
 // CreateMonitorRequest represents the request to create a new monitor.
 type CreateMonitorRequest struct {
 	Name                     string                `json:"friendlyName"`
-	URL                      string                `json:"url"`
+	URL                      string                `json:"url,omitempty"`
 	Type                     MonitorType           `json:"type"`
 	Interval                 int                   `json:"interval"`
 	Timeout                  *int                  `json:"timeout,omitempty"`
@@ -59,7 +59,7 @@ type CreateMonitorRequest struct {
 // UpdateMonitorRequest represents the request to update an existing monitor.
 type UpdateMonitorRequest struct {
 	Name                     string                 `json:"friendlyName"`
-	URL                      string                 `json:"url"`
+	URL                      string                 `json:"url,omitempty"`
 	Type                     MonitorType            `json:"type"`
 	Interval                 int                    `json:"interval"`
 	Timeout                  *int                   `json:"timeout,omitempty"`

--- a/internal/client/request_marshal_test.go
+++ b/internal/client/request_marshal_test.go
@@ -33,6 +33,43 @@ func TestUpdateMonitorRequest_AssignedAlertContacts_JSON(t *testing.T) {
 	}
 }
 
+func TestMonitorRequests_EmptyURL_JSON(t *testing.T) {
+	updateReq := UpdateMonitorRequest{
+		Name:     "heartbeat",
+		Type:     MonitorTypeHeartbeat,
+		Interval: 300,
+	}
+	updateRaw, err := json.Marshal(updateReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(updateRaw), `"url"`) {
+		t.Fatalf("expected empty update url to be omitted, got %s", updateRaw)
+	}
+
+	createReq := CreateMonitorRequest{
+		Name:     "heartbeat",
+		Type:     MonitorTypeHeartbeat,
+		Interval: 300,
+	}
+	createRaw, err := json.Marshal(createReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(createRaw), `"url"`) {
+		t.Fatalf("expected empty create url to be omitted, got %s", createRaw)
+	}
+
+	createReq.URL = "https://example.com/health"
+	createRaw, err = json.Marshal(createReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(createRaw), `"url":"https://example.com/health"`) {
+		t.Fatalf("expected non-empty create url to be encoded, got %s", createRaw)
+	}
+}
+
 func TestCreateMonitorRequest_Config_JSON(t *testing.T) {
 	req := CreateMonitorRequest{
 		Name:     "dns-monitor",

--- a/internal/provider/integration_resource.go
+++ b/internal/provider/integration_resource.go
@@ -344,12 +344,12 @@ func normalizeWebhookPostValueString(value string) (types.String, bool, error) {
 	return types.StringValue(value), true, nil
 }
 
-func webhookBoolState(parsed types.Bool, known bool, prev types.Bool, topLevel bool) types.Bool {
+func webhookBoolState(parsed types.Bool, known bool, prev types.Bool, topLevel *bool) types.Bool {
 	if known {
 		return parsed
 	}
-	if topLevel {
-		return types.BoolValue(true)
+	if topLevel != nil {
+		return types.BoolValue(*topLevel)
 	}
 	if !prev.IsNull() && !prev.IsUnknown() {
 		return prev
@@ -875,7 +875,7 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 		// Set webhook-specific fields from parsed config
 		state.SendAsJSON = webhookBoolState(webhookFields.SendAsJSON, webhookFields.SendAsJSONKnown, prev.SendAsJSON, integration.SendAsJSON)
 		state.SendAsQueryString = webhookBoolState(webhookFields.SendAsQueryString, webhookFields.SendAsQueryKnown, prev.SendAsQueryString, integration.SendAsQueryString)
-		state.SendAsPostParameters = webhookBoolState(webhookFields.SendAsPostParameters, webhookFields.SendAsPostKnown, prev.SendAsPostParameters, false)
+		state.SendAsPostParameters = webhookBoolState(webhookFields.SendAsPostParameters, webhookFields.SendAsPostKnown, prev.SendAsPostParameters, integration.SendAsPostParameters)
 		postValue, err := webhookPostValueState(webhookFields.PostValue, webhookFields.PostValueKnown, prev.PostValue, integration.PostValue)
 		if err != nil {
 			resp.Diagnostics.AddError(

--- a/internal/provider/integration_resource.go
+++ b/internal/provider/integration_resource.go
@@ -58,10 +58,10 @@ func convertNotificationsForFromString(value string) int64 {
 
 // webhookConfig represents the webhook configuration stored in customValue.
 type webhookConfig struct {
-	PostValue map[string]interface{} `json:"postValue,omitempty"`
-	SendJSON  string                 `json:"sendJSON,omitempty"`
-	SendQuery string                 `json:"sendQuery,omitempty"`
-	SendPost  string                 `json:"sendPost,omitempty"`
+	PostValue json.RawMessage `json:"postValue,omitempty"`
+	SendJSON  json.RawMessage `json:"sendJSON,omitempty"`
+	SendQuery json.RawMessage `json:"sendQuery,omitempty"`
+	SendPost  json.RawMessage `json:"sendPost,omitempty"`
 }
 
 func isTempServerErr(err error) bool {
@@ -218,6 +218,10 @@ type webhookStateFields struct {
 	SendAsPostParameters types.Bool
 	PostValue            types.String
 	CustomValue          types.String
+	SendAsJSONKnown      bool
+	SendAsQueryKnown     bool
+	SendAsPostKnown      bool
+	PostValueKnown       bool
 }
 
 // parseWebhookStateFields parses webhook configuration and returns the state fields.
@@ -228,26 +232,143 @@ func parseWebhookStateFields(customValue string) (*webhookStateFields, error) {
 		return nil, fmt.Errorf("could not parse webhook configuration from API response: %w", err)
 	}
 
-	// Set webhook-specific fields from parsed config
-	fields := &webhookStateFields{
-		SendAsJSON:           types.BoolValue(webhookConfig.SendJSON == "1"),
-		SendAsQueryString:    types.BoolValue(webhookConfig.SendQuery == "1"),
-		SendAsPostParameters: types.BoolValue(webhookConfig.SendPost == "1"),
-		CustomValue:          types.StringNull(), // Webhook integrations don't use custom_value
+	sendAsJSON, sendAsJSONKnown, err := webhookFlagFromRaw(webhookConfig.SendJSON)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse sendJSON from webhook configuration: %w", err)
+	}
+	sendAsQuery, sendAsQueryKnown, err := webhookFlagFromRaw(webhookConfig.SendQuery)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse sendQuery from webhook configuration: %w", err)
+	}
+	sendAsPost, sendAsPostKnown, err := webhookFlagFromRaw(webhookConfig.SendPost)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse sendPost from webhook configuration: %w", err)
+	}
+	postValue, postValueKnown, err := webhookPostValueFromRaw(webhookConfig.PostValue)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse postValue from webhook configuration: %w", err)
 	}
 
-	// Set PostValue from parsed config - convert object back to JSON string for user
-	if webhookConfig.PostValue != nil {
-		postValueJSON, err := json.Marshal(webhookConfig.PostValue)
-		if err != nil {
-			return nil, fmt.Errorf("could not marshal post value from webhook configuration: %w", err)
-		}
-		fields.PostValue = types.StringValue(string(postValueJSON))
-	} else {
-		fields.PostValue = types.StringNull()
+	fields := &webhookStateFields{
+		SendAsJSON:           sendAsJSON,
+		SendAsQueryString:    sendAsQuery,
+		SendAsPostParameters: sendAsPost,
+		PostValue:            postValue,
+		CustomValue:          types.StringNull(), // Webhook integrations don't use custom_value
+		SendAsJSONKnown:      sendAsJSONKnown,
+		SendAsQueryKnown:     sendAsQueryKnown,
+		SendAsPostKnown:      sendAsPostKnown,
+		PostValueKnown:       postValueKnown,
 	}
 
 	return fields, nil
+}
+
+func webhookFlagFromRaw(raw json.RawMessage) (types.Bool, bool, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return types.BoolValue(false), false, nil
+	}
+
+	var b bool
+	if err := json.Unmarshal(raw, &b); err == nil {
+		return types.BoolValue(b), true, nil
+	}
+
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		switch strings.ToLower(strings.TrimSpace(s)) {
+		case "1", "true":
+			return types.BoolValue(true), true, nil
+		case "0", "false", "":
+			return types.BoolValue(false), true, nil
+		default:
+			return types.BoolValue(false), true, fmt.Errorf("unsupported boolean value %q", s)
+		}
+	}
+
+	var n int
+	if err := json.Unmarshal(raw, &n); err == nil {
+		switch n {
+		case 1:
+			return types.BoolValue(true), true, nil
+		case 0:
+			return types.BoolValue(false), true, nil
+		default:
+			return types.BoolValue(false), true, fmt.Errorf("unsupported boolean value %d", n)
+		}
+	}
+
+	return types.BoolValue(false), true, fmt.Errorf("unsupported boolean JSON %s", string(raw))
+}
+
+func webhookPostValueFromRaw(raw json.RawMessage) (types.String, bool, error) {
+	if len(raw) == 0 {
+		return types.StringNull(), false, nil
+	}
+	if string(raw) == "null" {
+		return types.StringNull(), true, nil
+	}
+
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return normalizeWebhookPostValueString(s)
+	}
+
+	var v interface{}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return types.StringNull(), true, err
+	}
+
+	normalized, err := json.Marshal(v)
+	if err != nil {
+		return types.StringNull(), true, err
+	}
+	return types.StringValue(string(normalized)), true, nil
+}
+
+func normalizeWebhookPostValueString(value string) (types.String, bool, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return types.StringNull(), true, nil
+	}
+
+	var v interface{}
+	if err := json.Unmarshal([]byte(trimmed), &v); err == nil {
+		normalized, err := json.Marshal(v)
+		if err != nil {
+			return types.StringNull(), true, err
+		}
+		return types.StringValue(string(normalized)), true, nil
+	}
+
+	return types.StringValue(value), true, nil
+}
+
+func webhookBoolState(parsed types.Bool, known bool, prev types.Bool, topLevel bool) types.Bool {
+	if known {
+		return parsed
+	}
+	if topLevel {
+		return types.BoolValue(true)
+	}
+	if !prev.IsNull() && !prev.IsUnknown() {
+		return prev
+	}
+	return types.BoolValue(false)
+}
+
+func webhookPostValueState(parsed types.String, known bool, prev types.String, topLevel string) (types.String, error) {
+	if known {
+		return parsed, nil
+	}
+	if strings.TrimSpace(topLevel) != "" {
+		value, _, err := normalizeWebhookPostValueString(topLevel)
+		return value, err
+	}
+	if !prev.IsNull() && !prev.IsUnknown() {
+		return prev, nil
+	}
+	return types.StringNull(), nil
 }
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -752,10 +873,18 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 		}
 
 		// Set webhook-specific fields from parsed config
-		state.SendAsJSON = webhookFields.SendAsJSON
-		state.SendAsQueryString = webhookFields.SendAsQueryString
-		state.SendAsPostParameters = webhookFields.SendAsPostParameters
-		state.PostValue = webhookFields.PostValue
+		state.SendAsJSON = webhookBoolState(webhookFields.SendAsJSON, webhookFields.SendAsJSONKnown, prev.SendAsJSON, integration.SendAsJSON)
+		state.SendAsQueryString = webhookBoolState(webhookFields.SendAsQueryString, webhookFields.SendAsQueryKnown, prev.SendAsQueryString, integration.SendAsQueryString)
+		state.SendAsPostParameters = webhookBoolState(webhookFields.SendAsPostParameters, webhookFields.SendAsPostKnown, prev.SendAsPostParameters, false)
+		postValue, err := webhookPostValueState(webhookFields.PostValue, webhookFields.PostValueKnown, prev.PostValue, integration.PostValue)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error parsing webhook configuration",
+				err.Error(),
+			)
+			return
+		}
+		state.PostValue = postValue
 		state.CustomValue = webhookFields.CustomValue
 
 		state.Priority = types.StringNull()

--- a/internal/provider/integration_resource_test.go
+++ b/internal/provider/integration_resource_test.go
@@ -131,3 +131,73 @@ func TestStickyStringPreferPrevOnMismatch(t *testing.T) {
 		t.Fatalf("expected api value when previous is null, got=%q", got.ValueString())
 	}
 }
+
+func TestParseWebhookStateFields_PostValueString(t *testing.T) {
+	t.Parallel()
+
+	fields, err := parseWebhookStateFields(`{"postValue":"{\"b\":\"x\",\"a\":1}","sendJSON":"1","sendQuery":"0","sendPost":"0"}`)
+	if err != nil {
+		t.Fatalf("parseWebhookStateFields returned error: %v", err)
+	}
+
+	if fields.PostValue.IsNull() || fields.PostValue.ValueString() != `{"a":1,"b":"x"}` {
+		t.Fatalf("expected normalized post_value, got %q", fields.PostValue.ValueString())
+	}
+	if !fields.PostValueKnown {
+		t.Fatalf("expected postValue to be marked known")
+	}
+	if !fields.SendAsJSON.ValueBool() || !fields.SendAsJSONKnown {
+		t.Fatalf("expected send_as_json to be true and known")
+	}
+	if fields.SendAsQueryString.ValueBool() || !fields.SendAsQueryKnown {
+		t.Fatalf("expected send_as_query_string to be false and known")
+	}
+	if fields.SendAsPostParameters.ValueBool() || !fields.SendAsPostKnown {
+		t.Fatalf("expected send_as_post_parameters to be false and known")
+	}
+}
+
+func TestParseWebhookStateFields_PostValueObject(t *testing.T) {
+	t.Parallel()
+
+	fields, err := parseWebhookStateFields(`{"postValue":{"b":"x","a":1},"sendJSON":true,"sendQuery":false,"sendPost":0}`)
+	if err != nil {
+		t.Fatalf("parseWebhookStateFields returned error: %v", err)
+	}
+
+	if fields.PostValue.IsNull() || fields.PostValue.ValueString() != `{"a":1,"b":"x"}` {
+		t.Fatalf("expected normalized post_value, got %q", fields.PostValue.ValueString())
+	}
+	if !fields.SendAsJSON.ValueBool() {
+		t.Fatalf("expected send_as_json to be true")
+	}
+}
+
+func TestWebhookStateKeepsPreviousValuesWhenAPIOmitsConfig(t *testing.T) {
+	t.Parallel()
+
+	prevBool := types.BoolValue(true)
+	gotBool := webhookBoolState(types.BoolValue(false), false, prevBool, false)
+	if gotBool.IsNull() || !gotBool.ValueBool() {
+		t.Fatalf("expected previous webhook bool value to be preserved")
+	}
+
+	gotTopLevelBool := webhookBoolState(types.BoolValue(false), false, types.BoolNull(), true)
+	if gotTopLevelBool.IsNull() || !gotTopLevelBool.ValueBool() {
+		t.Fatalf("expected top-level webhook bool value to be used")
+	}
+
+	gotKnownFalse := webhookBoolState(types.BoolValue(false), true, prevBool, true)
+	if gotKnownFalse.IsNull() || gotKnownFalse.ValueBool() {
+		t.Fatalf("expected explicit false from webhook config to win")
+	}
+
+	prevPostValue := types.StringValue(`{"message":"existing"}`)
+	gotPostValue, err := webhookPostValueState(types.StringNull(), false, prevPostValue, "")
+	if err != nil {
+		t.Fatalf("webhookPostValueState returned error: %v", err)
+	}
+	if gotPostValue.IsNull() || gotPostValue.ValueString() != prevPostValue.ValueString() {
+		t.Fatalf("expected previous post_value to be preserved, got %q", gotPostValue.ValueString())
+	}
+}

--- a/internal/provider/integration_resource_test.go
+++ b/internal/provider/integration_resource_test.go
@@ -177,17 +177,24 @@ func TestWebhookStateKeepsPreviousValuesWhenAPIOmitsConfig(t *testing.T) {
 	t.Parallel()
 
 	prevBool := types.BoolValue(true)
-	gotBool := webhookBoolState(types.BoolValue(false), false, prevBool, false)
+	gotBool := webhookBoolState(types.BoolValue(false), false, prevBool, nil)
 	if gotBool.IsNull() || !gotBool.ValueBool() {
 		t.Fatalf("expected previous webhook bool value to be preserved")
 	}
 
-	gotTopLevelBool := webhookBoolState(types.BoolValue(false), false, types.BoolNull(), true)
+	topLevelTrue := true
+	gotTopLevelBool := webhookBoolState(types.BoolValue(false), false, types.BoolNull(), &topLevelTrue)
 	if gotTopLevelBool.IsNull() || !gotTopLevelBool.ValueBool() {
 		t.Fatalf("expected top-level webhook bool value to be used")
 	}
 
-	gotKnownFalse := webhookBoolState(types.BoolValue(false), true, prevBool, true)
+	topLevelFalse := false
+	gotTopLevelFalse := webhookBoolState(types.BoolValue(true), false, prevBool, &topLevelFalse)
+	if gotTopLevelFalse.IsNull() || gotTopLevelFalse.ValueBool() {
+		t.Fatalf("expected explicit false from top-level webhook field to win")
+	}
+
+	gotKnownFalse := webhookBoolState(types.BoolValue(false), true, prevBool, &topLevelTrue)
 	if gotKnownFalse.IsNull() || gotKnownFalse.ValueBool() {
 		t.Fatalf("expected explicit false from webhook config to win")
 	}

--- a/internal/provider/monitor_compare.go
+++ b/internal/provider/monitor_compare.go
@@ -741,7 +741,7 @@ func equalComparable(want, got monComparable) bool {
 	if want.CheckSSLErrors != nil && (got.CheckSSLErrors == nil || *want.CheckSSLErrors != *got.CheckSSLErrors) {
 		return false
 	}
-	if want.ResponseTimeThreshold != nil && (got.ResponseTimeThreshold == nil || *want.ResponseTimeThreshold != *got.ResponseTimeThreshold) {
+	if want.ResponseTimeThreshold != nil && got.ResponseTimeThreshold != nil && *want.ResponseTimeThreshold != *got.ResponseTimeThreshold {
 		return false
 	}
 	if want.RegionalData != nil && (got.RegionalData == nil || *want.RegionalData != *got.RegionalData) {
@@ -860,7 +860,7 @@ func fieldsStillDifferent(want, got monComparable) []string {
 	if want.CheckSSLErrors != nil && (got.CheckSSLErrors == nil || *want.CheckSSLErrors != *got.CheckSSLErrors) {
 		f = append(f, "check_ssl_errors")
 	}
-	if want.ResponseTimeThreshold != nil && (got.ResponseTimeThreshold == nil || *want.ResponseTimeThreshold != *got.ResponseTimeThreshold) {
+	if want.ResponseTimeThreshold != nil && got.ResponseTimeThreshold != nil && *want.ResponseTimeThreshold != *got.ResponseTimeThreshold {
 		f = append(f, "response_time_threshold")
 	}
 	if want.RegionalData != nil && (got.RegionalData == nil || *want.RegionalData != *got.RegionalData) {

--- a/internal/provider/monitor_compare_test.go
+++ b/internal/provider/monitor_compare_test.go
@@ -198,3 +198,48 @@ func TestFieldsStillDifferent_IncludesHTTPMethodTypeAndType(t *testing.T) {
 		t.Fatalf("expected diff to include http_method_type, got: %v", diff)
 	}
 }
+
+func TestEqualComparable_ResponseTimeThresholdMissingEchoIsAccepted(t *testing.T) {
+	t.Parallel()
+
+	wantThreshold := 3000
+	gotThreshold := 5000
+
+	if !equalComparable(
+		monComparable{ResponseTimeThreshold: &wantThreshold},
+		monComparable{},
+	) {
+		t.Fatalf("expected missing API response_time_threshold echo to be accepted")
+	}
+
+	if equalComparable(
+		monComparable{ResponseTimeThreshold: &wantThreshold},
+		monComparable{ResponseTimeThreshold: &gotThreshold},
+	) {
+		t.Fatalf("expected mismatched response_time_threshold echo to differ")
+	}
+
+	diff := fieldsStillDifferent(
+		monComparable{ResponseTimeThreshold: &wantThreshold},
+		monComparable{},
+	)
+	for _, field := range diff {
+		if field == "response_time_threshold" {
+			t.Fatalf("did not expect missing response_time_threshold echo to be reported as a diff")
+		}
+	}
+
+	diff = fieldsStillDifferent(
+		monComparable{ResponseTimeThreshold: &wantThreshold},
+		monComparable{ResponseTimeThreshold: &gotThreshold},
+	)
+	found := false
+	for _, field := range diff {
+		if field == "response_time_threshold" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected mismatched response_time_threshold echo to be reported as a diff")
+	}
+}

--- a/internal/provider/monitor_crud_create.go
+++ b/internal/provider/monitor_crud_create.go
@@ -189,7 +189,8 @@ func (r *monitorResource) buildCreateRequest(
 		Name:     unescapeHTML(plan.Name.ValueString()),
 		Interval: int(plan.Interval.ValueInt64()),
 	}
-	if !plan.URL.IsNull() && !plan.URL.IsUnknown() {
+	// HEARTBEAT URLs are server-generated and must never be sent on create.
+	if strings.ToUpper(plan.Type.ValueString()) != MonitorTypeHEARTBEAT && !plan.URL.IsNull() && !plan.URL.IsUnknown() {
 		req.URL = unescapeHTML(plan.URL.ValueString())
 	}
 

--- a/internal/provider/monitor_crud_update.go
+++ b/internal/provider/monitor_crud_update.go
@@ -52,7 +52,7 @@ func (r *monitorResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 	configSent := updateReq.Config != nil
 
-	initialUpdated, err := r.client.UpdateMonitor(ctx, id, updateReq)
+	initialUpdated, err := r.updateMonitorWithRetry(ctx, id, updateReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating monitor", "Could not update monitor: "+err.Error())
 		return
@@ -116,6 +116,41 @@ func (r *monitorResource) Update(ctx context.Context, req resource.UpdateRequest
 }
 
 // Helpers
+
+func (r *monitorResource) updateMonitorWithRetry(ctx context.Context, id int64, req *client.UpdateMonitorRequest) (*client.Monitor, error) {
+	backoffs := []time.Duration{
+		500 * time.Millisecond,
+		1 * time.Second,
+		2 * time.Second,
+		3 * time.Second,
+		5 * time.Second,
+	}
+	maxAttempts := len(backoffs) + 1
+
+	var updated *client.Monitor
+	var err error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		updated, err = r.client.UpdateMonitor(ctx, id, req)
+		if err == nil {
+			return updated, nil
+		}
+		if !shouldRetryUpdateMonitor(err, attempt, maxAttempts) {
+			return nil, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(backoffs[attempt]):
+		}
+	}
+
+	return nil, err
+}
+
+func shouldRetryUpdateMonitor(err error, attempt, maxAttempts int) bool {
+	return err != nil && isTempServerErr(err) && attempt < maxAttempts-1
+}
 
 func validateUpdateHighLevel(plan monitorResourceModel, resp *resource.UpdateResponse) bool {
 	t := plan.Type.ValueString()

--- a/internal/provider/monitor_transform_test.go
+++ b/internal/provider/monitor_transform_test.go
@@ -168,6 +168,37 @@ func TestApplyUpdatedMonitorToState_ManagedEmptyConfig_NotSent_Preserved(t *test
 	}
 }
 
+func TestBuildCreateRequest_HeartbeatOmitsURL(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	plan := monitorResourceModel{
+		Type:        types.StringValue(MonitorTypeHEARTBEAT),
+		Name:        types.StringValue("heartbeat"),
+		URL:         types.StringValue("client-provided-hash"),
+		Interval:    types.Int64Value(300),
+		GracePeriod: types.Int64Value(120),
+	}
+	resp := &resource.CreateResponse{}
+
+	req, _ := (&monitorResource{}).buildCreateRequest(ctx, plan, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
+	}
+	if req == nil {
+		t.Fatal("expected non-nil create request")
+	}
+	if req.URL != "" {
+		t.Fatalf("expected heartbeat create to omit url, got %q", req.URL)
+	}
+	if req.GracePeriod == nil || *req.GracePeriod != 120 {
+		t.Fatalf("expected grace_period=120, got %#v", req.GracePeriod)
+	}
+	if req.Timeout != nil {
+		t.Fatalf("expected timeout to be omitted for heartbeat, got %#v", req.Timeout)
+	}
+}
+
 func TestBuildUpdateRequest_HeartbeatOmitsServerGeneratedURL(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/monitor_update_test.go
+++ b/internal/provider/monitor_update_test.go
@@ -1,0 +1,66 @@
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/uptimerobot/terraform-provider-uptimerobot/internal/client"
+)
+
+func TestShouldRetryUpdateMonitor(t *testing.T) {
+	t.Parallel()
+
+	transientErr := fmt.Errorf("wrapped: %w", &client.APIError{StatusCode: http.StatusBadGateway, Message: "bad gateway"})
+	nonTransientErr := errors.New("validation failed")
+
+	tests := []struct {
+		name        string
+		err         error
+		attempt     int
+		maxAttempts int
+		want        bool
+	}{
+		{
+			name:        "retry transient before last attempt",
+			err:         transientErr,
+			attempt:     0,
+			maxAttempts: 5,
+			want:        true,
+		},
+		{
+			name:        "do not retry transient on last attempt",
+			err:         transientErr,
+			attempt:     4,
+			maxAttempts: 5,
+			want:        false,
+		},
+		{
+			name:        "do not retry non-transient",
+			err:         nonTransientErr,
+			attempt:     0,
+			maxAttempts: 5,
+			want:        false,
+		},
+		{
+			name:        "do not retry nil error",
+			err:         nil,
+			attempt:     0,
+			maxAttempts: 5,
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := shouldRetryUpdateMonitor(tt.err, tt.attempt, tt.maxAttempts)
+			if got != tt.want {
+				t.Fatalf("unexpected retry decision: got=%v want=%v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Heartbeat monitor create/update now omit URL and empty URL values are no longer serialized.
  * Webhook parsing now tolerates multiple encodings, preserves send options/postValue across reads, and supports nullable webhook flags to avoid accidental drifts.
  * Monitor updates avoid spurious differences for response_time_threshold when API omits it.
  * Initial monitor update is retried on transient server errors.

* **Tests**
  * Added tests for monitor JSON marshalling, heartbeat create behavior, webhook parsing/normalization, comparison logic, and retry decisions.

* **Chores**
  * Updated changelog for release 1.4.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->