### PR TITLE
feat: add monitor region_data support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+### Added
+
+- Added structured `region_data` support for `uptimerobot_monitor`, including multi-region `regions` and optional per-region response-time `thresholds`.
+
+### Changed
+
+- Deprecated legacy single-region `regional_data` in favor of `region_data`; the two attributes conflict to support a safe migration path.
+
 ## 1.4.7 — 2026-05-03
 
 ### Fixed

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -203,6 +203,28 @@ resource "uptimerobot_monitor" "gateway_ping" {
 }
 ```
 
+### Multi-region Monitor
+
+```terraform
+resource "uptimerobot_monitor" "multi_region" {
+  name     = "Multi-region Website"
+  type     = "HTTP"
+  url      = "https://example.com"
+  interval = 300
+  timeout  = 30
+
+  region_data = {
+    regions = ["na", "eu", "as"]
+
+    thresholds = {
+      na = 3000
+      eu = 4000
+      as = 6000
+    }
+  }
+}
+```
+
 ### UDP Monitor
 
 ```terraform
@@ -660,7 +682,11 @@ terraform import 'uptimerobot_monitor.monitors["www_production"]' 800123456
 - `port` (Number) The port to monitor
 - `post_value_data` (String) JSON body (use jsonencode). Mutually exclusive with post_value_kv.
 - `post_value_kv` (Map of String) Key/Value body for application/x-www-form-urlencoded. Mutually exclusive with post_value_data.
