### PR TITLE
Serialize duplicate integration creates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.4.6 — 2026-05-02
+
 ### Fixed
 
 - Serialized concurrent `uptimerobot_integration` creates with the same integration type and value inside one Terraform apply, avoiding non-transactional API duplicate races that could create mixed duplicate/409 results.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixed
+
+- Serialized concurrent `uptimerobot_integration` creates with the same integration type and value inside one Terraform apply, avoiding non-transactional API duplicate races that could create mixed duplicate/409 results.
+
 ## 1.4.5 — 2026-05-01
 
 ### Fixed

--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -12,8 +12,8 @@ Manages an integration in UptimeRobot.
 ## Notes
 
 - The UptimeRobot API enforces uniqueness for some integration types by webhook URL, but the check is not fully transactional. Concurrent creates with the same webhook can occasionally yield duplicates or mixed 201/409 responses.
-- If you create multiple integrations with the same webhook, prefer serial execution: run `terraform apply -parallelism=1`, or use `depends_on` to force ordering.
-- If a create returns "already exists" (409), import the existing integration and re-apply instead of retrying blindly.
+- The provider serializes creates with the same integration type and value inside a single Terraform apply to avoid racing that API uniqueness check. Separate Terraform runs or older provider versions may still need serial execution (`terraform apply -parallelism=1`) or explicit `depends_on` ordering.
+- If a create returns "already exists" (409), import the existing integration or change the configuration to create a distinct integration instead of retrying blindly.
 
 
 ## Example Usage

--- a/internal/provider/integration_create_lock.go
+++ b/internal/provider/integration_create_lock.go
@@ -1,0 +1,44 @@
+package provider
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"sync"
+)
+
+// UptimeRobot's duplicate-integration check is not fully transactional, so
+// serialize matching creates inside one provider process before calling the API.
+var integrationCreateLocks sync.Map // map[string]chan struct{}
+
+func integrationCreateLockKey(integrationType, value string) string {
+	integrationType = strings.ToLower(strings.TrimSpace(integrationType))
+	value = strings.TrimSpace(value)
+	if integrationType == "" || value == "" {
+		return ""
+	}
+
+	sum := sha256.Sum256([]byte(integrationType + "\x00" + value))
+	return hex.EncodeToString(sum[:])
+}
+
+func lockIntegrationCreate(ctx context.Context, key string) (func(), error) {
+	if key == "" {
+		return func() {}, nil
+	}
+
+	raw, _ := integrationCreateLocks.LoadOrStore(key, make(chan struct{}, 1))
+	lock, ok := raw.(chan struct{})
+	if !ok {
+		return nil, errors.New("integration create lock has unexpected type")
+	}
+
+	select {
+	case lock <- struct{}{}:
+		return func() { <-lock }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/internal/provider/integration_resource.go
+++ b/internal/provider/integration_resource.go
@@ -697,6 +697,13 @@ func (r *integrationResource) Create(ctx context.Context, req resource.CreateReq
 		Data: integrationData,
 	}
 
+	unlockCreate, lockErr := lockIntegrationCreate(ctx, integrationCreateLockKey(integrationTypeAPI, plan.Value.ValueString()))
+	if lockErr != nil {
+		resp.Diagnostics.AddError("Create cancelled", lockErr.Error())
+		return
+	}
+	defer unlockCreate()
+
 	var newIntegration *client.Integration
 	backoffs := []time.Duration{
 		500 * time.Millisecond, 1 * time.Second, 2 * time.Second, 3 * time.Second, 5 * time.Second,

--- a/internal/provider/integration_resource_test.go
+++ b/internal/provider/integration_resource_test.go
@@ -1,7 +1,10 @@
 package provider
 
 import (
+	"context"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/uptimerobot/terraform-provider-uptimerobot/internal/client"
@@ -56,6 +59,72 @@ func TestPagerDutyLocationFromAPI(t *testing.T) {
 				t.Fatalf("value mismatch: got=%q want=%q", gotValue, tt.wantValue)
 			}
 		})
+	}
+}
+
+func TestIntegrationCreateLockKeyNormalizesAndHashesValue(t *testing.T) {
+	t.Parallel()
+
+	key := integrationCreateLockKey(" Mattermost ", " https://example.com/hook ")
+	if key == "" {
+		t.Fatal("expected non-empty lock key")
+	}
+	if key != integrationCreateLockKey("mattermost", "https://example.com/hook") {
+		t.Fatalf("expected type and value whitespace/case normalization")
+	}
+	if key == integrationCreateLockKey("webhook", "https://example.com/hook") {
+		t.Fatalf("expected integration type to contribute to lock key")
+	}
+	if strings.Contains(key, "example.com") {
+		t.Fatalf("expected lock key to avoid storing the sensitive integration value")
+	}
+}
+
+func TestLockIntegrationCreateSerializesSameKey(t *testing.T) {
+	t.Parallel()
+
+	key := "test-lock-" + t.Name()
+	unlock, err := lockIntegrationCreate(context.Background(), key)
+	if err != nil {
+		t.Fatalf("first lock failed: %v", err)
+	}
+
+	acquired := make(chan struct{})
+	releaseSecond := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		unlockSecond, err := lockIntegrationCreate(context.Background(), key)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		close(acquired)
+		<-releaseSecond
+		unlockSecond()
+		errCh <- nil
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("second lock acquired before first lock was released")
+	case err := <-errCh:
+		t.Fatalf("second lock failed early: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	unlock()
+
+	select {
+	case <-acquired:
+	case err := <-errCh:
+		t.Fatalf("second lock failed: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("second lock did not acquire after first lock was released")
+	}
+
+	close(releaseSecond)
+	if err := <-errCh; err != nil {
+		t.Fatalf("second lock returned error: %v", err)
 	}
 }
 

--- a/templates/resources/integration.md.tmpl
+++ b/templates/resources/integration.md.tmpl
@@ -12,8 +12,8 @@ description: |-
 ## Notes
 
 - The UptimeRobot API enforces uniqueness for some integration types by webhook URL, but the check is not fully transactional. Concurrent creates with the same webhook can occasionally yield duplicates or mixed 201/409 responses.
-- If you create multiple integrations with the same webhook, prefer serial execution: run `terraform apply -parallelism=1`, or use `depends_on` to force ordering.
-- If a create returns "already exists" (409), import the existing integration and re-apply instead of retrying blindly.
+- The provider serializes creates with the same integration type and value inside a single Terraform apply to avoid racing that API uniqueness check. Separate Terraform runs or older provider versions may still need serial execution (`terraform apply -parallelism=1`) or explicit `depends_on` ordering.
+- If a create returns "already exists" (409), import the existing integration or change the configuration to create a distinct integration instead of retrying blindly.
 
 
 ## Example Usage


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Creates for integrations with the same type/value within a single Terraform apply are now serialized to reduce duplicate API creates and 409 conflicts.

## Documentation
- Clarified integration notes: guidance on 409 "already exists" responses, importing existing integrations or changing config instead of retrying, and when `terraform apply -parallelism=1` or `depends_on` may still be needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->