### PR TITLE
feat: allow auto region selection without regions

### DIFF
--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -218,9 +218,10 @@ resource "uptimerobot_monitor" "multi_region" {
   region_data = {
     regions = ["na", "eu", "as"]
 
-    # Optional: let UptimeRobot choose the monitoring region automatically.
-    # When omitted or false, the configured regions are used manually.
-    # auto_select = true
+    # For automatic selection, replace this region_data object with:
+    # region_data = {
+    #   auto_select = true
+    # }
 
     thresholds = {
       na = 3000
@@ -690,8 +691,8 @@ terraform import 'uptimerobot_monitor.monitors["www_production"]' 800123456
 - `post_value_kv` (Map of String) Key/Value body for application/x-www-form-urlencoded. Mutually exclusive with post_value_data.
 - `region_data` (Attributes) Multi-region monitor settings. Uses the API v3 `regionData` object.
 
-- `regions` selects the active monitoring regions: `na`, `eu`, `as`, `oc`.
-- `auto_select` lets UptimeRobot choose the monitoring region automatically. When omitted or `false`, the configured `regions` are used as manually selected regions.
+- `regions` selects the active monitoring regions: `na`, `eu`, `as`, `oc`. Required unless `auto_select` is `true`.
+- `auto_select` lets UptimeRobot choose the monitoring region automatically. When `true`, `regions` can be omitted and the provider sends the API-required carrier region without managing it. When omitted or `false`, configured `regions` are used as manually selected regions.
 - `thresholds` optionally sets per-region response-time thresholds in milliseconds. Keys must be selected regions and values must be between `0` and `60000`. (see [below for nested schema](#nestedatt--region_data))
 - `regional_data` (String, Deprecated) Legacy single region for monitoring: na (North America), eu (Europe), as (Asia), oc (Oceania). Use region_data for new multi-region monitor settings.
 - `response_time_threshold` (Number) Response time threshold in milliseconds. Response time over this threshold will trigger an incident
@@ -800,11 +801,8 @@ Optional:
 <a id="nestedatt--region_data"></a>
 ### Nested Schema for `region_data`
 
-Required:
-
-- `regions` (Set of String) Active monitoring regions: na (North America), eu (Europe), as (Asia), oc (Oceania).
-
 Optional:
 
-- `auto_select` (Boolean) When true, UptimeRobot automatically chooses the monitoring region. When omitted or false, the configured regions are used as manually selected regions.
+- `auto_select` (Boolean) When true, UptimeRobot automatically chooses the monitoring region. Regions can be omitted in this mode. When omitted or false, configured regions are used as manually selected regions.
+- `regions` (Set of String) Active monitoring regions: na (North America), eu (Europe), as (Asia), oc (Oceania). Required unless auto_select is true.
 - `thresholds` (Map of Number) Optional per-region response-time thresholds in milliseconds. Keys must be selected regions.

--- a/examples/resources/uptimerobot_monitor/region_data.tf
+++ b/examples/resources/uptimerobot_monitor/region_data.tf
@@ -10,9 +10,10 @@ resource "uptimerobot_monitor" "multi_region" {
   region_data = {
     regions = ["na", "eu", "as"]
 
-    # Optional: let UptimeRobot choose the monitoring region automatically.
-    # When omitted or false, the configured regions are used manually.
-    # auto_select = true
+    # For automatic selection, replace this region_data object with:
+    # region_data = {
+    #   auto_select = true
+    # }
 
     thresholds = {
       na = 3000

--- a/internal/client/monitor.go
+++ b/internal/client/monitor.go
@@ -160,6 +160,7 @@ type AlertContact struct {
 
 type RegionDataRequest struct {
 	Regions        []string        `json:"REGION"`
+	RegionsManaged bool            `json:"-"`
 	ManualSelected *bool           `json:"MANUAL_SELECTED,omitempty"`
 	Thresholds     *map[string]int `json:"THRESHOLD,omitempty"`
 }

--- a/internal/provider/monitor_compare.go
+++ b/internal/provider/monitor_compare.go
@@ -172,8 +172,9 @@ func wantFromCreateReq(req *client.CreateMonitorRequest) monComparable {
 		c.RegionalData = &s
 	}
 	if req.RegionData != nil {
-		c.RegionData = &regionDataComparable{
-			Regions: normalizeRegions(req.RegionData.Regions),
+		c.RegionData = &regionDataComparable{}
+		if req.RegionData.RegionsManaged {
+			c.RegionData.Regions = normalizeRegions(req.RegionData.Regions)
 		}
 		if req.RegionData.ManualSelected != nil {
 			autoSelect := !*req.RegionData.ManualSelected
@@ -339,8 +340,9 @@ func wantFromUpdateReq(req *client.UpdateMonitorRequest) monComparable {
 		c.RegionalData = &s
 	}
 	if req.RegionData != nil {
-		c.RegionData = &regionDataComparable{
-			Regions: normalizeRegions(req.RegionData.Regions),
+		c.RegionData = &regionDataComparable{}
+		if req.RegionData.RegionsManaged {
+			c.RegionData.Regions = normalizeRegions(req.RegionData.Regions)
 		}
 		if req.RegionData.ManualSelected != nil {
 			autoSelect := !*req.RegionData.ManualSelected

--- a/internal/provider/monitor_crud_create.go
+++ b/internal/provider/monitor_crud_create.go
@@ -663,9 +663,10 @@ func (r *monitorResource) buildStateAfterCreate(
 
 	// Region data
 	if !plan.RegionData.IsNull() && !plan.RegionData.IsUnknown() {
+		includeRegions := regionDataRegionsManaged(ctx, plan.RegionData)
 		includeThresholds := regionDataThresholdsManaged(ctx, plan.RegionData)
 		autoSelect := regionDataAutoSelectValue(ctx, plan.RegionData)
-		regionState, d := flattenRegionDataToStateWithAutoSelect(api.RegionalData, includeThresholds, autoSelect)
+		regionState, d := flattenRegionDataToStateWithManagedFields(api.RegionalData, includeRegions, includeThresholds, autoSelect)
 		resp.Diagnostics.Append(d...)
 		if !resp.Diagnostics.HasError() && !regionState.IsNull() && !regionState.IsUnknown() {
 			plan.RegionData = regionState

--- a/internal/provider/monitor_crud_read.go
+++ b/internal/provider/monitor_crud_read.go
@@ -242,12 +242,13 @@ func readApplyRegionalData(ctx context.Context, resp *resource.ReadResponse, sta
 		if apiRegionData, ok := normalizeRegionDataFromAPI(m.RegionalData); ok {
 			includeThresholds := len(apiRegionData.Thresholds) > 0
 			includeAutoSelect := apiRegionData.AutoSelect != nil && *apiRegionData.AutoSelect
+			includeRegions := !includeAutoSelect || includeThresholds
 			useRegionData := len(apiRegionData.Regions) > 1 ||
 				includeThresholds ||
 				includeAutoSelect ||
 				(len(apiRegionData.Regions) == 1 && !isDefaultRegion(apiRegionData.Regions[0]))
 			if useRegionData {
-				regionState, d := regionDataObjectValue(apiRegionData, includeThresholds, includeAutoSelect)
+				regionState, d := regionDataObjectValue(apiRegionData, includeRegions, includeThresholds, includeAutoSelect)
 				resp.Diagnostics.Append(d...)
 				if !resp.Diagnostics.HasError() {
 					state.RegionData = regionState
@@ -261,9 +262,10 @@ func readApplyRegionalData(ctx context.Context, resp *resource.ReadResponse, sta
 		return
 	}
 	if !state.RegionData.IsNull() && !state.RegionData.IsUnknown() {
+		includeRegions := regionDataRegionsManaged(ctx, state.RegionData)
 		includeThresholds := regionDataThresholdsManaged(ctx, state.RegionData)
 		autoSelect := regionDataAutoSelectValue(ctx, state.RegionData)
-		regionState, d := flattenRegionDataToStateWithAutoSelect(m.RegionalData, includeThresholds, autoSelect)
+		regionState, d := flattenRegionDataToStateWithManagedFields(m.RegionalData, includeRegions, includeThresholds, autoSelect)
 		resp.Diagnostics.Append(d...)
 		if !resp.Diagnostics.HasError() && !regionState.IsNull() && !regionState.IsUnknown() {
 			state.RegionData = regionState

--- a/internal/provider/monitor_crud_update.go
+++ b/internal/provider/monitor_crud_update.go
@@ -356,7 +356,15 @@ func buildUpdateRequest(
 		v := int(plan.ResponseTimeThreshold.ValueInt64())
 		req.ResponseTimeThreshold = &v
 	}
-	if regionData, ok, d := expandRegionDataToAPI(ctx, plan.RegionData); d.HasError() {
+	fallbackRegions, _, d := regionDataRegionsValue(ctx, state.RegionData)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return nil, ""
+	}
+	if len(fallbackRegions) == 0 && !state.RegionalData.IsNull() && !state.RegionalData.IsUnknown() {
+		fallbackRegions = []string{state.RegionalData.ValueString()}
+	}
+	if regionData, ok, d := expandRegionDataToAPIWithFallback(ctx, plan.RegionData, fallbackRegions); d.HasError() {
 		resp.Diagnostics.Append(d...)
 		return nil, ""
 	} else if ok {
@@ -684,9 +692,10 @@ func applyUpdatedMonitorToState(
 
 	// region_data set only if managed
 	if !plan.RegionData.IsNull() && !plan.RegionData.IsUnknown() {
+		includeRegions := regionDataRegionsManaged(ctx, plan.RegionData)
 		includeThresholds := regionDataThresholdsManaged(ctx, plan.RegionData)
 		autoSelect := regionDataAutoSelectValue(ctx, plan.RegionData)
-		regionState, d := flattenRegionDataToStateWithAutoSelect(m.RegionalData, includeThresholds, autoSelect)
+		regionState, d := flattenRegionDataToStateWithManagedFields(m.RegionalData, includeRegions, includeThresholds, autoSelect)
 		resp.Diagnostics.Append(d...)
 		if !resp.Diagnostics.HasError() && !regionState.IsNull() && !regionState.IsUnknown() {
 			out.RegionData = regionState

--- a/internal/provider/monitor_read_test.go
+++ b/internal/provider/monitor_read_test.go
@@ -251,13 +251,7 @@ func TestReadApplyRegionalData_ImportAutoSelectUsesRegionData(t *testing.T) {
 	if got.AutoSelect.IsNull() || !got.AutoSelect.ValueBool() {
 		t.Fatalf("expected imported auto_select=true, got %#v", got.AutoSelect)
 	}
-
-	var regions []string
-	diags = got.Regions.ElementsAs(ctx, &regions, false)
-	if diags.HasError() {
-		t.Fatalf("unexpected region diagnostics: %v", diags)
-	}
-	if len(regions) != 1 || regions[0] != "na" {
-		t.Fatalf("expected imported regions to contain na, got %#v", regions)
+	if !got.Regions.IsNull() {
+		t.Fatalf("expected imported auto-select carrier regions to remain unmanaged, got %#v", got.Regions)
 	}
 }

--- a/internal/provider/monitor_region_data.go
+++ b/internal/provider/monitor_region_data.go
@@ -16,6 +16,8 @@ import (
 
 var canonicalRegionOrder = []string{"na", "eu", "as", "oc"}
 
+const defaultAutoSelectRegion = "na"
+
 type regionDataComparable struct {
 	Regions    []string
 	AutoSelect *bool
@@ -60,6 +62,10 @@ func normalizeRegionThresholds(in map[string]int) map[string]int {
 }
 
 func expandRegionDataToAPI(ctx context.Context, value types.Object) (*client.RegionDataRequest, bool, diag.Diagnostics) {
+	return expandRegionDataToAPIWithFallback(ctx, value, nil)
+}
+
+func expandRegionDataToAPIWithFallback(ctx context.Context, value types.Object, fallbackRegions []string) (*client.RegionDataRequest, bool, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	if value.IsNull() || value.IsUnknown() {
 		return nil, false, diags
@@ -71,35 +77,31 @@ func expandRegionDataToAPI(ctx context.Context, value types.Object) (*client.Reg
 		return nil, false, diags
 	}
 
-	var regions []string
-	diags.Append(data.Regions.ElementsAs(ctx, &regions, false)...)
-	if diags.HasError() {
-		return nil, false, diags
-	}
-	regions = normalizeRegions(regions)
-	if len(regions) == 0 {
-		diags.AddAttributeError(
-			path.Root("region_data").AtName("regions"),
-			"Missing regions",
-			"region_data.regions must contain at least one valid region: na, eu, as, oc.",
-		)
-		return nil, false, diags
+	autoSelect := false
+	if !data.AutoSelect.IsNull() && !data.AutoSelect.IsUnknown() {
+		autoSelect = data.AutoSelect.ValueBool()
 	}
 
-	out := &client.RegionDataRequest{Regions: regions}
-	if !data.AutoSelect.IsNull() && !data.AutoSelect.IsUnknown() {
-		autoSelect := data.AutoSelect.ValueBool()
-		manualSelected := !autoSelect
-		out.ManualSelected = &manualSelected
+	var regions []string
+	regionsManaged := !data.Regions.IsNull() && !data.Regions.IsUnknown()
+	if regionsManaged {
+		diags.Append(data.Regions.ElementsAs(ctx, &regions, false)...)
+		if diags.HasError() {
+			return nil, false, diags
+		}
+		regions = normalizeRegions(regions)
 	}
-	if !data.Thresholds.IsNull() && !data.Thresholds.IsUnknown() {
+
+	var thresholdsOut map[string]int
+	thresholdsManaged := !data.Thresholds.IsNull() && !data.Thresholds.IsUnknown()
+	if thresholdsManaged {
 		var thresholds map[string]int64
 		diags.Append(data.Thresholds.ElementsAs(ctx, &thresholds, false)...)
 		if diags.HasError() {
 			return nil, false, diags
 		}
 
-		thresholdsOut := map[string]int{}
+		thresholdsOut = map[string]int{}
 		for raw, v := range thresholds {
 			region, ok := normalizeRegionCode(raw)
 			if !ok {
@@ -112,6 +114,41 @@ func expandRegionDataToAPI(ctx context.Context, value types.Object) (*client.Reg
 			}
 			thresholdsOut[region] = int(v)
 		}
+	}
+
+	if len(regions) == 0 {
+		switch {
+		case autoSelect && len(thresholdsOut) == 0:
+			regions = normalizeRegions(fallbackRegions)
+			if len(regions) == 0 {
+				regions = []string{defaultAutoSelectRegion}
+			}
+		case len(thresholdsOut) > 0:
+			diags.AddAttributeError(
+				path.Root("region_data").AtName("regions"),
+				"Missing regions",
+				"region_data.regions is required when region_data.thresholds contains entries.",
+			)
+			return nil, false, diags
+		default:
+			diags.AddAttributeError(
+				path.Root("region_data").AtName("regions"),
+				"Missing regions",
+				"region_data.regions is required unless region_data.auto_select is true.",
+			)
+			return nil, false, diags
+		}
+	}
+
+	out := &client.RegionDataRequest{
+		Regions:        regions,
+		RegionsManaged: regionsManaged,
+	}
+	if !data.AutoSelect.IsNull() && !data.AutoSelect.IsUnknown() {
+		manualSelected := !autoSelect
+		out.ManualSelected = &manualSelected
+	}
+	if thresholdsManaged {
 		out.Thresholds = &thresholdsOut
 	}
 
@@ -134,21 +171,31 @@ func validateRegionData(ctx context.Context, data *monitorResourceModel, resp *r
 	}
 
 	var regions []string
-	resp.Diagnostics.Append(regionData.Regions.ElementsAs(ctx, &regions, false)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
+	regionsManaged := !regionData.Regions.IsNull()
 	selected := map[string]struct{}{}
-	for _, raw := range regions {
-		region, ok := normalizeRegionCode(raw)
-		if !ok {
-			continue
+	if regionsManaged {
+		resp.Diagnostics.Append(regionData.Regions.ElementsAs(ctx, &regions, false)...)
+		if resp.Diagnostics.HasError() {
+			return
 		}
-		selected[region] = struct{}{}
+
+		for _, raw := range regions {
+			region, ok := normalizeRegionCode(raw)
+			if !ok {
+				continue
+			}
+			selected[region] = struct{}{}
+		}
 	}
 
 	if regionData.Thresholds.IsNull() || regionData.Thresholds.IsUnknown() {
+		if !regionsManaged && (regionData.AutoSelect.IsNull() || regionData.AutoSelect.IsUnknown() || !regionData.AutoSelect.ValueBool()) {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("region_data").AtName("regions"),
+				"Missing regions",
+				"region_data.regions is required unless region_data.auto_select is true.",
+			)
+		}
 		return
 	}
 
@@ -156,6 +203,25 @@ func validateRegionData(ctx context.Context, data *monitorResourceModel, resp *r
 	resp.Diagnostics.Append(regionData.Thresholds.ElementsAs(ctx, &thresholds, false)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if !regionsManaged {
+		if len(thresholds) > 0 {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("region_data").AtName("regions"),
+				"Missing regions",
+				"region_data.regions is required when region_data.thresholds contains entries.",
+			)
+			return
+		}
+		if regionData.AutoSelect.IsNull() || regionData.AutoSelect.IsUnknown() || !regionData.AutoSelect.ValueBool() {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("region_data").AtName("regions"),
+				"Missing regions",
+				"region_data.regions is required unless region_data.auto_select is true.",
+			)
+			return
+		}
 	}
 
 	for raw, v := range thresholds {
@@ -200,8 +266,9 @@ func regionDataFromTF(ctx context.Context, value types.Object) (*regionDataCompa
 		return nil, ok, diags
 	}
 
-	out := &regionDataComparable{
-		Regions: normalizeRegions(req.Regions),
+	out := &regionDataComparable{}
+	if req.RegionsManaged {
+		out.Regions = normalizeRegions(req.Regions)
 	}
 	if req.ManualSelected != nil {
 		autoSelect := !*req.ManualSelected
@@ -211,6 +278,29 @@ func regionDataFromTF(ctx context.Context, value types.Object) (*regionDataCompa
 		out.Thresholds = normalizeRegionThresholds(*req.Thresholds)
 	}
 	return out, true, diags
+}
+
+func regionDataRegionsManaged(ctx context.Context, value types.Object) bool {
+	_, ok, diags := regionDataRegionsValue(ctx, value)
+	return ok && !diags.HasError()
+}
+
+func regionDataRegionsValue(ctx context.Context, value types.Object) ([]string, bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if value.IsNull() || value.IsUnknown() {
+		return nil, false, diags
+	}
+	var data regionDataTF
+	diags.Append(value.As(ctx, &data, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true})...)
+	if diags.HasError() || data.Regions.IsNull() || data.Regions.IsUnknown() {
+		return nil, false, diags
+	}
+	var regions []string
+	diags.Append(data.Regions.ElementsAs(ctx, &regions, false)...)
+	if diags.HasError() {
+		return nil, false, diags
+	}
+	return normalizeRegions(regions), true, diags
 }
 
 func regionDataAutoSelectValue(ctx context.Context, value types.Object) *bool {
@@ -284,6 +374,7 @@ func cloneUpdateRequestForRegionThresholdClear(req *client.UpdateMonitorRequest)
 	if req.RegionData != nil {
 		regionData := *req.RegionData
 		regionData.Regions = append([]string(nil), req.RegionData.Regions...)
+		regionData.RegionsManaged = req.RegionData.RegionsManaged
 		thresholds := map[string]int{}
 		regionData.Thresholds = &thresholds
 		out.RegionData = &regionData
@@ -487,10 +578,14 @@ func intFromRaw(raw interface{}) (int, bool) {
 }
 
 func flattenRegionDataToState(apiValue interface{}, includeThresholds bool) (types.Object, diag.Diagnostics) {
-	return flattenRegionDataToStateWithAutoSelect(apiValue, includeThresholds, nil)
+	return flattenRegionDataToStateWithManagedFields(apiValue, true, includeThresholds, nil)
 }
 
 func flattenRegionDataToStateWithAutoSelect(apiValue interface{}, includeThresholds bool, fallbackAutoSelect *bool) (types.Object, diag.Diagnostics) {
+	return flattenRegionDataToStateWithManagedFields(apiValue, true, includeThresholds, fallbackAutoSelect)
+}
+
+func flattenRegionDataToStateWithManagedFields(apiValue interface{}, includeRegions, includeThresholds bool, fallbackAutoSelect *bool) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	apiData, ok := normalizeRegionDataFromAPI(apiValue)
 	if !ok {
@@ -500,23 +595,27 @@ func flattenRegionDataToStateWithAutoSelect(apiValue interface{}, includeThresho
 		autoSelect := *fallbackAutoSelect
 		apiData.AutoSelect = &autoSelect
 	}
-	return regionDataObjectValue(apiData, includeThresholds, fallbackAutoSelect != nil)
+	return regionDataObjectValue(apiData, includeRegions, includeThresholds, fallbackAutoSelect != nil)
 }
 
-func regionDataObjectValue(data *regionDataComparable, includeThresholds, includeAutoSelect bool) (types.Object, diag.Diagnostics) {
+func regionDataObjectValue(data *regionDataComparable, includeRegions, includeThresholds, includeAutoSelect bool) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	if data == nil || len(data.Regions) == 0 {
 		return types.ObjectNull(regionDataObjectType().AttrTypes), diags
 	}
 
-	regionValues := make([]attr.Value, 0, len(data.Regions))
-	for _, region := range normalizeRegions(data.Regions) {
-		regionValues = append(regionValues, types.StringValue(region))
-	}
-	regions, d := types.SetValue(types.StringType, regionValues)
-	diags.Append(d...)
-	if diags.HasError() {
-		return types.ObjectNull(regionDataObjectType().AttrTypes), diags
+	regions := types.SetNull(types.StringType)
+	if includeRegions {
+		regionValues := make([]attr.Value, 0, len(data.Regions))
+		for _, region := range normalizeRegions(data.Regions) {
+			regionValues = append(regionValues, types.StringValue(region))
+		}
+		regionSet, d := types.SetValue(types.StringType, regionValues)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(regionDataObjectType().AttrTypes), diags
+		}
+		regions = regionSet
 	}
 
 	thresholds := types.MapNull(types.Int64Type)
@@ -566,7 +665,7 @@ func equalRegionData(want, got *regionDataComparable) bool {
 	if got == nil {
 		return false
 	}
-	if !equalStringSet(want.Regions, got.Regions) {
+	if len(want.Regions) > 0 && !equalStringSet(want.Regions, got.Regions) {
 		return false
 	}
 	if want.AutoSelect != nil {

--- a/internal/provider/monitor_region_data_test.go
+++ b/internal/provider/monitor_region_data_test.go
@@ -91,6 +91,84 @@ func TestExpandRegionDataToAPI_AutoSelectMapsToManualSelected(t *testing.T) {
 	}
 }
 
+func TestExpandRegionDataToAPI_AutoSelectAllowsOmittedRegions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	value := regionDataObjectTestValue(map[string]attr.Value{
+		"auto_select": types.BoolValue(true),
+	})
+
+	got, ok, diags := expandRegionDataToAPI(ctx, value)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !ok || got == nil {
+		t.Fatal("expected region data request")
+	}
+	if got.RegionsManaged {
+		t.Fatal("expected fallback region to stay unmanaged")
+	}
+	if len(got.Regions) != 1 || got.Regions[0] != defaultAutoSelectRegion {
+		t.Fatalf("expected default API carrier region, got %#v", got.Regions)
+	}
+	if got.ManualSelected == nil || *got.ManualSelected {
+		t.Fatalf("expected MANUAL_SELECTED=false, got %#v", got.ManualSelected)
+	}
+}
+
+func TestExpandRegionDataToAPI_AutoSelectUsesFallbackRegions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	value := regionDataObjectTestValue(map[string]attr.Value{
+		"auto_select": types.BoolValue(true),
+	})
+
+	got, ok, diags := expandRegionDataToAPIWithFallback(ctx, value, []string{"eu"})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !ok || got == nil {
+		t.Fatal("expected region data request")
+	}
+	if got.RegionsManaged {
+		t.Fatal("expected fallback region to stay unmanaged")
+	}
+	if len(got.Regions) != 1 || got.Regions[0] != "eu" {
+		t.Fatalf("expected fallback API carrier region, got %#v", got.Regions)
+	}
+}
+
+func TestExpandRegionDataToAPI_RequiresRegionsForManualSelection(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	value := regionDataObjectTestValue(map[string]attr.Value{})
+
+	_, _, diags := expandRegionDataToAPI(ctx, value)
+	if !diags.HasError() {
+		t.Fatal("expected diagnostics when regions are omitted without auto_select=true")
+	}
+}
+
+func TestExpandRegionDataToAPI_RequiresRegionsForThresholdEntries(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	value := regionDataObjectTestValue(map[string]attr.Value{
+		"auto_select": types.BoolValue(true),
+		"thresholds": types.MapValueMust(types.Int64Type, map[string]attr.Value{
+			"na": types.Int64Value(3000),
+		}),
+	})
+
+	_, _, diags := expandRegionDataToAPI(ctx, value)
+	if !diags.HasError() {
+		t.Fatal("expected diagnostics when thresholds are set without regions")
+	}
+}
+
 func TestFlattenRegionDataToState_ObjectResponse(t *testing.T) {
 	t.Parallel()
 
@@ -191,6 +269,33 @@ func TestFlattenRegionDataToState_PreservesManagedAutoSelectFallback(t *testing.
 	}
 }
 
+func TestFlattenRegionDataToState_LeavesUnmanagedRegionsNull(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	apiValue := map[string]interface{}{
+		"REGION": []interface{}{"na"},
+	}
+	autoSelect := true
+
+	state, diags := flattenRegionDataToStateWithManagedFields(apiValue, false, false, &autoSelect)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	var got regionDataTF
+	diags = state.As(ctx, &got, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true})
+	if diags.HasError() {
+		t.Fatalf("unexpected decode diagnostics: %v", diags)
+	}
+	if !got.Regions.IsNull() {
+		t.Fatalf("expected unmanaged regions to remain null, got %#v", got.Regions)
+	}
+	if got.AutoSelect.IsNull() || !got.AutoSelect.ValueBool() {
+		t.Fatalf("expected auto_select=true, got %#v", got.AutoSelect)
+	}
+}
+
 func TestEqualRegionData_IgnoresRegionOrder(t *testing.T) {
 	t.Parallel()
 
@@ -275,6 +380,42 @@ func TestValidateRegionData_AllowsEmptyThresholdsWithGlobalThreshold(t *testing.
 
 	if resp.Diagnostics.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+}
+
+func TestValidateRegionData_AllowsAutoSelectWithoutRegions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	data := &monitorResourceModel{
+		RegionData: regionDataObjectTestValue(map[string]attr.Value{
+			"auto_select": types.BoolValue(true),
+		}),
+		ResponseTimeThreshold: types.Int64Null(),
+	}
+	resp := &resource.ValidateConfigResponse{}
+
+	validateRegionData(ctx, data, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+}
+
+func TestValidateRegionData_RejectsManualSelectionWithoutRegions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	data := &monitorResourceModel{
+		RegionData:            regionDataObjectTestValue(map[string]attr.Value{}),
+		ResponseTimeThreshold: types.Int64Null(),
+	}
+	resp := &resource.ValidateConfigResponse{}
+
+	validateRegionData(ctx, data, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected validation error")
 	}
 }
 

--- a/internal/provider/monitor_resource_acc_test.go
+++ b/internal/provider/monitor_resource_acc_test.go
@@ -1579,14 +1579,12 @@ resource "uptimerobot_monitor" "test" {
   timeout  = 30
 
   region_data = {
-    regions     = ["na"]
     auto_select = true
   }
 }`, name, url),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "region_data.regions.#", "1"),
-					resource.TestCheckTypeSetElemAttr("uptimerobot_monitor.test", "region_data.regions.*", "na"),
 					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "region_data.auto_select", "true"),
+					resource.TestCheckNoResourceAttr("uptimerobot_monitor.test", "region_data.regions.#"),
 				),
 			},
 			{
@@ -1599,7 +1597,6 @@ resource "uptimerobot_monitor" "test" {
   timeout  = 30
 
   region_data = {
-    regions     = ["na"]
     auto_select = true
   }
 }`, name, url),

--- a/internal/provider/monitor_schema.go
+++ b/internal/provider/monitor_schema.go
@@ -423,14 +423,14 @@ Alert contacts assigned to this monitor.
 			"region_data": schema.SingleNestedAttribute{
 				Description: "Multi-region monitor settings. Uses the API v3 regionData object.",
 				MarkdownDescription: "Multi-region monitor settings. Uses the API v3 `regionData` object.\n\n" +
-					"- `regions` selects the active monitoring regions: `na`, `eu`, `as`, `oc`.\n" +
-					"- `auto_select` lets UptimeRobot choose the monitoring region automatically. When omitted or `false`, the configured `regions` are used as manually selected regions.\n" +
+					"- `regions` selects the active monitoring regions: `na`, `eu`, `as`, `oc`. Required unless `auto_select` is `true`.\n" +
+					"- `auto_select` lets UptimeRobot choose the monitoring region automatically. When `true`, `regions` can be omitted and the provider sends the API-required carrier region without managing it. When omitted or `false`, configured `regions` are used as manually selected regions.\n" +
 					"- `thresholds` optionally sets per-region response-time thresholds in milliseconds. Keys must be selected regions and values must be between `0` and `60000`.",
 				Optional: true,
 				Attributes: map[string]schema.Attribute{
 					"regions": schema.SetAttribute{
-						Description: "Active monitoring regions: na (North America), eu (Europe), as (Asia), oc (Oceania).",
-						Required:    true,
+						Description: "Active monitoring regions: na (North America), eu (Europe), as (Asia), oc (Oceania). Required unless auto_select is true.",
+						Optional:    true,
 						ElementType: types.StringType,
 						Validators: []validator.Set{
 							setvalidator.SizeAtLeast(1),
@@ -441,7 +441,7 @@ Alert contacts assigned to this monitor.
 						},
 					},
 					"auto_select": schema.BoolAttribute{
-						Description: "When true, UptimeRobot automatically chooses the monitoring region. When omitted or false, the configured regions are used as manually selected regions.",
+						Description: "When true, UptimeRobot automatically chooses the monitoring region. Regions can be omitted in this mode. When omitted or false, configured regions are used as manually selected regions.",
 						Optional:    true,
 					},
 					"thresholds": schema.MapAttribute{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified that the `regions` parameter for multi-region monitors is required only when `auto_select` is `false`; it can be omitted when `auto_select` is `true`.

* **Examples**
  * Updated monitor region data configuration examples to demonstrate the revised pattern.

* **Tests**
  * Added test coverage for region auto-selection behavior and managed region scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->