-- `regional_data` (String) Region for monitoring: na (North America), eu (Europe), as (Asia), oc (Oceania)
+- `region_data` (Attributes) Multi-region monitor settings. Uses the API v3 `regionData` object.
+
+- `regions` selects the active monitoring regions: `na`, `eu`, `as`, `oc`.
+- `thresholds` optionally sets per-region response-time thresholds in milliseconds. Keys must be selected regions and values must be between `0` and `60000`. (see [below for nested schema](#nestedatt--region_data))
+- `regional_data` (String, Deprecated) Legacy single region for monitoring: na (North America), eu (Europe), as (Asia), oc (Oceania). Use region_data for new multi-region monitor settings.
 - `response_time_threshold` (Number) Response time threshold in milliseconds. Response time over this threshold will trigger an incident
 - `ssl_expiration_reminder` (Boolean) Whether to enable SSL expiration reminders
 - `success_http_response_codes` (Set of String) The expected HTTP response codes. If not set API applies defaults.
@@ -761,3 +787,16 @@ Optional:
 
 - `packet_loss_threshold` (Number) Packet loss threshold percentage.
 - `payload` (String) Optional UDP payload to send.
+
+
+
+<a id="nestedatt--region_data"></a>
+### Nested Schema for `region_data`
+
+Required:
+
+- `regions` (Set of String) Active monitoring regions: na (North America), eu (Europe), as (Asia), oc (Oceania).
+
+Optional:
+
+- `thresholds` (Map of Number) Optional per-region response-time thresholds in milliseconds. Keys must be selected regions.

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -216,6 +216,10 @@ resource "uptimerobot_monitor" "multi_region" {
   region_data = {
     regions = ["na", "eu", "as"]
 
+    # Optional: let UptimeRobot choose the monitoring region automatically.
+    # When omitted or false, the configured regions are used manually.
+    # auto_select = true
+
     thresholds = {
       na = 3000
       eu = 4000
@@ -685,6 +689,7 @@ terraform import 'uptimerobot_monitor.monitors["www_production"]' 800123456
 - `region_data` (Attributes) Multi-region monitor settings. Uses the API v3 `regionData` object.
 
 - `regions` selects the active monitoring regions: `na`, `eu`, `as`, `oc`.
+- `auto_select` lets UptimeRobot choose the monitoring region automatically. When omitted or `false`, the configured `regions` are used as manually selected regions.
 - `thresholds` optionally sets per-region response-time thresholds in milliseconds. Keys must be selected regions and values must be between `0` and `60000`. (see [below for nested schema](#nestedatt--region_data))
 - `regional_data` (String, Deprecated) Legacy single region for monitoring: na (North America), eu (Europe), as (Asia), oc (Oceania). Use region_data for new multi-region monitor settings.
 - `response_time_threshold` (Number) Response time threshold in milliseconds. Response time over this threshold will trigger an incident
@@ -799,4 +804,5 @@ Required:
 
 Optional:
 
+- `auto_select` (Boolean) When true, UptimeRobot automatically chooses the monitoring region. When omitted or false, the configured regions are used as manually selected regions.
 - `thresholds` (Map of Number) Optional per-region response-time thresholds in milliseconds. Keys must be selected regions.

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -206,6 +206,8 @@ resource "uptimerobot_monitor" "gateway_ping" {
 ### Multi-region Monitor
 
 ```terraform
+# Requires an account with monitor-location-settings support.
+# Accounts without that feature cannot use region_data.
 resource "uptimerobot_monitor" "multi_region" {
   name     = "Multi-region Website"
   type     = "HTTP"

--- a/examples/resources/uptimerobot_monitor/region_data.tf
+++ b/examples/resources/uptimerobot_monitor/region_data.tf
@@ -1,0 +1,17 @@
+resource "uptimerobot_monitor" "multi_region" {
+  name     = "Multi-region Website"
+  type     = "HTTP"
+  url      = "https://example.com"
+  interval = 300
+  timeout  = 30
+
+  region_data = {
+    regions = ["na", "eu", "as"]
+
+    thresholds = {
+      na = 3000
+      eu = 4000
+      as = 6000
+    }
+  }
+}

--- a/examples/resources/uptimerobot_monitor/region_data.tf
+++ b/examples/resources/uptimerobot_monitor/region_data.tf
@@ -1,3 +1,5 @@
+# Requires an account with monitor-location-settings support.
+# Accounts without that feature cannot use region_data.
 resource "uptimerobot_monitor" "multi_region" {
   name     = "Multi-region Website"
   type     = "HTTP"

--- a/examples/resources/uptimerobot_monitor/region_data.tf
+++ b/examples/resources/uptimerobot_monitor/region_data.tf
@@ -8,6 +8,10 @@ resource "uptimerobot_monitor" "multi_region" {
   region_data = {
     regions = ["na", "eu", "as"]
 
+    # Optional: let UptimeRobot choose the monitoring region automatically.
+    # When omitted or false, the configured regions are used manually.
+    # auto_select = true
+
     thresholds = {
       na = 3000
       eu = 4000

--- a/internal/client/monitor.go
+++ b/internal/client/monitor.go
@@ -159,8 +159,8 @@ type AlertContact struct {
 }
 
 type RegionDataRequest struct {
-	Regions    []string       `json:"REGION"`
-	Thresholds map[string]int `json:"THRESHOLD,omitempty"`
+	Regions    []string        `json:"REGION"`
+	Thresholds *map[string]int `json:"THRESHOLD,omitempty"`
 }
 
 type MonitorConfig struct {

--- a/internal/client/monitor.go
+++ b/internal/client/monitor.go
@@ -52,6 +52,7 @@ type CreateMonitorRequest struct {
 	FollowRedirections       bool                  `json:"followRedirections"`
 	ResponseTimeThreshold    int                   `json:"responseTimeThreshold,omitempty"`
 	RegionalData             string                `json:"regionalData,omitempty"`
+	RegionData               *RegionDataRequest    `json:"regionData,omitempty"`
 	Config                   *MonitorConfig        `json:"config,omitempty"`
 	GroupID                  *int                  `json:"groupId,omitempty"`
 }
@@ -86,6 +87,7 @@ type UpdateMonitorRequest struct {
 	FollowRedirections       bool                   `json:"followRedirections"`
 	ResponseTimeThreshold    *int                   `json:"responseTimeThreshold,omitempty"`
 	RegionalData             *string                `json:"regionalData,omitempty"`
+	RegionData               *RegionDataRequest     `json:"regionData,omitempty"`
 	Config                   *MonitorConfig         `json:"config,omitempty"`
 	GroupID                  *int                   `json:"groupId,omitempty"`
 }
@@ -154,6 +156,11 @@ type AlertContact struct {
 	AlertContactID StringOrNumberID `json:"alertContactId"`
 	Threshold      int64            `json:"threshold"`
 	Recurrence     int64            `json:"recurrence"`
+}
+
+type RegionDataRequest struct {
+	Regions    []string       `json:"REGION"`
+	Thresholds map[string]int `json:"THRESHOLD,omitempty"`
 }
 
 type MonitorConfig struct {

--- a/internal/client/monitor.go
+++ b/internal/client/monitor.go
@@ -159,8 +159,9 @@ type AlertContact struct {
 }
 
 type RegionDataRequest struct {
-	Regions    []string        `json:"REGION"`
-	Thresholds *map[string]int `json:"THRESHOLD,omitempty"`
+	Regions        []string        `json:"REGION"`
+	ManualSelected *bool           `json:"MANUAL_SELECTED,omitempty"`
+	Thresholds     *map[string]int `json:"THRESHOLD,omitempty"`
 }
 
 type MonitorConfig struct {

--- a/internal/client/request_marshal_test.go
+++ b/internal/client/request_marshal_test.go
@@ -209,17 +209,18 @@ func TestCreateMonitorRequest_Config_UDP_JSON(t *testing.T) {
 }
 
 func TestMonitorRequest_RegionData_JSON(t *testing.T) {
+	reqThresholds := map[string]int{
+		"na": 3000,
+		"eu": 5000,
+	}
 	req := CreateMonitorRequest{
 		Name:     "multi-region",
 		URL:      "https://example.com",
 		Type:     MonitorTypeHTTP,
 		Interval: 300,
 		RegionData: &RegionDataRequest{
-			Regions: []string{"na", "eu"},
-			Thresholds: map[string]int{
-				"na": 3000,
-				"eu": 5000,
-			},
+			Regions:    []string{"na", "eu"},
+			Thresholds: &reqThresholds,
 		},
 	}
 
@@ -247,12 +248,51 @@ func TestMonitorRequest_RegionData_JSON(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected THRESHOLD object, got %#v", regionData["THRESHOLD"])
 	}
-	naThreshold, ok := thresholds["na"].(float64)
-	if !ok {
-		t.Fatalf("expected na threshold number, got %#v", thresholds["na"])
+	if len(thresholds) != len(reqThresholds) {
+		t.Fatalf("expected %d threshold entries, got %#v", len(reqThresholds), thresholds)
 	}
-	if got := int(naThreshold); got != 3000 {
-		t.Fatalf("expected na threshold=3000, got %d", got)
+	for region, want := range reqThresholds {
+		rawThreshold, ok := thresholds[region].(float64)
+		if !ok {
+			t.Fatalf("expected %s threshold number, got %#v", region, thresholds[region])
+		}
+		if got := int(rawThreshold); got != want {
+			t.Fatalf("expected %s threshold=%d, got %d", region, want, got)
+		}
+	}
+}
+
+func TestMonitorRequest_RegionData_EmptyThresholds_JSON(t *testing.T) {
+	reqThresholds := map[string]int{}
+	req := UpdateMonitorRequest{
+		Name:     "multi-region",
+		Type:     MonitorTypeHTTP,
+		Interval: 300,
+		RegionData: &RegionDataRequest{
+			Regions:    []string{"na", "eu"},
+			Thresholds: &reqThresholds,
+		},
+	}
+
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	regionData, ok := m["regionData"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected regionData object, got %#v", m["regionData"])
+	}
+	thresholds, ok := regionData["THRESHOLD"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected empty THRESHOLD object, got %#v in %s", regionData["THRESHOLD"], raw)
+	}
+	if len(thresholds) != 0 {
+		t.Fatalf("expected empty THRESHOLD object, got %#v", thresholds)
 	}
 }
 

--- a/internal/client/request_marshal_test.go
+++ b/internal/client/request_marshal_test.go
@@ -267,6 +267,50 @@ func TestMonitorRequest_RegionData_JSON(t *testing.T) {
 			t.Fatalf("expected %s threshold=%d, got %d", region, want, got)
 		}
 	}
+	if _, ok := regionData["MANUAL_SELECTED"]; ok {
+		t.Fatalf("expected MANUAL_SELECTED to be omitted when auto_select is unmanaged, got %s", raw)
+	}
+}
+
+func TestMonitorRequest_RegionData_ManualSelected_JSON(t *testing.T) {
+	for name, manualSelected := range map[string]bool{
+		"auto":   false,
+		"manual": true,
+	} {
+		t.Run(name, func(t *testing.T) {
+			req := CreateMonitorRequest{
+				Name:     "multi-region",
+				URL:      "https://example.com",
+				Type:     MonitorTypeHTTP,
+				Interval: 300,
+				RegionData: &RegionDataRequest{
+					Regions:        []string{"na"},
+					ManualSelected: &manualSelected,
+				},
+			}
+
+			raw, err := json.Marshal(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var m map[string]any
+			if err := json.Unmarshal(raw, &m); err != nil {
+				t.Fatal(err)
+			}
+			regionData, ok := m["regionData"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected regionData object, got %#v", m["regionData"])
+			}
+			got, ok := regionData["MANUAL_SELECTED"].(bool)
+			if !ok {
+				t.Fatalf("expected MANUAL_SELECTED bool, got %#v in %s", regionData["MANUAL_SELECTED"], raw)
+			}
+			if got != manualSelected {
+				t.Fatalf("expected MANUAL_SELECTED=%t, got %t", manualSelected, got)
+			}
+		})
+	}
 }
 
 func TestMonitorRequest_RegionData_EmptyThresholds_JSON(t *testing.T) {

--- a/internal/client/request_marshal_test.go
+++ b/internal/client/request_marshal_test.go
@@ -244,6 +244,13 @@ func TestMonitorRequest_RegionData_JSON(t *testing.T) {
 	if !ok || len(regions) != 2 {
 		t.Fatalf("expected two REGION values, got %#v", regionData["REGION"])
 	}
+	expectedRegions := []string{"na", "eu"}
+	for i, want := range expectedRegions {
+		got, ok := regions[i].(string)
+		if !ok || got != want {
+			t.Fatalf("expected REGION[%d]=%q, got %#v", i, want, regions[i])
+		}
+	}
 	thresholds, ok := regionData["THRESHOLD"].(map[string]any)
 	if !ok {
 		t.Fatalf("expected THRESHOLD object, got %#v", regionData["THRESHOLD"])

--- a/internal/client/request_marshal_test.go
+++ b/internal/client/request_marshal_test.go
@@ -208,6 +208,75 @@ func TestCreateMonitorRequest_Config_UDP_JSON(t *testing.T) {
 	}
 }
 
+func TestMonitorRequest_RegionData_JSON(t *testing.T) {
+	req := CreateMonitorRequest{
+		Name:     "multi-region",
+		URL:      "https://example.com",
+		Type:     MonitorTypeHTTP,
+		Interval: 300,
+		RegionData: &RegionDataRequest{
+			Regions: []string{"na", "eu"},
+			Thresholds: map[string]int{
+				"na": 3000,
+				"eu": 5000,
+			},
+		},
+	}
+
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := m["regionalData"]; ok {
+		t.Fatalf("new region data should use regionData, got %s", raw)
+	}
+	regionData, ok := m["regionData"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected regionData object, got %#v", m["regionData"])
+	}
+	regions, ok := regionData["REGION"].([]any)
+	if !ok || len(regions) != 2 {
+		t.Fatalf("expected two REGION values, got %#v", regionData["REGION"])
+	}
+	thresholds, ok := regionData["THRESHOLD"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected THRESHOLD object, got %#v", regionData["THRESHOLD"])
+	}
+	naThreshold, ok := thresholds["na"].(float64)
+	if !ok {
+		t.Fatalf("expected na threshold number, got %#v", thresholds["na"])
+	}
+	if got := int(naThreshold); got != 3000 {
+		t.Fatalf("expected na threshold=3000, got %d", got)
+	}
+}
+
+func TestMonitorRequest_LegacyRegionalData_JSON(t *testing.T) {
+	req := CreateMonitorRequest{
+		Name:         "single-region",
+		URL:          "https://example.com",
+		Type:         MonitorTypeHTTP,
+		Interval:     300,
+		RegionalData: "eu",
+	}
+
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"regionalData":"eu"`) {
+		t.Fatalf("expected legacy regionalData string, got %s", raw)
+	}
+	if strings.Contains(string(raw), `"regionData"`) {
+		t.Fatalf("did not expect new regionData object, got %s", raw)
+	}
+}
+
 func TestMaintenanceWindowRequest_AutoAddMonitors_JSON(t *testing.T) {
 	createReq := CreateMaintenanceWindowRequest{
 		Name:     "mw-create",

--- a/internal/provider/monitor_compare.go
+++ b/internal/provider/monitor_compare.go
@@ -176,7 +176,7 @@ func wantFromCreateReq(req *client.CreateMonitorRequest) monComparable {
 			Regions: normalizeRegions(req.RegionData.Regions),
 		}
 		if req.RegionData.Thresholds != nil {
-			c.RegionData.Thresholds = normalizeRegionThresholds(req.RegionData.Thresholds)
+			c.RegionData.Thresholds = normalizeRegionThresholds(*req.RegionData.Thresholds)
 		}
 	}
 	if req.GroupID != nil {
@@ -339,7 +339,7 @@ func wantFromUpdateReq(req *client.UpdateMonitorRequest) monComparable {
 			Regions: normalizeRegions(req.RegionData.Regions),
 		}
 		if req.RegionData.Thresholds != nil {
-			c.RegionData.Thresholds = normalizeRegionThresholds(req.RegionData.Thresholds)
+			c.RegionData.Thresholds = normalizeRegionThresholds(*req.RegionData.Thresholds)
 		}
 	}
 	if req.GroupID != nil {

--- a/internal/provider/monitor_compare.go
+++ b/internal/provider/monitor_compare.go
@@ -30,6 +30,7 @@ type monComparable struct {
 	CheckSSLErrors           *bool
 	ResponseTimeThreshold    *int
 	RegionalData             *string
+	RegionData               *regionDataComparable
 	GroupID                  *int
 
 	// Collections compared as sets and maps when present
@@ -169,6 +170,14 @@ func wantFromCreateReq(req *client.CreateMonitorRequest) monComparable {
 	if req.RegionalData != "" {
 		s := strings.ToLower(strings.TrimSpace(req.RegionalData))
 		c.RegionalData = &s
+	}
+	if req.RegionData != nil {
+		c.RegionData = &regionDataComparable{
+			Regions: normalizeRegions(req.RegionData.Regions),
+		}
+		if req.RegionData.Thresholds != nil {
+			c.RegionData.Thresholds = normalizeRegionThresholds(req.RegionData.Thresholds)
+		}
 	}
 	if req.GroupID != nil {
 		v := *req.GroupID
@@ -325,6 +334,14 @@ func wantFromUpdateReq(req *client.UpdateMonitorRequest) monComparable {
 		s := strings.ToLower(strings.TrimSpace(*req.RegionalData))
 		c.RegionalData = &s
 	}
+	if req.RegionData != nil {
+		c.RegionData = &regionDataComparable{
+			Regions: normalizeRegions(req.RegionData.Regions),
+		}
+		if req.RegionData.Thresholds != nil {
+			c.RegionData.Thresholds = normalizeRegionThresholds(req.RegionData.Thresholds)
+		}
+	}
 	if req.GroupID != nil {
 		v := *req.GroupID
 		c.GroupID = &v
@@ -466,16 +483,11 @@ func buildComparableFromAPI(m *client.Monitor) monComparable {
 
 	// API may return an object. Normalization to a string should be performed
 	if m.RegionalData != nil {
-		switch v := m.RegionalData.(type) {
-		case string:
-			s := strings.ToLower(strings.TrimSpace(v))
-			c.RegionalData = &s
-		case map[string]interface{}:
-			if regions, ok := v["REGION"].([]interface{}); ok && len(regions) > 0 {
-				if r0, ok := regions[0].(string); ok && r0 != "" {
-					s := strings.ToLower(strings.TrimSpace(r0))
-					c.RegionalData = &s
-				}
+		if regionData, ok := normalizeRegionDataFromAPI(m.RegionalData); ok {
+			c.RegionData = regionData
+			if len(regionData.Regions) > 0 {
+				s := regionData.Regions[0]
+				c.RegionalData = &s
 			}
 		}
 	}
@@ -806,6 +818,9 @@ func equalComparable(want, got monComparable) bool {
 	if want.RegionalData != nil && (got.RegionalData == nil || *want.RegionalData != *got.RegionalData) {
 		return false
 	}
+	if want.RegionData != nil && !equalRegionData(want.RegionData, got.RegionData) {
+		return false
+	}
 	if want.GroupID != nil && (got.GroupID == nil || *want.GroupID != *got.GroupID) {
 		return false
 	}
@@ -924,6 +939,9 @@ func fieldsStillDifferent(want, got monComparable) []string {
 	}
 	if want.RegionalData != nil && (got.RegionalData == nil || *want.RegionalData != *got.RegionalData) {
 		f = append(f, "regional_data")
+	}
+	if want.RegionData != nil && !equalRegionData(want.RegionData, got.RegionData) {
+		f = append(f, "region_data")
 	}
 	if want.GroupID != nil && (got.GroupID == nil || *want.GroupID != *got.GroupID) {
 		f = append(f, "group_id")

--- a/internal/provider/monitor_compare.go
+++ b/internal/provider/monitor_compare.go
@@ -175,6 +175,10 @@ func wantFromCreateReq(req *client.CreateMonitorRequest) monComparable {
 		c.RegionData = &regionDataComparable{
 			Regions: normalizeRegions(req.RegionData.Regions),
 		}
+		if req.RegionData.ManualSelected != nil {
+			autoSelect := !*req.RegionData.ManualSelected
+			c.RegionData.AutoSelect = &autoSelect
+		}
 		if req.RegionData.Thresholds != nil {
 			c.RegionData.Thresholds = normalizeRegionThresholds(*req.RegionData.Thresholds)
 		}
@@ -337,6 +341,10 @@ func wantFromUpdateReq(req *client.UpdateMonitorRequest) monComparable {
 	if req.RegionData != nil {
 		c.RegionData = &regionDataComparable{
 			Regions: normalizeRegions(req.RegionData.Regions),
+		}
+		if req.RegionData.ManualSelected != nil {
+			autoSelect := !*req.RegionData.ManualSelected
+			c.RegionData.AutoSelect = &autoSelect
 		}
 		if req.RegionData.Thresholds != nil {
 			c.RegionData.Thresholds = normalizeRegionThresholds(*req.RegionData.Thresholds)

--- a/internal/provider/monitor_crud_create.go
+++ b/internal/provider/monitor_crud_create.go
@@ -45,7 +45,7 @@ func (r *monitorResource) Create(ctx context.Context, req resource.CreateRequest
 	plan.ID = types.StringValue(strconv.FormatInt(created.ID, 10))
 	want := wantFromCreateReq(createReq)
 	settleTimeout := 60 * time.Second
-	if strings.ToUpper(plan.Type.ValueString()) == MonitorTypeKEYWORD || want.DNSRecords != nil || want.APIAssertions != nil || want.AssignedAlertContacts != nil {
+	if strings.ToUpper(plan.Type.ValueString()) == MonitorTypeKEYWORD || want.DNSRecords != nil || want.APIAssertions != nil || want.AssignedAlertContacts != nil || want.RegionData != nil || want.RegionalData != nil {
 		settleTimeout = 180 * time.Second
 	}
 	api, err := r.waitMonitorSettled(ctx, created.ID, want, settleTimeout)
@@ -234,7 +234,12 @@ func (r *monitorResource) buildCreateRequest(
 	if !plan.ResponseTimeThreshold.IsNull() && !plan.ResponseTimeThreshold.IsUnknown() {
 		req.ResponseTimeThreshold = int(plan.ResponseTimeThreshold.ValueInt64())
 	}
-	if !plan.RegionalData.IsNull() && !plan.RegionalData.IsUnknown() {
+	if regionData, ok, d := expandRegionDataToAPI(ctx, plan.RegionData); d.HasError() {
+		resp.Diagnostics.Append(d...)
+		return nil, ""
+	} else if ok {
+		req.RegionData = regionData
+	} else if !plan.RegionalData.IsNull() && !plan.RegionalData.IsUnknown() {
 		req.RegionalData = plan.RegionalData.ValueString()
 	}
 	if !plan.GroupID.IsNull() && !plan.GroupID.IsUnknown() {
@@ -653,6 +658,24 @@ func (r *monitorResource) buildStateAfterCreate(
 		resp.Diagnostics.Append(d...)
 		if !resp.Diagnostics.HasError() {
 			plan.Config = cfgState
+		}
+	}
+
+	// Region data
+	if !plan.RegionData.IsNull() && !plan.RegionData.IsUnknown() {
+		includeThresholds := regionDataThresholdsManaged(ctx, plan.RegionData)
+		regionState, d := flattenRegionDataToState(api.RegionalData, includeThresholds)
+		resp.Diagnostics.Append(d...)
+		if !resp.Diagnostics.HasError() && !regionState.IsNull() && !regionState.IsUnknown() {
+			plan.RegionData = regionState
+		}
+		plan.RegionalData = types.StringNull()
+	} else {
+		plan.RegionData = types.ObjectNull(regionDataObjectType().AttrTypes)
+	}
+	if !plan.RegionalData.IsNull() && !plan.RegionalData.IsUnknown() {
+		if region, ok := coerceRegion(api.RegionalData); ok {
+			plan.RegionalData = types.StringValue(region)
 		}
 	}
 

--- a/internal/provider/monitor_crud_create.go
+++ b/internal/provider/monitor_crud_create.go
@@ -664,7 +664,8 @@ func (r *monitorResource) buildStateAfterCreate(
 	// Region data
 	if !plan.RegionData.IsNull() && !plan.RegionData.IsUnknown() {
 		includeThresholds := regionDataThresholdsManaged(ctx, plan.RegionData)
-		regionState, d := flattenRegionDataToState(api.RegionalData, includeThresholds)
+		autoSelect := regionDataAutoSelectValue(ctx, plan.RegionData)
+		regionState, d := flattenRegionDataToStateWithAutoSelect(api.RegionalData, includeThresholds, autoSelect)
 		resp.Diagnostics.Append(d...)
 		if !resp.Diagnostics.HasError() && !regionState.IsNull() && !regionState.IsUnknown() {
 			plan.RegionData = regionState

--- a/internal/provider/monitor_crud_read.go
+++ b/internal/provider/monitor_crud_read.go
@@ -241,11 +241,13 @@ func readApplyRegionalData(ctx context.Context, resp *resource.ReadResponse, sta
 	if isImport {
 		if apiRegionData, ok := normalizeRegionDataFromAPI(m.RegionalData); ok {
 			includeThresholds := len(apiRegionData.Thresholds) > 0
+			includeAutoSelect := apiRegionData.AutoSelect != nil && *apiRegionData.AutoSelect
 			useRegionData := len(apiRegionData.Regions) > 1 ||
 				includeThresholds ||
+				includeAutoSelect ||
 				(len(apiRegionData.Regions) == 1 && !isDefaultRegion(apiRegionData.Regions[0]))
 			if useRegionData {
-				regionState, d := regionDataObjectValue(apiRegionData, includeThresholds)
+				regionState, d := regionDataObjectValue(apiRegionData, includeThresholds, includeAutoSelect)
 				resp.Diagnostics.Append(d...)
 				if !resp.Diagnostics.HasError() {
 					state.RegionData = regionState
@@ -260,7 +262,8 @@ func readApplyRegionalData(ctx context.Context, resp *resource.ReadResponse, sta
 	}
 	if !state.RegionData.IsNull() && !state.RegionData.IsUnknown() {
 		includeThresholds := regionDataThresholdsManaged(ctx, state.RegionData)
-		regionState, d := flattenRegionDataToState(m.RegionalData, includeThresholds)
+		autoSelect := regionDataAutoSelectValue(ctx, state.RegionData)
+		regionState, d := flattenRegionDataToStateWithAutoSelect(m.RegionalData, includeThresholds, autoSelect)
 		resp.Diagnostics.Append(d...)
 		if !resp.Diagnostics.HasError() && !regionState.IsNull() && !regionState.IsUnknown() {
 			state.RegionData = regionState

--- a/internal/provider/monitor_crud_read.go
+++ b/internal/provider/monitor_crud_read.go
@@ -56,7 +56,7 @@ func (r *monitorResource) Read(ctx context.Context, req resource.ReadRequest, re
 	readApplyKeywordAndPort(&state, monitor, isImport)
 	readApplyIdentity(&state, monitor)
 	readApplyPausedState(&state, monitor, isImport)
-	readApplyRegionalData(&state, monitor, isImport)
+	readApplyRegionalData(ctx, resp, &state, monitor, isImport)
 	readApplyTagsHeadersAC(ctx, resp, &state, monitor, isImport)
 	readApplySuccessCodes(ctx, resp, &state, monitor)
 	readApplyBooleans(&state, monitor, isImport)
@@ -237,18 +237,40 @@ func readApplyPausedState(state *monitorResourceModel, m *client.Monitor, isImpo
 	state.IsPaused = types.BoolValue(isMonitorPausedStatus(m.Status))
 }
 
-func readApplyRegionalData(state *monitorResourceModel, m *client.Monitor, isImport bool) {
+func readApplyRegionalData(ctx context.Context, resp *resource.ReadResponse, state *monitorResourceModel, m *client.Monitor, isImport bool) {
 	if isImport {
-		if m.RegionalData != nil {
-			if region, ok := coerceRegion(m.RegionalData); ok && !isDefaultRegion(region) {
-				state.RegionalData = types.StringValue(region)
+		if apiRegionData, ok := normalizeRegionDataFromAPI(m.RegionalData); ok {
+			if len(apiRegionData.Regions) > 1 || len(apiRegionData.Thresholds) > 0 {
+				regionState, d := regionDataObjectValue(apiRegionData, len(apiRegionData.Thresholds) > 0)
+				resp.Diagnostics.Append(d...)
+				if !resp.Diagnostics.HasError() {
+					state.RegionData = regionState
+					state.RegionalData = types.StringNull()
+				}
 				return
 			}
-		} else {
-			state.RegionalData = types.StringNull()
+			if len(apiRegionData.Regions) == 1 && !isDefaultRegion(apiRegionData.Regions[0]) {
+				state.RegionalData = types.StringValue(apiRegionData.Regions[0])
+				state.RegionData = types.ObjectNull(regionDataObjectType().AttrTypes)
+				return
+			}
 		}
+		state.RegionalData = types.StringNull()
+		state.RegionData = types.ObjectNull(regionDataObjectType().AttrTypes)
 		return
 	}
+	if !state.RegionData.IsNull() && !state.RegionData.IsUnknown() {
+		includeThresholds := regionDataThresholdsManaged(ctx, state.RegionData)
+		regionState, d := flattenRegionDataToState(m.RegionalData, includeThresholds)
+		resp.Diagnostics.Append(d...)
+		if !resp.Diagnostics.HasError() && !regionState.IsNull() && !regionState.IsUnknown() {
+			state.RegionData = regionState
+		}
+		state.RegionalData = types.StringNull()
+		return
+	}
+	state.RegionData = types.ObjectNull(regionDataObjectType().AttrTypes)
+
 	if state.RegionalData.IsNull() || state.RegionalData.IsUnknown() {
 		// user did not manage this field and it should be kept as null
 		return
@@ -403,6 +425,15 @@ func monitorReadStabilizationWant(ctx context.Context, state monitorResourceMode
 		}
 	}
 
+	if !state.RegionData.IsNull() && !state.RegionData.IsUnknown() {
+		if regionData, ok, diags := regionDataFromTF(ctx, state.RegionData); ok && !diags.HasError() {
+			want.RegionData = regionData
+		}
+	} else if !state.RegionalData.IsNull() && !state.RegionalData.IsUnknown() {
+		region := strings.ToLower(strings.TrimSpace(state.RegionalData.ValueString()))
+		want.RegionalData = &region
+	}
+
 	return want
 }
 
@@ -414,6 +445,8 @@ func hasMonitorReadStabilizationAssertions(want monComparable) bool {
 		want.DomainExpirationReminder != nil ||
 		want.CheckSSLErrors != nil ||
 		want.AssignedAlertContacts != nil ||
+		want.RegionData != nil ||
+		want.RegionalData != nil ||
 		want.DNSRecords != nil ||
 		want.SSLExpirationPeriodDays != nil ||
 		want.APIAssertions != nil {

--- a/internal/provider/monitor_crud_read.go
+++ b/internal/provider/monitor_crud_read.go
@@ -240,18 +240,17 @@ func readApplyPausedState(state *monitorResourceModel, m *client.Monitor, isImpo
 func readApplyRegionalData(ctx context.Context, resp *resource.ReadResponse, state *monitorResourceModel, m *client.Monitor, isImport bool) {
 	if isImport {
 		if apiRegionData, ok := normalizeRegionDataFromAPI(m.RegionalData); ok {
-			if len(apiRegionData.Regions) > 1 || len(apiRegionData.Thresholds) > 0 {
-				regionState, d := regionDataObjectValue(apiRegionData, len(apiRegionData.Thresholds) > 0)
+			includeThresholds := len(apiRegionData.Thresholds) > 0
+			useRegionData := len(apiRegionData.Regions) > 1 ||
+				includeThresholds ||
+				(len(apiRegionData.Regions) == 1 && !isDefaultRegion(apiRegionData.Regions[0]))
+			if useRegionData {
+				regionState, d := regionDataObjectValue(apiRegionData, includeThresholds)
 				resp.Diagnostics.Append(d...)
 				if !resp.Diagnostics.HasError() {
 					state.RegionData = regionState
 					state.RegionalData = types.StringNull()
 				}
-				return
-			}
-			if len(apiRegionData.Regions) == 1 && !isDefaultRegion(apiRegionData.Regions[0]) {
-				state.RegionalData = types.StringValue(apiRegionData.Regions[0])
-				state.RegionData = types.ObjectNull(regionDataObjectType().AttrTypes)
 				return
 			}
 		}

--- a/internal/provider/monitor_crud_update.go
+++ b/internal/provider/monitor_crud_update.go
@@ -685,7 +685,8 @@ func applyUpdatedMonitorToState(
 	// region_data set only if managed
 	if !plan.RegionData.IsNull() && !plan.RegionData.IsUnknown() {
 		includeThresholds := regionDataThresholdsManaged(ctx, plan.RegionData)
-		regionState, d := flattenRegionDataToState(m.RegionalData, includeThresholds)
+		autoSelect := regionDataAutoSelectValue(ctx, plan.RegionData)
+		regionState, d := flattenRegionDataToStateWithAutoSelect(m.RegionalData, includeThresholds, autoSelect)
 		resp.Diagnostics.Append(d...)
 		if !resp.Diagnostics.HasError() && !regionState.IsNull() && !regionState.IsUnknown() {
 			out.RegionData = regionState

--- a/internal/provider/monitor_crud_update.go
+++ b/internal/provider/monitor_crud_update.go
@@ -52,6 +52,19 @@ func (r *monitorResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 	configSent := updateReq.Config != nil
 
+	clearRegionThresholds, d := shouldClearRegionDataThresholds(ctx, plan, state)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if clearRegionThresholds {
+		clearReq := cloneUpdateRequestForRegionThresholdClear(updateReq)
+		if _, err := r.updateMonitorWithRetry(ctx, id, clearReq); err != nil {
+			resp.Diagnostics.AddError("Error clearing regional thresholds", "Could not clear monitor regional thresholds before update: "+err.Error())
+			return
+		}
+	}
+
 	initialUpdated, err := r.updateMonitorWithRetry(ctx, id, updateReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating monitor", "Could not update monitor: "+err.Error())
@@ -69,7 +82,9 @@ func (r *monitorResource) Update(ctx context.Context, req resource.UpdateRequest
 		settleWant.DNSRecords != nil ||
 		settleWant.APIAssertions != nil ||
 		settleWant.AssignedAlertContacts != nil ||
-		settleWant.MaintenanceWindowIDs != nil {
+		settleWant.MaintenanceWindowIDs != nil ||
+		settleWant.RegionData != nil ||
+		settleWant.RegionalData != nil {
 		settleTimeout = 240 * time.Second
 	}
 
@@ -341,7 +356,12 @@ func buildUpdateRequest(
 		v := int(plan.ResponseTimeThreshold.ValueInt64())
 		req.ResponseTimeThreshold = &v
 	}
-	if !plan.RegionalData.IsNull() && !plan.RegionalData.IsUnknown() {
+	if regionData, ok, d := expandRegionDataToAPI(ctx, plan.RegionData); d.HasError() {
+		resp.Diagnostics.Append(d...)
+		return nil, ""
+	} else if ok {
+		req.RegionData = regionData
+	} else if !plan.RegionalData.IsNull() && !plan.RegionalData.IsUnknown() {
 		v := plan.RegionalData.ValueString()
 		req.RegionalData = &v
 	}
@@ -662,8 +682,23 @@ func applyUpdatedMonitorToState(
 		out.ResponseTimeThreshold = types.Int64Null()
 	}
 
+	// region_data set only if managed
+	if !plan.RegionData.IsNull() && !plan.RegionData.IsUnknown() {
+		includeThresholds := regionDataThresholdsManaged(ctx, plan.RegionData)
+		regionState, d := flattenRegionDataToState(m.RegionalData, includeThresholds)
+		resp.Diagnostics.Append(d...)
+		if !resp.Diagnostics.HasError() && !regionState.IsNull() && !regionState.IsUnknown() {
+			out.RegionData = regionState
+		} else {
+			out.RegionData = plan.RegionData
+		}
+		out.RegionalData = types.StringNull()
+	} else {
+		out.RegionData = types.ObjectNull(regionDataObjectType().AttrTypes)
+	}
+
 	// regional_data set only if managed
-	if !plan.RegionalData.IsNull() && !plan.RegionalData.IsUnknown() {
+	if out.RegionData.IsNull() && !plan.RegionalData.IsNull() && !plan.RegionalData.IsUnknown() {
 		if m.RegionalData != nil {
 			if region, ok := coerceRegion(m.RegionalData); ok {
 				out.RegionalData = types.StringValue(region)

--- a/internal/provider/monitor_model.go
+++ b/internal/provider/monitor_model.go
@@ -86,8 +86,9 @@ type udpTF struct {
 }
 
 type regionDataTF struct {
-	Regions    types.Set `tfsdk:"regions"`
-	Thresholds types.Map `tfsdk:"thresholds"`
+	Regions    types.Set  `tfsdk:"regions"`
+	AutoSelect types.Bool `tfsdk:"auto_select"`
+	Thresholds types.Map  `tfsdk:"thresholds"`
 }
 
 type apiAssertionCheckTF struct {
@@ -158,8 +159,9 @@ func udpObjectType() types.ObjectType {
 func regionDataObjectType() types.ObjectType {
 	return types.ObjectType{
 		AttrTypes: map[string]attr.Type{
-			"regions":    types.SetType{ElemType: types.StringType},
-			"thresholds": types.MapType{ElemType: types.Int64Type},
+			"regions":     types.SetType{ElemType: types.StringType},
+			"auto_select": types.BoolType,
+			"thresholds":  types.MapType{ElemType: types.Int64Type},
 		},
 	}
 }

--- a/internal/provider/monitor_model.go
+++ b/internal/provider/monitor_model.go
@@ -39,6 +39,7 @@ type monitorResourceModel struct {
 	AssignedAlertContacts    types.Set            `tfsdk:"assigned_alert_contacts"`
 	ResponseTimeThreshold    types.Int64          `tfsdk:"response_time_threshold"`
 	RegionalData             types.String         `tfsdk:"regional_data"`
+	RegionData               types.Object         `tfsdk:"region_data"`
 	CheckSSLErrors           types.Bool           `tfsdk:"check_ssl_errors"`
 	Config                   types.Object         `tfsdk:"config"`
 }
@@ -82,6 +83,11 @@ type apiAssertionsTF struct {
 type udpTF struct {
 	Payload             types.String `tfsdk:"payload"`
 	PacketLossThreshold types.Int64  `tfsdk:"packet_loss_threshold"`
+}
+
+type regionDataTF struct {
+	Regions    types.Set `tfsdk:"regions"`
+	Thresholds types.Map `tfsdk:"thresholds"`
 }
 
 type apiAssertionCheckTF struct {
@@ -145,6 +151,15 @@ func udpObjectType() types.ObjectType {
 		AttrTypes: map[string]attr.Type{
 			"payload":               types.StringType,
 			"packet_loss_threshold": types.Int64Type,
+		},
+	}
+}
+
+func regionDataObjectType() types.ObjectType {
+	return types.ObjectType{
+		AttrTypes: map[string]attr.Type{
+			"regions":    types.SetType{ElemType: types.StringType},
+			"thresholds": types.MapType{ElemType: types.Int64Type},
 		},
 	}
 }

--- a/internal/provider/monitor_read_test.go
+++ b/internal/provider/monitor_read_test.go
@@ -251,4 +251,13 @@ func TestReadApplyRegionalData_ImportAutoSelectUsesRegionData(t *testing.T) {
 	if got.AutoSelect.IsNull() || !got.AutoSelect.ValueBool() {
 		t.Fatalf("expected imported auto_select=true, got %#v", got.AutoSelect)
 	}
+
+	var regions []string
+	diags = got.Regions.ElementsAs(ctx, &regions, false)
+	if diags.HasError() {
+		t.Fatalf("unexpected region diagnostics: %v", diags)
+	}
+	if len(regions) != 1 || regions[0] != "na" {
+		t.Fatalf("expected imported regions to contain na, got %#v", regions)
+	}
 }

--- a/internal/provider/monitor_read_test.go
+++ b/internal/provider/monitor_read_test.go
@@ -196,3 +196,59 @@ func TestReadApplyRegionalData_ImportSingleRegionUsesCanonicalRegionData(t *test
 		t.Fatalf("expected imported region_data.thresholds to remain null, got %#v", got.Thresholds)
 	}
 }
+
+func TestReadApplyRegionalData_ImportDefaultManualRegionStaysUnmanaged(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	state := monitorResourceModel{}
+	resp := &resource.ReadResponse{}
+
+	readApplyRegionalData(ctx, resp, &state, &client.Monitor{
+		RegionalData: map[string]interface{}{
+			"REGION":          []interface{}{"na"},
+			"MANUAL_SELECTED": true,
+		},
+	}, true)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+	if !state.RegionalData.IsNull() {
+		t.Fatalf("expected deprecated regional_data to stay null, got %#v", state.RegionalData)
+	}
+	if !state.RegionData.IsNull() {
+		t.Fatalf("expected default manual region_data to stay null on import, got %#v", state.RegionData)
+	}
+}
+
+func TestReadApplyRegionalData_ImportAutoSelectUsesRegionData(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	state := monitorResourceModel{}
+	resp := &resource.ReadResponse{}
+
+	readApplyRegionalData(ctx, resp, &state, &client.Monitor{
+		RegionalData: map[string]interface{}{
+			"REGION":          []interface{}{"na"},
+			"MANUAL_SELECTED": false,
+		},
+	}, true)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+	if state.RegionData.IsNull() {
+		t.Fatal("expected auto-select import to populate region_data")
+	}
+
+	var got regionDataTF
+	diags := state.RegionData.As(ctx, &got, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true})
+	if diags.HasError() {
+		t.Fatalf("unexpected region_data diagnostics: %v", diags)
+	}
+	if got.AutoSelect.IsNull() || !got.AutoSelect.ValueBool() {
+		t.Fatalf("expected imported auto_select=true, got %#v", got.AutoSelect)
+	}
+}

--- a/internal/provider/monitor_read_test.go
+++ b/internal/provider/monitor_read_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/uptimerobot/terraform-provider-uptimerobot/internal/client"
 )
 
@@ -153,5 +154,45 @@ func TestReadApplyTagsHeadersAC_ImportKeepsEmptyAlertContactsNull(t *testing.T) 
 	}
 	if !state.AssignedAlertContacts.IsNull() {
 		t.Fatalf("expected import read with no alert contacts to keep assigned_alert_contacts null, got %#v", state.AssignedAlertContacts)
+	}
+}
+
+func TestReadApplyRegionalData_ImportSingleRegionUsesCanonicalRegionData(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	state := monitorResourceModel{}
+	resp := &resource.ReadResponse{}
+
+	readApplyRegionalData(ctx, resp, &state, &client.Monitor{
+		RegionalData: "eu",
+	}, true)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+	if !state.RegionalData.IsNull() {
+		t.Fatalf("expected deprecated regional_data to stay null, got %#v", state.RegionalData)
+	}
+	if state.RegionData.IsNull() {
+		t.Fatal("expected import read to populate canonical region_data")
+	}
+
+	var got regionDataTF
+	diags := state.RegionData.As(ctx, &got, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true})
+	if diags.HasError() {
+		t.Fatalf("unexpected region_data diagnostics: %v", diags)
+	}
+
+	var regions []string
+	diags = got.Regions.ElementsAs(ctx, &regions, false)
+	if diags.HasError() {
+		t.Fatalf("unexpected region diagnostics: %v", diags)
+	}
+	if len(regions) != 1 || regions[0] != "eu" {
+		t.Fatalf("expected imported region_data.regions to contain eu, got %#v", regions)
+	}
+	if !got.Thresholds.IsNull() {
+		t.Fatalf("expected imported region_data.thresholds to remain null, got %#v", got.Thresholds)
 	}
 }

--- a/internal/provider/monitor_region_data.go
+++ b/internal/provider/monitor_region_data.go
@@ -1,0 +1,503 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/uptimerobot/terraform-provider-uptimerobot/internal/client"
+)
+
+var canonicalRegionOrder = []string{"na", "eu", "as", "oc"}
+
+type regionDataComparable struct {
+	Regions    []string
+	Thresholds map[string]int
+}
+
+func normalizeRegionCode(raw string) (string, bool) {
+	s := strings.ToLower(strings.TrimSpace(raw))
+	_, ok := allowedRegion[s]
+	return s, ok
+}
+
+func normalizeRegions(in []string) []string {
+	seen := map[string]struct{}{}
+	for _, raw := range in {
+		if s, ok := normalizeRegionCode(raw); ok {
+			seen[s] = struct{}{}
+		}
+	}
+
+	out := make([]string, 0, len(seen))
+	for _, region := range canonicalRegionOrder {
+		if _, ok := seen[region]; ok {
+			out = append(out, region)
+		}
+	}
+	return out
+}
+
+func normalizeRegionThresholds(in map[string]int) map[string]int {
+	if len(in) == 0 {
+		return map[string]int{}
+	}
+
+	out := make(map[string]int, len(in))
+	for raw, v := range in {
+		if region, ok := normalizeRegionCode(raw); ok {
+			out[region] = v
+		}
+	}
+	return out
+}
+
+func expandRegionDataToAPI(ctx context.Context, value types.Object) (*client.RegionDataRequest, bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if value.IsNull() || value.IsUnknown() {
+		return nil, false, diags
+	}
+
+	var data regionDataTF
+	diags.Append(value.As(ctx, &data, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true})...)
+	if diags.HasError() {
+		return nil, false, diags
+	}
+
+	var regions []string
+	diags.Append(data.Regions.ElementsAs(ctx, &regions, false)...)
+	if diags.HasError() {
+		return nil, false, diags
+	}
+	regions = normalizeRegions(regions)
+	if len(regions) == 0 {
+		diags.AddAttributeError(
+			path.Root("region_data").AtName("regions"),
+			"Missing regions",
+			"region_data.regions must contain at least one valid region: na, eu, as, oc.",
+		)
+		return nil, false, diags
+	}
+
+	out := &client.RegionDataRequest{Regions: regions}
+	if !data.Thresholds.IsNull() && !data.Thresholds.IsUnknown() {
+		var thresholds map[string]int64
+		diags.Append(data.Thresholds.ElementsAs(ctx, &thresholds, false)...)
+		if diags.HasError() {
+			return nil, false, diags
+		}
+
+		out.Thresholds = map[string]int{}
+		for raw, v := range thresholds {
+			region, ok := normalizeRegionCode(raw)
+			if !ok {
+				diags.AddAttributeError(
+					path.Root("region_data").AtName("thresholds"),
+					"Invalid threshold region",
+					fmt.Sprintf("Threshold key %q must be one of: na, eu, as, oc.", raw),
+				)
+				continue
+			}
+			out.Thresholds[region] = int(v)
+		}
+	}
+
+	return out, true, diags
+}
+
+func validateRegionData(ctx context.Context, data *monitorResourceModel, resp *resource.ValidateConfigResponse) {
+	if data.RegionData.IsNull() || data.RegionData.IsUnknown() {
+		return
+	}
+
+	var regionData regionDataTF
+	resp.Diagnostics.Append(data.RegionData.As(ctx, &regionData, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if regionData.Regions.IsUnknown() {
+		return
+	}
+
+	var regions []string
+	resp.Diagnostics.Append(regionData.Regions.ElementsAs(ctx, &regions, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	selected := map[string]struct{}{}
+	for _, raw := range regions {
+		region, ok := normalizeRegionCode(raw)
+		if !ok {
+			continue
+		}
+		selected[region] = struct{}{}
+	}
+
+	if regionData.Thresholds.IsNull() || regionData.Thresholds.IsUnknown() {
+		return
+	}
+
+	var thresholds map[string]int64
+	resp.Diagnostics.Append(regionData.Thresholds.ElementsAs(ctx, &thresholds, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	for raw, v := range thresholds {
+		region, ok := normalizeRegionCode(raw)
+		if !ok {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("region_data").AtName("thresholds"),
+				"Invalid threshold region",
+				fmt.Sprintf("Threshold key %q must be one of: na, eu, as, oc.", raw),
+			)
+			continue
+		}
+		if _, ok := selected[region]; !ok {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("region_data").AtName("thresholds"),
+				"Threshold region is not selected",
+				fmt.Sprintf("Threshold key %q must also be present in region_data.regions.", region),
+			)
+		}
+		if v < 0 || v > 60000 {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("region_data").AtName("thresholds"),
+				"Invalid response-time threshold",
+				fmt.Sprintf("Threshold for %q must be between 0 and 60000 milliseconds.", region),
+			)
+		}
+	}
+
+	if !regionData.Thresholds.IsNull() && !regionData.Thresholds.IsUnknown() &&
+		!data.ResponseTimeThreshold.IsNull() && !data.ResponseTimeThreshold.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("response_time_threshold"),
+			"Conflicting response-time threshold settings",
+			"Use either response_time_threshold with region_data.regions for one threshold across all selected regions, or region_data.thresholds for per-region thresholds.",
+		)
+	}
+}
+
+func regionDataFromTF(ctx context.Context, value types.Object) (*regionDataComparable, bool, diag.Diagnostics) {
+	req, ok, diags := expandRegionDataToAPI(ctx, value)
+	if !ok || req == nil || diags.HasError() {
+		return nil, ok, diags
+	}
+
+	out := &regionDataComparable{
+		Regions: normalizeRegions(req.Regions),
+	}
+	if req.Thresholds != nil {
+		out.Thresholds = normalizeRegionThresholds(req.Thresholds)
+	}
+	return out, true, diags
+}
+
+func regionDataThresholdsManaged(ctx context.Context, value types.Object) bool {
+	if value.IsNull() || value.IsUnknown() {
+		return false
+	}
+	var data regionDataTF
+	diags := value.As(ctx, &data, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true})
+	return !diags.HasError() && !data.Thresholds.IsNull() && !data.Thresholds.IsUnknown()
+}
+
+func shouldClearRegionDataThresholds(ctx context.Context, plan, state monitorResourceModel) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if plan.RegionData.IsNull() || plan.RegionData.IsUnknown() {
+		return false, diags
+	}
+
+	var planData regionDataTF
+	diags.Append(plan.RegionData.As(ctx, &planData, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true})...)
+	if diags.HasError() || planData.Thresholds.IsNull() || planData.Thresholds.IsUnknown() {
+		return false, diags
+	}
+
+	planComparable, _, d := regionDataFromTF(ctx, plan.RegionData)
+	diags.Append(d...)
+	if diags.HasError() || planComparable == nil {
+		return false, diags
+	}
+
+	stateComparable, ok, d := regionDataFromTF(ctx, state.RegionData)
+	diags.Append(d...)
+	if diags.HasError() || !ok || stateComparable == nil || stateComparable.Thresholds == nil {
+		return false, diags
+	}
+
+	if len(planComparable.Thresholds) == 0 {
+		return len(stateComparable.Thresholds) > 0, diags
+	}
+
+	for region := range stateComparable.Thresholds {
+		if _, ok := planComparable.Thresholds[region]; !ok {
+			return true, diags
+		}
+	}
+
+	return false, diags
+}
+
+func cloneUpdateRequestForRegionThresholdClear(req *client.UpdateMonitorRequest) *client.UpdateMonitorRequest {
+	if req == nil {
+		return nil
+	}
+
+	out := *req
+	zero := 0
+	out.ResponseTimeThreshold = &zero
+	if req.RegionData != nil {
+		regionData := *req.RegionData
+		regionData.Regions = append([]string(nil), req.RegionData.Regions...)
+		regionData.Thresholds = nil
+		out.RegionData = &regionData
+	}
+	return &out
+}
+
+func normalizeRegionDataFromAPI(value interface{}) (*regionDataComparable, bool) {
+	switch v := value.(type) {
+	case nil:
+		return nil, false
+	case string:
+		if region, ok := normalizeRegionCode(v); ok {
+			return &regionDataComparable{Regions: []string{region}}, true
+		}
+	case map[string]interface{}:
+		return normalizeRegionDataFromMap(v)
+	case []interface{}:
+		return normalizeRegionDataFromEntries(v)
+	}
+	return nil, false
+}
+
+func normalizeRegionDataFromMap(v map[string]interface{}) (*regionDataComparable, bool) {
+	out := &regionDataComparable{}
+	if raw, ok := lookupMapAny(v, "REGION"); ok {
+		out.Regions = normalizeRegions(regionsFromRaw(raw))
+	}
+	if raw, ok := lookupMapAny(v, "THRESHOLD"); ok {
+		if thresholds, ok := thresholdsFromRaw(raw); ok {
+			out.Thresholds = normalizeRegionThresholds(thresholds)
+		}
+	}
+	if len(out.Regions) == 0 {
+		return nil, false
+	}
+	return out, true
+}
+
+func normalizeRegionDataFromEntries(entries []interface{}) (*regionDataComparable, bool) {
+	var regions []string
+	thresholds := map[string]int{}
+	thresholdsSeen := false
+
+	for _, entry := range entries {
+		m, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		rawType, _ := lookupMapAny(m, "type")
+		typ, _ := rawType.(string)
+		switch strings.ToUpper(strings.TrimSpace(typ)) {
+		case "REGION":
+			if raw, ok := lookupMapAny(m, "value"); ok {
+				regions = append(regions, regionsFromRaw(raw)...)
+			}
+		case "THRESHOLD":
+			rawRegion, _ := lookupMapAny(m, "region")
+			region, _ := rawRegion.(string)
+			if code, ok := normalizeRegionCode(region); ok {
+				if rawValue, ok := lookupMapAny(m, "value"); ok {
+					if threshold, ok := intFromRaw(rawValue); ok {
+						thresholds[code] = threshold
+						thresholdsSeen = true
+					}
+				}
+			}
+		}
+	}
+
+	out := &regionDataComparable{Regions: normalizeRegions(regions)}
+	if thresholdsSeen {
+		out.Thresholds = normalizeRegionThresholds(thresholds)
+	}
+	if len(out.Regions) == 0 {
+		return nil, false
+	}
+	return out, true
+}
+
+func lookupMapAny(m map[string]interface{}, key string) (interface{}, bool) {
+	if v, ok := m[key]; ok {
+		return v, true
+	}
+	for k, v := range m {
+		if strings.EqualFold(k, key) {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func regionsFromRaw(raw interface{}) []string {
+	switch v := raw.(type) {
+	case []interface{}:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	case []string:
+		return append([]string(nil), v...)
+	case string:
+		return []string{v}
+	}
+	return nil
+}
+
+func thresholdsFromRaw(raw interface{}) (map[string]int, bool) {
+	switch v := raw.(type) {
+	case map[string]interface{}:
+		out := make(map[string]int, len(v))
+		for key, rawValue := range v {
+			if threshold, ok := intFromRaw(rawValue); ok {
+				out[key] = threshold
+			}
+		}
+		return out, true
+	case map[string]int:
+		return v, true
+	case map[string]int64:
+		out := make(map[string]int, len(v))
+		for key, threshold := range v {
+			out[key] = int(threshold)
+		}
+		return out, true
+	case map[string]float64:
+		out := make(map[string]int, len(v))
+		for key, threshold := range v {
+			out[key] = int(threshold)
+		}
+		return out, true
+	}
+	return nil, false
+}
+
+func intFromRaw(raw interface{}) (int, bool) {
+	switch v := raw.(type) {
+	case int:
+		return v, true
+	case int64:
+		return int(v), true
+	case float64:
+		if v == float64(int(v)) {
+			return int(v), true
+		}
+	case float32:
+		if v == float32(int(v)) {
+			return int(v), true
+		}
+	}
+	return 0, false
+}
+
+func flattenRegionDataToState(apiValue interface{}, includeThresholds bool) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	apiData, ok := normalizeRegionDataFromAPI(apiValue)
+	if !ok {
+		return types.ObjectNull(regionDataObjectType().AttrTypes), diags
+	}
+	return regionDataObjectValue(apiData, includeThresholds)
+}
+
+func regionDataObjectValue(data *regionDataComparable, includeThresholds bool) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if data == nil || len(data.Regions) == 0 {
+		return types.ObjectNull(regionDataObjectType().AttrTypes), diags
+	}
+
+	regionValues := make([]attr.Value, 0, len(data.Regions))
+	for _, region := range normalizeRegions(data.Regions) {
+		regionValues = append(regionValues, types.StringValue(region))
+	}
+	regions, d := types.SetValue(types.StringType, regionValues)
+	diags.Append(d...)
+	if diags.HasError() {
+		return types.ObjectNull(regionDataObjectType().AttrTypes), diags
+	}
+
+	thresholds := types.MapNull(types.Int64Type)
+	if includeThresholds {
+		values := map[string]attr.Value{}
+		for region, threshold := range normalizeRegionThresholds(data.Thresholds) {
+			values[region] = types.Int64Value(int64(threshold))
+		}
+		thresholdMap, d := types.MapValue(types.Int64Type, values)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(regionDataObjectType().AttrTypes), diags
+		}
+		thresholds = thresholdMap
+	}
+
+	out, d := types.ObjectValue(regionDataObjectType().AttrTypes, map[string]attr.Value{
+		"regions":    regions,
+		"thresholds": thresholds,
+	})
+	diags.Append(d...)
+	return out, diags
+}
+
+func firstRegionFromAPI(value interface{}) (string, bool) {
+	data, ok := normalizeRegionDataFromAPI(value)
+	if !ok || len(data.Regions) == 0 {
+		return "", false
+	}
+	return data.Regions[0], true
+}
+
+func equalRegionData(want, got *regionDataComparable) bool {
+	if want == nil {
+		return true
+	}
+	if got == nil {
+		return false
+	}
+	if !equalStringSet(want.Regions, got.Regions) {
+		return false
+	}
+	if want.Thresholds == nil {
+		return true
+	}
+	if got.Thresholds == nil {
+		return len(want.Thresholds) == 0
+	}
+	return equalIntMap(want.Thresholds, got.Thresholds)
+}
+
+func equalIntMap(a, b map[string]int) bool {
+	a = normalizeRegionThresholds(a)
+	b = normalizeRegionThresholds(b)
+	if len(a) != len(b) {
+		return false
+	}
+	for key, av := range a {
+		if b[key] != av {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/provider/monitor_region_data.go
+++ b/internal/provider/monitor_region_data.go
@@ -178,7 +178,7 @@ func validateRegionData(ctx context.Context, data *monitorResourceModel, resp *r
 		}
 	}
 
-	if !regionData.Thresholds.IsNull() && !regionData.Thresholds.IsUnknown() &&
+	if len(thresholds) > 0 &&
 		!data.ResponseTimeThreshold.IsNull() && !data.ResponseTimeThreshold.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("response_time_threshold"),

--- a/internal/provider/monitor_region_data.go
+++ b/internal/provider/monitor_region_data.go
@@ -220,9 +220,10 @@ func shouldClearRegionDataThresholds(ctx context.Context, plan, state monitorRes
 
 	var planData regionDataTF
 	diags.Append(plan.RegionData.As(ctx, &planData, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true})...)
-	if diags.HasError() || planData.Thresholds.IsUnknown() {
+	if diags.HasError() {
 		return false, diags
 	}
+	planThresholdsManaged := !planData.Thresholds.IsNull() && !planData.Thresholds.IsUnknown()
 
 	planComparable, _, d := regionDataFromTF(ctx, plan.RegionData)
 	diags.Append(d...)
@@ -236,7 +237,7 @@ func shouldClearRegionDataThresholds(ctx context.Context, plan, state monitorRes
 		return false, diags
 	}
 
-	if len(planComparable.Thresholds) == 0 {
+	if !planThresholdsManaged || len(planComparable.Thresholds) == 0 {
 		return len(stateComparable.Thresholds) > 0, diags
 	}
 

--- a/internal/provider/monitor_region_data.go
+++ b/internal/provider/monitor_region_data.go
@@ -220,7 +220,7 @@ func shouldClearRegionDataThresholds(ctx context.Context, plan, state monitorRes
 
 	var planData regionDataTF
 	diags.Append(plan.RegionData.As(ctx, &planData, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true})...)
-	if diags.HasError() || planData.Thresholds.IsNull() || planData.Thresholds.IsUnknown() {
+	if diags.HasError() || planData.Thresholds.IsUnknown() {
 		return false, diags
 	}
 

--- a/internal/provider/monitor_region_data.go
+++ b/internal/provider/monitor_region_data.go
@@ -18,6 +18,7 @@ var canonicalRegionOrder = []string{"na", "eu", "as", "oc"}
 
 type regionDataComparable struct {
 	Regions    []string
+	AutoSelect *bool
 	Thresholds map[string]int
 }
 
@@ -86,6 +87,11 @@ func expandRegionDataToAPI(ctx context.Context, value types.Object) (*client.Reg
 	}
 
 	out := &client.RegionDataRequest{Regions: regions}
+	if !data.AutoSelect.IsNull() && !data.AutoSelect.IsUnknown() {
+		autoSelect := data.AutoSelect.ValueBool()
+		manualSelected := !autoSelect
+		out.ManualSelected = &manualSelected
+	}
 	if !data.Thresholds.IsNull() && !data.Thresholds.IsUnknown() {
 		var thresholds map[string]int64
 		diags.Append(data.Thresholds.ElementsAs(ctx, &thresholds, false)...)
@@ -197,10 +203,27 @@ func regionDataFromTF(ctx context.Context, value types.Object) (*regionDataCompa
 	out := &regionDataComparable{
 		Regions: normalizeRegions(req.Regions),
 	}
+	if req.ManualSelected != nil {
+		autoSelect := !*req.ManualSelected
+		out.AutoSelect = &autoSelect
+	}
 	if req.Thresholds != nil {
 		out.Thresholds = normalizeRegionThresholds(*req.Thresholds)
 	}
 	return out, true, diags
+}
+
+func regionDataAutoSelectValue(ctx context.Context, value types.Object) *bool {
+	if value.IsNull() || value.IsUnknown() {
+		return nil
+	}
+	var data regionDataTF
+	diags := value.As(ctx, &data, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true})
+	if diags.HasError() || data.AutoSelect.IsNull() || data.AutoSelect.IsUnknown() {
+		return nil
+	}
+	autoSelect := data.AutoSelect.ValueBool()
+	return &autoSelect
 }
 
 func regionDataThresholdsManaged(ctx context.Context, value types.Object) bool {
@@ -294,6 +317,12 @@ func normalizeRegionDataFromMap(v map[string]interface{}) (*regionDataComparable
 			out.Thresholds = normalizeRegionThresholds(thresholds)
 		}
 	}
+	if raw, ok := lookupMapAny(v, "MANUAL_SELECTED"); ok {
+		if manualSelected, ok := boolFromRaw(raw); ok {
+			autoSelect := !manualSelected
+			out.AutoSelect = &autoSelect
+		}
+	}
 	if len(out.Regions) == 0 {
 		return nil, false
 	}
@@ -304,6 +333,7 @@ func normalizeRegionDataFromEntries(entries []interface{}) (*regionDataComparabl
 	var regions []string
 	thresholds := map[string]int{}
 	thresholdsSeen := false
+	var autoSelect *bool
 
 	for _, entry := range entries {
 		m, ok := entry.(map[string]interface{})
@@ -316,6 +346,13 @@ func normalizeRegionDataFromEntries(entries []interface{}) (*regionDataComparabl
 		case "REGION":
 			if raw, ok := lookupMapAny(m, "value"); ok {
 				regions = append(regions, regionsFromRaw(raw)...)
+			}
+		case "MANUAL_SELECTED":
+			if raw, ok := lookupMapAny(m, "value"); ok {
+				if manualSelected, ok := boolFromRaw(raw); ok {
+					v := !manualSelected
+					autoSelect = &v
+				}
 			}
 		case "THRESHOLD":
 			rawRegion, _ := lookupMapAny(m, "region")
@@ -332,6 +369,9 @@ func normalizeRegionDataFromEntries(entries []interface{}) (*regionDataComparabl
 	}
 
 	out := &regionDataComparable{Regions: normalizeRegions(regions)}
+	if autoSelect != nil {
+		out.AutoSelect = autoSelect
+	}
 	if thresholdsSeen {
 		out.Thresholds = normalizeRegionThresholds(thresholds)
 	}
@@ -399,6 +439,35 @@ func thresholdsFromRaw(raw interface{}) (map[string]int, bool) {
 	return nil, false
 }
 
+func boolFromRaw(raw interface{}) (bool, bool) {
+	switch v := raw.(type) {
+	case bool:
+		return v, true
+	case string:
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "true", "1":
+			return true, true
+		case "false", "0":
+			return false, true
+		}
+	case float64:
+		if v == 1 {
+			return true, true
+		}
+		if v == 0 {
+			return false, true
+		}
+	case int:
+		if v == 1 {
+			return true, true
+		}
+		if v == 0 {
+			return false, true
+		}
+	}
+	return false, false
+}
+
 func intFromRaw(raw interface{}) (int, bool) {
 	switch v := raw.(type) {
 	case int:
@@ -418,15 +487,23 @@ func intFromRaw(raw interface{}) (int, bool) {
 }
 
 func flattenRegionDataToState(apiValue interface{}, includeThresholds bool) (types.Object, diag.Diagnostics) {
+	return flattenRegionDataToStateWithAutoSelect(apiValue, includeThresholds, nil)
+}
+
+func flattenRegionDataToStateWithAutoSelect(apiValue interface{}, includeThresholds bool, fallbackAutoSelect *bool) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	apiData, ok := normalizeRegionDataFromAPI(apiValue)
 	if !ok {
 		return types.ObjectNull(regionDataObjectType().AttrTypes), diags
 	}
-	return regionDataObjectValue(apiData, includeThresholds)
+	if apiData.AutoSelect == nil && fallbackAutoSelect != nil {
+		autoSelect := *fallbackAutoSelect
+		apiData.AutoSelect = &autoSelect
+	}
+	return regionDataObjectValue(apiData, includeThresholds, fallbackAutoSelect != nil)
 }
 
-func regionDataObjectValue(data *regionDataComparable, includeThresholds bool) (types.Object, diag.Diagnostics) {
+func regionDataObjectValue(data *regionDataComparable, includeThresholds, includeAutoSelect bool) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	if data == nil || len(data.Regions) == 0 {
 		return types.ObjectNull(regionDataObjectType().AttrTypes), diags
@@ -456,9 +533,19 @@ func regionDataObjectValue(data *regionDataComparable, includeThresholds bool) (
 		thresholds = thresholdMap
 	}
 
+	autoSelect := types.BoolNull()
+	if includeAutoSelect {
+		v := false
+		if data.AutoSelect != nil {
+			v = *data.AutoSelect
+		}
+		autoSelect = types.BoolValue(v)
+	}
+
 	out, d := types.ObjectValue(regionDataObjectType().AttrTypes, map[string]attr.Value{
-		"regions":    regions,
-		"thresholds": thresholds,
+		"regions":     regions,
+		"auto_select": autoSelect,
+		"thresholds":  thresholds,
 	})
 	diags.Append(d...)
 	return out, diags
@@ -481,6 +568,15 @@ func equalRegionData(want, got *regionDataComparable) bool {
 	}
 	if !equalStringSet(want.Regions, got.Regions) {
 		return false
+	}
+	if want.AutoSelect != nil {
+		gotAutoSelect := false
+		if got.AutoSelect != nil {
+			gotAutoSelect = *got.AutoSelect
+		}
+		if *want.AutoSelect != gotAutoSelect {
+			return false
+		}
 	}
 	if want.Thresholds == nil {
 		return true

--- a/internal/provider/monitor_region_data.go
+++ b/internal/provider/monitor_region_data.go
@@ -93,7 +93,7 @@ func expandRegionDataToAPI(ctx context.Context, value types.Object) (*client.Reg
 			return nil, false, diags
 		}
 
-		out.Thresholds = map[string]int{}
+		thresholdsOut := map[string]int{}
 		for raw, v := range thresholds {
 			region, ok := normalizeRegionCode(raw)
 			if !ok {
@@ -104,8 +104,9 @@ func expandRegionDataToAPI(ctx context.Context, value types.Object) (*client.Reg
 				)
 				continue
 			}
-			out.Thresholds[region] = int(v)
+			thresholdsOut[region] = int(v)
 		}
+		out.Thresholds = &thresholdsOut
 	}
 
 	return out, true, diags
@@ -197,7 +198,7 @@ func regionDataFromTF(ctx context.Context, value types.Object) (*regionDataCompa
 		Regions: normalizeRegions(req.Regions),
 	}
 	if req.Thresholds != nil {
-		out.Thresholds = normalizeRegionThresholds(req.Thresholds)
+		out.Thresholds = normalizeRegionThresholds(*req.Thresholds)
 	}
 	return out, true, diags
 }
@@ -259,7 +260,8 @@ func cloneUpdateRequestForRegionThresholdClear(req *client.UpdateMonitorRequest)
 	if req.RegionData != nil {
 		regionData := *req.RegionData
 		regionData.Regions = append([]string(nil), req.RegionData.Regions...)
-		regionData.Thresholds = nil
+		thresholds := map[string]int{}
+		regionData.Thresholds = &thresholds
 		out.RegionData = &regionData
 	}
 	return &out

--- a/internal/provider/monitor_region_data_test.go
+++ b/internal/provider/monitor_region_data_test.go
@@ -163,3 +163,38 @@ func TestShouldClearRegionDataThresholds_RemovedKey(t *testing.T) {
 		t.Fatal("expected threshold clear before update when a threshold key is removed")
 	}
 }
+
+func TestShouldClearRegionDataThresholds_OmittedThresholds(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	state := monitorResourceModel{
+		RegionData: types.ObjectValueMust(regionDataObjectType().AttrTypes, map[string]attr.Value{
+			"regions": types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("na"),
+				types.StringValue("eu"),
+			}),
+			"thresholds": types.MapValueMust(types.Int64Type, map[string]attr.Value{
+				"na": types.Int64Value(3000),
+				"eu": types.Int64Value(5000),
+			}),
+		}),
+	}
+	plan := monitorResourceModel{
+		RegionData: types.ObjectValueMust(regionDataObjectType().AttrTypes, map[string]attr.Value{
+			"regions": types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("na"),
+				types.StringValue("eu"),
+			}),
+			"thresholds": types.MapNull(types.Int64Type),
+		}),
+	}
+
+	got, diags := shouldClearRegionDataThresholds(ctx, plan, state)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !got {
+		t.Fatal("expected threshold clear before update when thresholds are omitted from plan")
+	}
+}

--- a/internal/provider/monitor_region_data_test.go
+++ b/internal/provider/monitor_region_data_test.go
@@ -122,6 +122,13 @@ func TestFlattenRegionDataToState_ObjectResponse(t *testing.T) {
 	if len(regions) != 2 {
 		t.Fatalf("expected two regions, got %#v", regions)
 	}
+	seen := map[string]bool{}
+	for _, region := range regions {
+		seen[region] = true
+	}
+	if !seen["na"] || !seen["eu"] {
+		t.Fatalf("expected regions to contain na and eu, got %#v", regions)
+	}
 
 	var thresholds map[string]int64
 	diags = got.Thresholds.ElementsAs(ctx, &thresholds, false)

--- a/internal/provider/monitor_region_data_test.go
+++ b/internal/provider/monitor_region_data_test.go
@@ -35,7 +35,11 @@ func TestExpandRegionDataToAPI_NormalizesSetAndThresholds(t *testing.T) {
 	if len(got.Regions) != 2 || got.Regions[0] != "na" || got.Regions[1] != "eu" {
 		t.Fatalf("unexpected normalized regions: %#v", got.Regions)
 	}
-	if got.Thresholds["na"] != 3000 || got.Thresholds["eu"] != 5000 {
+	if got.Thresholds == nil {
+		t.Fatal("expected thresholds to be set")
+	}
+	thresholds := *got.Thresholds
+	if thresholds["na"] != 3000 || thresholds["eu"] != 5000 {
 		t.Fatalf("unexpected thresholds: %#v", got.Thresholds)
 	}
 }

--- a/internal/provider/monitor_region_data_test.go
+++ b/internal/provider/monitor_region_data_test.go
@@ -1,0 +1,161 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+func TestExpandRegionDataToAPI_NormalizesSetAndThresholds(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	value := types.ObjectValueMust(regionDataObjectType().AttrTypes, map[string]attr.Value{
+		"regions": types.SetValueMust(types.StringType, []attr.Value{
+			types.StringValue("eu"),
+			types.StringValue("na"),
+		}),
+		"thresholds": types.MapValueMust(types.Int64Type, map[string]attr.Value{
+			"eu": types.Int64Value(5000),
+			"na": types.Int64Value(3000),
+		}),
+	})
+
+	got, ok, diags := expandRegionDataToAPI(ctx, value)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !ok || got == nil {
+		t.Fatal("expected region data request")
+	}
+	if len(got.Regions) != 2 || got.Regions[0] != "na" || got.Regions[1] != "eu" {
+		t.Fatalf("unexpected normalized regions: %#v", got.Regions)
+	}
+	if got.Thresholds["na"] != 3000 || got.Thresholds["eu"] != 5000 {
+		t.Fatalf("unexpected thresholds: %#v", got.Thresholds)
+	}
+}
+
+func TestFlattenRegionDataToState_ObjectResponse(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	apiValue := map[string]interface{}{
+		"REGION": []interface{}{"eu", "na"},
+		"THRESHOLD": map[string]interface{}{
+			"eu": float64(5000),
+			"na": float64(3000),
+		},
+	}
+
+	state, diags := flattenRegionDataToState(apiValue, true)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	var got regionDataTF
+	diags = state.As(ctx, &got, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true})
+	if diags.HasError() {
+		t.Fatalf("unexpected decode diagnostics: %v", diags)
+	}
+
+	var regions []string
+	diags = got.Regions.ElementsAs(ctx, &regions, false)
+	if diags.HasError() {
+		t.Fatalf("unexpected region diagnostics: %v", diags)
+	}
+	if len(regions) != 2 {
+		t.Fatalf("expected two regions, got %#v", regions)
+	}
+
+	var thresholds map[string]int64
+	diags = got.Thresholds.ElementsAs(ctx, &thresholds, false)
+	if diags.HasError() {
+		t.Fatalf("unexpected threshold diagnostics: %v", diags)
+	}
+	if thresholds["na"] != 3000 || thresholds["eu"] != 5000 {
+		t.Fatalf("unexpected thresholds: %#v", thresholds)
+	}
+}
+
+func TestEqualRegionData_IgnoresRegionOrder(t *testing.T) {
+	t.Parallel()
+
+	want := &regionDataComparable{
+		Regions:    []string{"na", "eu"},
+		Thresholds: map[string]int{"na": 3000, "eu": 5000},
+	}
+	got := &regionDataComparable{
+		Regions:    []string{"eu", "na"},
+		Thresholds: map[string]int{"eu": 5000, "na": 3000},
+	}
+
+	if !equalRegionData(want, got) {
+		t.Fatalf("expected region data to match")
+	}
+}
+
+func TestValidateRegionData_RejectsThresholdOutsideSelectedRegions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	data := &monitorResourceModel{
+		RegionData: types.ObjectValueMust(regionDataObjectType().AttrTypes, map[string]attr.Value{
+			"regions": types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("eu"),
+			}),
+			"thresholds": types.MapValueMust(types.Int64Type, map[string]attr.Value{
+				"na": types.Int64Value(3000),
+			}),
+		}),
+		ResponseTimeThreshold: types.Int64Null(),
+	}
+	resp := &resource.ValidateConfigResponse{}
+
+	validateRegionData(ctx, data, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestShouldClearRegionDataThresholds_RemovedKey(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	state := monitorResourceModel{
+		RegionData: types.ObjectValueMust(regionDataObjectType().AttrTypes, map[string]attr.Value{
+			"regions": types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("na"),
+				types.StringValue("eu"),
+			}),
+			"thresholds": types.MapValueMust(types.Int64Type, map[string]attr.Value{
+				"na": types.Int64Value(3000),
+				"eu": types.Int64Value(5000),
+			}),
+		}),
+	}
+	plan := monitorResourceModel{
+		RegionData: types.ObjectValueMust(regionDataObjectType().AttrTypes, map[string]attr.Value{
+			"regions": types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("na"),
+				types.StringValue("eu"),
+			}),
+			"thresholds": types.MapValueMust(types.Int64Type, map[string]attr.Value{
+				"na": types.Int64Value(3000),
+			}),
+		}),
+	}
+
+	got, diags := shouldClearRegionDataThresholds(ctx, plan, state)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !got {
+		t.Fatal("expected threshold clear before update when a threshold key is removed")
+	}
+}

--- a/internal/provider/monitor_region_data_test.go
+++ b/internal/provider/monitor_region_data_test.go
@@ -10,11 +10,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
+func regionDataObjectTestValue(values map[string]attr.Value) types.Object {
+	attrs := map[string]attr.Value{
+		"regions":     types.SetNull(types.StringType),
+		"auto_select": types.BoolNull(),
+		"thresholds":  types.MapNull(types.Int64Type),
+	}
+	for key, value := range values {
+		attrs[key] = value
+	}
+	return types.ObjectValueMust(regionDataObjectType().AttrTypes, attrs)
+}
+
 func TestExpandRegionDataToAPI_NormalizesSetAndThresholds(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	value := types.ObjectValueMust(regionDataObjectType().AttrTypes, map[string]attr.Value{
+	value := regionDataObjectTestValue(map[string]attr.Value{
 		"regions": types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("eu"),
 			types.StringValue("na"),
@@ -41,6 +53,41 @@ func TestExpandRegionDataToAPI_NormalizesSetAndThresholds(t *testing.T) {
 	thresholds := *got.Thresholds
 	if thresholds["na"] != 3000 || thresholds["eu"] != 5000 {
 		t.Fatalf("unexpected thresholds: %#v", got.Thresholds)
+	}
+}
+
+func TestExpandRegionDataToAPI_AutoSelectMapsToManualSelected(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	for name, autoSelect := range map[string]bool{
+		"auto":   true,
+		"manual": false,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			value := regionDataObjectTestValue(map[string]attr.Value{
+				"regions": types.SetValueMust(types.StringType, []attr.Value{
+					types.StringValue("na"),
+				}),
+				"auto_select": types.BoolValue(autoSelect),
+			})
+
+			got, ok, diags := expandRegionDataToAPI(ctx, value)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+			if !ok || got == nil {
+				t.Fatal("expected region data request")
+			}
+			if got.ManualSelected == nil {
+				t.Fatal("expected MANUAL_SELECTED to be sent")
+			}
+			if *got.ManualSelected == autoSelect {
+				t.Fatalf("expected MANUAL_SELECTED=%t for auto_select=%t", !autoSelect, autoSelect)
+			}
+		})
 	}
 }
 
@@ -84,6 +131,57 @@ func TestFlattenRegionDataToState_ObjectResponse(t *testing.T) {
 	if thresholds["na"] != 3000 || thresholds["eu"] != 5000 {
 		t.Fatalf("unexpected thresholds: %#v", thresholds)
 	}
+	if !got.AutoSelect.IsNull() {
+		t.Fatalf("expected auto_select to remain null when unmanaged, got %#v", got.AutoSelect)
+	}
+}
+
+func TestFlattenRegionDataToState_UsesManualSelectedWhenPresent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	apiValue := map[string]interface{}{
+		"REGION":          []interface{}{"na"},
+		"MANUAL_SELECTED": false,
+	}
+
+	state, diags := flattenRegionDataToStateWithAutoSelect(apiValue, false, boolPtr(false))
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	var got regionDataTF
+	diags = state.As(ctx, &got, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true})
+	if diags.HasError() {
+		t.Fatalf("unexpected decode diagnostics: %v", diags)
+	}
+	if got.AutoSelect.IsNull() || !got.AutoSelect.ValueBool() {
+		t.Fatalf("expected API MANUAL_SELECTED=false to decode as auto_select=true, got %#v", got.AutoSelect)
+	}
+}
+
+func TestFlattenRegionDataToState_PreservesManagedAutoSelectFallback(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	apiValue := map[string]interface{}{
+		"REGION": []interface{}{"na"},
+	}
+	autoSelect := true
+
+	state, diags := flattenRegionDataToStateWithAutoSelect(apiValue, false, &autoSelect)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	var got regionDataTF
+	diags = state.As(ctx, &got, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true})
+	if diags.HasError() {
+		t.Fatalf("unexpected decode diagnostics: %v", diags)
+	}
+	if got.AutoSelect.IsNull() || !got.AutoSelect.ValueBool() {
+		t.Fatalf("expected fallback auto_select=true, got %#v", got.AutoSelect)
+	}
 }
 
 func TestEqualRegionData_IgnoresRegionOrder(t *testing.T) {
@@ -108,7 +206,7 @@ func TestValidateRegionData_RejectsThresholdOutsideSelectedRegions(t *testing.T)
 
 	ctx := context.Background()
 	data := &monitorResourceModel{
-		RegionData: types.ObjectValueMust(regionDataObjectType().AttrTypes, map[string]attr.Value{
+		RegionData: regionDataObjectTestValue(map[string]attr.Value{
 			"regions": types.SetValueMust(types.StringType, []attr.Value{
 				types.StringValue("eu"),
 			}),
@@ -132,7 +230,7 @@ func TestValidateRegionData_RejectsNonEmptyThresholdsWithGlobalThreshold(t *test
 
 	ctx := context.Background()
 	data := &monitorResourceModel{
-		RegionData: types.ObjectValueMust(regionDataObjectType().AttrTypes, map[string]attr.Value{
+		RegionData: regionDataObjectTestValue(map[string]attr.Value{
 			"regions": types.SetValueMust(types.StringType, []attr.Value{
 				types.StringValue("na"),
 			}),
@@ -156,7 +254,7 @@ func TestValidateRegionData_AllowsEmptyThresholdsWithGlobalThreshold(t *testing.
 
 	ctx := context.Background()
 	data := &monitorResourceModel{
-		RegionData: types.ObjectValueMust(regionDataObjectType().AttrTypes, map[string]attr.Value{
+		RegionData: regionDataObjectTestValue(map[string]attr.Value{
 			"regions": types.SetValueMust(types.StringType, []attr.Value{
 				types.StringValue("na"),
 			}),
@@ -178,7 +276,7 @@ func TestShouldClearRegionDataThresholds_RemovedKey(t *testing.T) {
 
 	ctx := context.Background()
 	state := monitorResourceModel{
-		RegionData: types.ObjectValueMust(regionDataObjectType().AttrTypes, map[string]attr.Value{
+		RegionData: regionDataObjectTestValue(map[string]attr.Value{
 			"regions": types.SetValueMust(types.StringType, []attr.Value{
 				types.StringValue("na"),
 				types.StringValue("eu"),
@@ -190,7 +288,7 @@ func TestShouldClearRegionDataThresholds_RemovedKey(t *testing.T) {
 		}),
 	}
 	plan := monitorResourceModel{
-		RegionData: types.ObjectValueMust(regionDataObjectType().AttrTypes, map[string]attr.Value{
+		RegionData: regionDataObjectTestValue(map[string]attr.Value{
 			"regions": types.SetValueMust(types.StringType, []attr.Value{
 				types.StringValue("na"),
 				types.StringValue("eu"),
@@ -215,7 +313,7 @@ func TestShouldClearRegionDataThresholds_OmittedThresholds(t *testing.T) {
 
 	ctx := context.Background()
 	state := monitorResourceModel{
-		RegionData: types.ObjectValueMust(regionDataObjectType().AttrTypes, map[string]attr.Value{
+		RegionData: regionDataObjectTestValue(map[string]attr.Value{
 			"regions": types.SetValueMust(types.StringType, []attr.Value{
 				types.StringValue("na"),
 				types.StringValue("eu"),
@@ -227,7 +325,7 @@ func TestShouldClearRegionDataThresholds_OmittedThresholds(t *testing.T) {
 		}),
 	}
 	plan := monitorResourceModel{
-		RegionData: types.ObjectValueMust(regionDataObjectType().AttrTypes, map[string]attr.Value{
+		RegionData: regionDataObjectTestValue(map[string]attr.Value{
 			"regions": types.SetValueMust(types.StringType, []attr.Value{
 				types.StringValue("na"),
 				types.StringValue("eu"),
@@ -243,4 +341,8 @@ func TestShouldClearRegionDataThresholds_OmittedThresholds(t *testing.T) {
 	if !got {
 		t.Fatal("expected threshold clear before update when thresholds are omitted from plan")
 	}
+}
+
+func boolPtr(v bool) *bool {
+	return &v
 }

--- a/internal/provider/monitor_region_data_test.go
+++ b/internal/provider/monitor_region_data_test.go
@@ -127,6 +127,52 @@ func TestValidateRegionData_RejectsThresholdOutsideSelectedRegions(t *testing.T)
 	}
 }
 
+func TestValidateRegionData_RejectsNonEmptyThresholdsWithGlobalThreshold(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	data := &monitorResourceModel{
+		RegionData: types.ObjectValueMust(regionDataObjectType().AttrTypes, map[string]attr.Value{
+			"regions": types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("na"),
+			}),
+			"thresholds": types.MapValueMust(types.Int64Type, map[string]attr.Value{
+				"na": types.Int64Value(3000),
+			}),
+		}),
+		ResponseTimeThreshold: types.Int64Value(3000),
+	}
+	resp := &resource.ValidateConfigResponse{}
+
+	validateRegionData(ctx, data, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestValidateRegionData_AllowsEmptyThresholdsWithGlobalThreshold(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	data := &monitorResourceModel{
+		RegionData: types.ObjectValueMust(regionDataObjectType().AttrTypes, map[string]attr.Value{
+			"regions": types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("na"),
+			}),
+			"thresholds": types.MapValueMust(types.Int64Type, map[string]attr.Value{}),
+		}),
+		ResponseTimeThreshold: types.Int64Value(3000),
+	}
+	resp := &resource.ValidateConfigResponse{}
+
+	validateRegionData(ctx, data, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+}
+
 func TestShouldClearRegionDataThresholds_RemovedKey(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/monitor_region_data_test.go
+++ b/internal/provider/monitor_region_data_test.go
@@ -343,6 +343,42 @@ func TestShouldClearRegionDataThresholds_OmittedThresholds(t *testing.T) {
 	}
 }
 
+func TestShouldClearRegionDataThresholds_EmptyThresholds(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	state := monitorResourceModel{
+		RegionData: regionDataObjectTestValue(map[string]attr.Value{
+			"regions": types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("na"),
+				types.StringValue("eu"),
+			}),
+			"thresholds": types.MapValueMust(types.Int64Type, map[string]attr.Value{
+				"na": types.Int64Value(3000),
+				"eu": types.Int64Value(5000),
+			}),
+		}),
+	}
+	plan := monitorResourceModel{
+		RegionData: regionDataObjectTestValue(map[string]attr.Value{
+			"regions": types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("na"),
+				types.StringValue("eu"),
+			}),
+			"thresholds": types.MapValueMust(types.Int64Type, map[string]attr.Value{}),
+		}),
+		ResponseTimeThreshold: types.Int64Value(2500),
+	}
+
+	got, diags := shouldClearRegionDataThresholds(ctx, plan, state)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !got {
+		t.Fatal("expected threshold clear before update when thresholds are explicitly empty")
+	}
+}
+
 func boolPtr(v bool) *bool {
 	return &v
 }

--- a/internal/provider/monitor_resource_acc_test.go
+++ b/internal/provider/monitor_resource_acc_test.go
@@ -1490,6 +1490,88 @@ resource "uptimerobot_monitor" "test" {
 	})
 }
 
+func TestAccMonitorResource_RegionData(t *testing.T) {
+	if _, ok := testAccOptionalEnv("UPTIMEROBOT_TEST_MULTI_REGION"); !ok {
+		t.Skip("Set UPTIMEROBOT_TEST_MULTI_REGION=1 to run multi-region acceptance; the account must have monitor-location-settings.")
+	}
+
+	name := acctest.RandomWithPrefix("test-region-data")
+	url := testAccUniqueURL(name)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + fmt.Sprintf(`
+resource "uptimerobot_monitor" "test" {
+  name     = %q
+  url      = "%s"
+  type     = "HTTP"
+  interval = 300
+  timeout  = 30
+
+  region_data = {
+    regions = ["na", "eu"]
+    thresholds = {
+      na = 3000
+      eu = 5000
+    }
+  }
+}`, name, url),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "region_data.regions.#", "2"),
+					resource.TestCheckTypeSetElemAttr("uptimerobot_monitor.test", "region_data.regions.*", "na"),
+					resource.TestCheckTypeSetElemAttr("uptimerobot_monitor.test", "region_data.regions.*", "eu"),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "region_data.thresholds.%", "2"),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "region_data.thresholds.na", "3000"),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "region_data.thresholds.eu", "5000"),
+				),
+			},
+			{
+				Config: testAccProviderConfig() + fmt.Sprintf(`
+resource "uptimerobot_monitor" "test" {
+  name     = %q
+  url      = "%s"
+  type     = "HTTP"
+  interval = 300
+  timeout  = 30
+
+  region_data = {
+    regions = ["na", "eu"]
+    thresholds = {
+      na = 3000
+    }
+  }
+}`, name, url),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "region_data.regions.#", "2"),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "region_data.thresholds.%", "1"),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "region_data.thresholds.na", "3000"),
+				),
+			},
+			{
+				Config: testAccProviderConfig() + fmt.Sprintf(`
+resource "uptimerobot_monitor" "test" {
+  name     = %q
+  url      = "%s"
+  type     = "HTTP"
+  interval = 300
+  timeout  = 30
+
+  region_data = {
+    regions = ["na", "eu"]
+    thresholds = {
+      na = 3000
+    }
+  }
+}`, name, url),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 // TestAccMonitorResource_InvalidMonitorType tests that invalid monitor types are rejected.
 func TestAccMonitorResource_InvalidMonitorType(t *testing.T) {
 	name := acctest.RandomWithPrefix("test-invalid-monitor")

--- a/internal/provider/monitor_resource_acc_test.go
+++ b/internal/provider/monitor_resource_acc_test.go
@@ -1500,6 +1500,7 @@ func TestAccMonitorResource_RegionData(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMonitorDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig() + fmt.Sprintf(`

--- a/internal/provider/monitor_resource_acc_test.go
+++ b/internal/provider/monitor_resource_acc_test.go
@@ -1569,6 +1569,43 @@ resource "uptimerobot_monitor" "test" {
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
+			{
+				Config: testAccProviderConfig() + fmt.Sprintf(`
+resource "uptimerobot_monitor" "test" {
+  name     = %q
+  url      = "%s"
+  type     = "HTTP"
+  interval = 300
+  timeout  = 30
+
+  region_data = {
+    regions     = ["na"]
+    auto_select = true
+  }
+}`, name, url),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "region_data.regions.#", "1"),
+					resource.TestCheckTypeSetElemAttr("uptimerobot_monitor.test", "region_data.regions.*", "na"),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "region_data.auto_select", "true"),
+				),
+			},
+			{
+				Config: testAccProviderConfig() + fmt.Sprintf(`
+resource "uptimerobot_monitor" "test" {
+  name     = %q
+  url      = "%s"
+  type     = "HTTP"
+  interval = 300
+  timeout  = 30
+
+  region_data = {
+    regions     = ["na"]
+    auto_select = true
+  }
+}`, name, url),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
 		},
 	})
 }

--- a/internal/provider/monitor_schema.go
+++ b/internal/provider/monitor_schema.go
@@ -413,10 +413,37 @@ Alert contacts assigned to this monitor.
 				},
 			},
 			"regional_data": schema.StringAttribute{
-				Description: "Region for monitoring: na (North America), eu (Europe), as (Asia), oc (Oceania)",
-				Optional:    true,
+				Description:        "Legacy single region for monitoring: na (North America), eu (Europe), as (Asia), oc (Oceania). Use region_data for new multi-region monitor settings.",
+				DeprecationMessage: "Use region_data instead. regional_data only supports the legacy single-region API shape.",
+				Optional:           true,
 				Validators: []validator.String{
 					stringvalidator.OneOf("na", "eu", "as", "oc"),
+				},
+			},
+			"region_data": schema.SingleNestedAttribute{
+				Description: "Multi-region monitor settings. Uses the API v3 regionData object.",
+				MarkdownDescription: "Multi-region monitor settings. Uses the API v3 `regionData` object.\n\n" +
+					"- `regions` selects the active monitoring regions: `na`, `eu`, `as`, `oc`.\n" +
+					"- `thresholds` optionally sets per-region response-time thresholds in milliseconds. Keys must be selected regions and values must be between `0` and `60000`.",
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"regions": schema.SetAttribute{
+						Description: "Active monitoring regions: na (North America), eu (Europe), as (Asia), oc (Oceania).",
+						Required:    true,
+						ElementType: types.StringType,
+						Validators: []validator.Set{
+							setvalidator.SizeAtLeast(1),
+							setvalidator.SizeAtMost(4),
+							setvalidator.ValueStringsAre(
+								stringvalidator.OneOf("na", "eu", "as", "oc"),
+							),
+						},
+					},
+					"thresholds": schema.MapAttribute{
+						Description: "Optional per-region response-time thresholds in milliseconds. Keys must be selected regions.",
+						Optional:    true,
+						ElementType: types.Int64Type,
+					},
 				},
 			},
 			"check_ssl_errors": schema.BoolAttribute{

--- a/internal/provider/monitor_schema.go
+++ b/internal/provider/monitor_schema.go
@@ -424,6 +424,7 @@ Alert contacts assigned to this monitor.
 				Description: "Multi-region monitor settings. Uses the API v3 regionData object.",
 				MarkdownDescription: "Multi-region monitor settings. Uses the API v3 `regionData` object.\n\n" +
 					"- `regions` selects the active monitoring regions: `na`, `eu`, `as`, `oc`.\n" +
+					"- `auto_select` lets UptimeRobot choose the monitoring region automatically. When omitted or `false`, the configured `regions` are used as manually selected regions.\n" +
 					"- `thresholds` optionally sets per-region response-time thresholds in milliseconds. Keys must be selected regions and values must be between `0` and `60000`.",
 				Optional: true,
 				Attributes: map[string]schema.Attribute{
@@ -438,6 +439,10 @@ Alert contacts assigned to this monitor.
 								stringvalidator.OneOf("na", "eu", "as", "oc"),
 							),
 						},
+					},
+					"auto_select": schema.BoolAttribute{
+						Description: "When true, UptimeRobot automatically chooses the monitoring region. When omitted or false, the configured regions are used as manually selected regions.",
+						Optional:    true,
 					},
 					"thresholds": schema.MapAttribute{
 						Description: "Optional per-region response-time thresholds in milliseconds. Keys must be selected regions.",

--- a/internal/provider/monitor_transform.go
+++ b/internal/provider/monitor_transform.go
@@ -820,38 +820,5 @@ func firstNonEmpty(values ...string) string {
 var allowedRegion = map[string]struct{}{"na": {}, "eu": {}, "as": {}, "oc": {}}
 
 func coerceRegion(v interface{}) (string, bool) {
-	switch x := v.(type) {
-	case string:
-		s := strings.ToLower(strings.TrimSpace(x))
-		_, ok := allowedRegion[s]
-		return s, ok
-
-	case map[string]interface{}:
-		raw, ok := x["REGION"]
-		if !ok {
-			raw, ok = x["region"]
-			if !ok {
-				return "", false
-			}
-		}
-		switch a := raw.(type) {
-		case []interface{}:
-			for _, it := range a {
-				if s, ok := it.(string); ok {
-					s = strings.ToLower(strings.TrimSpace(s))
-					if _, ok := allowedRegion[s]; ok {
-						return s, true
-					}
-				}
-			}
-		case []string:
-			for _, s0 := range a {
-				s := strings.ToLower(strings.TrimSpace(s0))
-				if _, ok := allowedRegion[s]; ok {
-					return s, true
-				}
-			}
-		}
-	}
-	return "", false
+	return firstRegionFromAPI(v)
 }

--- a/internal/provider/monitor_upgrade.go
+++ b/internal/provider/monitor_upgrade.go
@@ -120,6 +120,7 @@ func upgradeMonitorFromV0(ctx context.Context, prior monitorV0Model) (monitorRes
 		AssignedAlertContacts:    acSet,
 		ResponseTimeThreshold:    prior.ResponseTimeThreshold,
 		RegionalData:             prior.RegionalData,
+		RegionData:               types.ObjectNull(regionDataObjectType().AttrTypes),
 		Config:                   types.ObjectNull(configObjectType().AttrTypes),
 	}
 
@@ -410,6 +411,7 @@ func upgradeMonitorFromV1(ctx context.Context, prior monitorV1Model) (monitorRes
 		AssignedAlertContacts:    acSet,
 		ResponseTimeThreshold:    prior.ResponseTimeThreshold,
 		RegionalData:             prior.RegionalData,
+		RegionData:               types.ObjectNull(regionDataObjectType().AttrTypes),
 		Config:                   types.ObjectNull(configObjectType().AttrTypes),
 	}
 
@@ -695,6 +697,7 @@ func upgradeMonitorFromV2(ctx context.Context, prior monitorV2Model) (monitorRes
 		AssignedAlertContacts:    acSet, // converted
 		ResponseTimeThreshold:    prior.ResponseTimeThreshold,
 		RegionalData:             prior.RegionalData,
+		RegionData:               types.ObjectNull(regionDataObjectType().AttrTypes),
 		Config:                   types.ObjectNull(configObjectType().AttrTypes),
 	}
 
@@ -1023,6 +1026,7 @@ func upgradeMonitorFromV3(ctx context.Context, prior monitorV3Model) (monitorRes
 		AssignedAlertContacts: acSet,
 		ResponseTimeThreshold: prior.ResponseTimeThreshold,
 		RegionalData:          prior.RegionalData,
+		RegionData:            types.ObjectNull(regionDataObjectType().AttrTypes),
 		CheckSSLErrors:        prior.CheckSSLErrors,
 		Config:                config,
 	}
@@ -1359,6 +1363,7 @@ func upgradeMonitorFromV4(ctx context.Context, prior monitorV4Model) (monitorRes
 
 		ResponseTimeThreshold: prior.ResponseTimeThreshold,
 		RegionalData:          prior.RegionalData,
+		RegionData:            types.ObjectNull(regionDataObjectType().AttrTypes),
 		CheckSSLErrors:        prior.CheckSSLErrors,
 		Config:                config,
 	}

--- a/internal/provider/monitor_validate.go
+++ b/internal/provider/monitor_validate.go
@@ -26,6 +26,10 @@ func (r *monitorResource) ConfigValidators(ctx context.Context) []resource.Confi
 			path.MatchRoot("post_value_data"),
 			path.MatchRoot("post_value_kv"),
 		),
+		resourcevalidator.Conflicting(
+			path.MatchRoot("regional_data"),
+			path.MatchRoot("region_data"),
+		),
 	}
 }
 
@@ -57,6 +61,7 @@ func (r *monitorResource) ValidateConfig(
 	validateMethodVsBody(ctx, &data, resp)
 	validateAssignedAlertContacts(ctx, &data, resp)
 	validateConfig(ctx, t, &data, resp)
+	validateRegionData(ctx, &data, resp)
 	validateHeadersCasingDuplication(ctx, &data, resp)
 	validatePortMonitor(ctx, t, &data, resp)
 	validateKeywordMonitor(ctx, t, &data, resp)

--- a/templates/resources/monitor.md.tmpl
+++ b/templates/resources/monitor.md.tmpl
@@ -35,6 +35,10 @@ description: |-
 
 {{tffile "examples/resources/uptimerobot_monitor/ping.tf"}}
 
+### Multi-region Monitor
+
+{{tffile "examples/resources/uptimerobot_monitor/region_data.tf"}}
+
 ### UDP Monitor
 
 {{tffile "examples/resources/uptimerobot_monitor/udp.tf"}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-region monitor configuration via a new region_data object with required regions, optional auto_select, and optional per-region response-time thresholds; legacy single-region regional_data is deprecated and conflicts with region_data.

* **Documentation**
  * Added docs, template, and example demonstrating multi-region setup, region selection, and per-region thresholds.

* **Validation**
  * Configuration now rejects using regional_data and region_data together and validates region/threshold rules.

* **Tests**
  * Added unit, JSON marshal, read, and acceptance tests covering multi-region behavior, validation, and serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->