### PR TITLE
feat(monitor): expose application_error_retries in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Added structured `region_data` support for `uptimerobot_monitor`, including multi-region `regions` and optional per-region response-time `thresholds`.
+- Added `config.application_error_retries` support for `uptimerobot_monitor` HTTP, KEYWORD, and API monitors, including `0..3` validation, import/read/update round-tripping, and explicit `null` clearing to restore the API default.
 
 ### Changed
 

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -383,9 +383,9 @@ For `HEARTBEAT` monitors, omit `url`. UptimeRobot generates the heartbeat URL an
 ```terraform
 # Set specific days for SSL expiration period days
 resource "uptimerobot_monitor" "set_days" {
-  name     = "DNS set days"
-  type     = "DNS"
-  url      = "example.com"
+  name     = "HTTP SSL set days"
+  type     = "HTTP"
+  url      = "https://example.com"
   interval = 300
 
   config = {
@@ -407,9 +407,9 @@ resource "uptimerobot_monitor" "preserve" {
 
 # Clear days on server - send an explicit empty list
 resource "uptimerobot_monitor" "clear" {
-  name     = "DNS clear"
-  type     = "DNS"
-  url      = "example.com"
+  name     = "HTTP SSL clear"
+  type     = "HTTP"
+  url      = "https://example.com"
   interval = 300
 
   config = {
@@ -419,9 +419,9 @@ resource "uptimerobot_monitor" "clear" {
 
 # UI-managed SSL days. Ignore drift if management is preferred via dashboard
 resource "uptimerobot_monitor" "ui_driven_ssl" {
-  name     = "UI-driven DNS SSL days"
-  type     = "DNS"
-  url      = "example.com"
+  name     = "UI-driven HTTP SSL days"
+  type     = "HTTP"
+  url      = "https://example.com"
   interval = 300
 
   lifecycle {
@@ -482,6 +482,18 @@ resource "uptimerobot_monitor" "ipv6_only_port" {
 
   config = {
     ip_version = "ipv6Only"
+  }
+}
+
+# HTTP monitor with explicit application-error retry budget (0..3). Set to null to clear.
+resource "uptimerobot_monitor" "tight_app_retry" {
+  name     = "Strict app-error retries"
+  type     = "HTTP"
+  url      = "https://example.com/health"
+  interval = 300
+
+  config = {
+    application_error_retries = 0
   }
 }
 
@@ -662,6 +674,7 @@ terraform import 'uptimerobot_monitor.monitors["www_production"]' 800123456
 - `ssl_expiration_period_days = []` → **clear** days on the server; non-empty list sets exactly those days (max 10).
 - Removing `ip_version` from a managed `config` block clears remote `ipVersion` (reverts to API default dual-stack behavior).
 - Setting `ip_version = ""` also acts as an explicit clear/default signal.
+- Omit `application_error_retries` to preserve the remote value; set `application_error_retries = null` to clear the remote override so the API applies its own default. Connection errors always retry (this setting only governs application/content failures).
 
 **Validation**
 - For `type = "DNS"` on create, `config` is required (use `config = {}` for defaults).
@@ -671,6 +684,7 @@ terraform import 'uptimerobot_monitor.monitors["www_production"]' 800123456
 - `ip_version` is only valid for HTTP/KEYWORD/PING/PORT/API monitors.
 - `config.api_assertions` is only valid for API monitors.
 - `config.udp` is only valid for UDP monitors.
+- `config.application_error_retries` is only valid for HTTP/KEYWORD/API monitors and must be 0..3.
 - Top-level `ssl_expiration_reminder` and `check_ssl_errors` are valid for HTTPS URLs on HTTP/KEYWORD/API monitors. (see [below for nested schema](#nestedatt--config))
 - `custom_http_headers` (Map of String) Custom HTTP headers as key:value. **Keys are case-insensitive.** The provider normalizes keys to **lower-case** on read and during planning to avoid false diffs. Tip: add keys in lower-case (e.g., `"content-type" = "application/json"`).
 - `domain_expiration_reminder` (Boolean) Whether to enable domain expiration reminders
@@ -736,6 +750,11 @@ Required:
 Optional:
 
 - `api_assertions` (Attributes) API monitor assertion rules. Supported only for type=API. (see [below for nested schema](#nestedatt--config--api_assertions))
+- `application_error_retries` (Number) Number of additional retries before declaring an application or content failure (response status, body assertion, keyword, etc.) for `HTTP`, `KEYWORD`, and `API` monitors. Connection errors (DNS, TCP, TLS, timeouts) are unaffected and always retry.
+
+- Allowed range: `0..3`.
+- Omit the attribute → **preserve** the remote value.
+- Set to `null` → **clear** the override; the API applies its own default.
 - `dns_records` (Attributes) DNS record lists for DNS monitors. If present on non-DNS types, validation fails. (see [below for nested schema](#nestedatt--config--dns_records))
 - `ip_version` (String) IP family selection for HTTP/KEYWORD/PING/PORT/API monitors. Use ipv4Only or ipv6Only. Set empty string to clear and fall back to API default behavior.
 - `ssl_expiration_period_days` (Set of Number) Reminder days before SSL expiry (0..365). Max 10 items.

--- a/examples/resources/uptimerobot_monitor/config.tf
+++ b/examples/resources/uptimerobot_monitor/config.tf
@@ -1,8 +1,8 @@
 # Set specific days for SSL expiration period days
 resource "uptimerobot_monitor" "set_days" {
-  name     = "DNS set days"
-  type     = "DNS"
-  url      = "example.com"
+  name     = "HTTP SSL set days"
+  type     = "HTTP"
+  url      = "https://example.com"
   interval = 300
 
   config = {
@@ -24,9 +24,9 @@ resource "uptimerobot_monitor" "preserve" {
 
 # Clear days on server - send an explicit empty list
 resource "uptimerobot_monitor" "clear" {
-  name     = "DNS clear"
-  type     = "DNS"
-  url      = "example.com"
+  name     = "HTTP SSL clear"
+  type     = "HTTP"
+  url      = "https://example.com"
   interval = 300
 
   config = {
@@ -36,9 +36,9 @@ resource "uptimerobot_monitor" "clear" {
 
 # UI-managed SSL days. Ignore drift if management is preferred via dashboard
 resource "uptimerobot_monitor" "ui_driven_ssl" {
-  name     = "UI-driven DNS SSL days"
-  type     = "DNS"
-  url      = "example.com"
+  name     = "UI-driven HTTP SSL days"
+  type     = "HTTP"
+  url      = "https://example.com"
   interval = 300
 
   lifecycle {
@@ -99,6 +99,18 @@ resource "uptimerobot_monitor" "ipv6_only_port" {
 
   config = {
     ip_version = "ipv6Only"
+  }
+}
+
+# HTTP monitor with explicit application-error retry budget (0..3). Set to null to clear.
+resource "uptimerobot_monitor" "tight_app_retry" {
+  name     = "Strict app-error retries"
+  type     = "HTTP"
+  url      = "https://example.com/health"
+  interval = 300
+
+  config = {
+    application_error_retries = 0
   }
 }
 

--- a/internal/client/monitor.go
+++ b/internal/client/monitor.go
@@ -171,6 +171,7 @@ type MonitorConfig struct {
 	APIAssertions           *APIMonitorAssertions `json:"apiAssertions,omitempty"`
 	UDP                     *UDPMonitorConfig     `json:"udp,omitempty"`
 	IPVersion               *string               `json:"ipVersion,omitempty"`
+	ApplicationErrorRetries json.RawMessage       `json:"applicationErrorRetries,omitempty"`
 }
 
 type UDPMonitorConfig struct {

--- a/internal/provider/monitor_application_error_retries_test.go
+++ b/internal/provider/monitor_application_error_retries_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/uptimerobot/terraform-provider-uptimerobot/internal/client"
@@ -216,6 +217,36 @@ func TestExpandConfigToAPI_ApplicationErrorRetriesUnknownIsOmitted(t *testing.T)
 	}
 }
 
+func TestConfigNullIfOmitted_ApplicationErrorRetriesMissingStaysUnknown(t *testing.T) {
+	t.Parallel()
+
+	partialConfig := types.ObjectValueMust(
+		map[string]attr.Type{
+			"ssl_expiration_period_days": types.SetType{ElemType: types.Int64Type},
+		},
+		map[string]attr.Value{
+			"ssl_expiration_period_days": types.SetNull(types.Int64Type),
+		},
+	)
+
+	resp := &planmodifier.ObjectResponse{}
+	configNullIfOmitted{}.PlanModifyObject(context.Background(), planmodifier.ObjectRequest{
+		ConfigValue: partialConfig,
+		StateValue:  types.ObjectNull(configObjectType().AttrTypes),
+	}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
+	}
+
+	retries, ok := resp.PlanValue.Attributes()["application_error_retries"].(types.Int64)
+	if !ok {
+		t.Fatalf("expected application_error_retries Int64 value, got %#v", resp.PlanValue.Attributes()["application_error_retries"])
+	}
+	if !retries.IsUnknown() {
+		t.Fatalf("expected missing application_error_retries to stay unknown, got %#v", retries)
+	}
+}
+
 func TestFlattenConfigToState_ApplicationErrorRetriesRoundTrips(t *testing.T) {
 	t.Parallel()
 
@@ -275,7 +306,7 @@ func TestFlattenConfigToState_ApplicationErrorRetriesNullFromAPIBecomesNull(t *t
 	}
 }
 
-func TestFlattenConfigToState_ApplicationErrorRetriesAbsentFromAPIBecomesNull(t *testing.T) {
+func TestFlattenConfigToState_ApplicationErrorRetriesAbsentFromAPIPreservesPriorValue(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -298,8 +329,39 @@ func TestFlattenConfigToState_ApplicationErrorRetriesAbsentFromAPIBecomesNull(t 
 	if d := stateObj.As(ctx, &cfg, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true}); d.HasError() {
 		t.Fatalf("unexpected object decode diagnostics: %+v", d)
 	}
+	if cfg.ApplicationErrorRetries.IsNull() || cfg.ApplicationErrorRetries.IsUnknown() {
+		t.Fatalf("expected application_error_retries to be preserved when API omits")
+	}
+	if cfg.ApplicationErrorRetries.ValueInt64() != 3 {
+		t.Fatalf("expected application_error_retries=3 when API omits, got %d", cfg.ApplicationErrorRetries.ValueInt64())
+	}
+}
+
+func TestFlattenConfigToState_ApplicationErrorRetriesAbsentFromAPIWithoutPriorValueBecomesNull(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	prev := types.ObjectValueMust(configObjectType().AttrTypes, map[string]attr.Value{
+		"ssl_expiration_period_days": types.SetNull(types.Int64Type),
+		"dns_records":                types.ObjectNull(dnsRecordsObjectType().AttrTypes),
+		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
+		"ip_version":                 types.StringNull(),
+		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
+	})
+
+	apiCfg := &client.MonitorConfig{}
+	stateObj, diags := flattenConfigToState(ctx, true, prev, apiCfg)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+
+	var cfg configTF
+	if d := stateObj.As(ctx, &cfg, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true}); d.HasError() {
+		t.Fatalf("unexpected object decode diagnostics: %+v", d)
+	}
 	if !cfg.ApplicationErrorRetries.IsNull() {
-		t.Fatalf("expected application_error_retries null when API omits, got %d", cfg.ApplicationErrorRetries.ValueInt64())
+		t.Fatalf("expected application_error_retries null when API omits and no prior value exists, got %d", cfg.ApplicationErrorRetries.ValueInt64())
 	}
 }
 

--- a/internal/provider/monitor_application_error_retries_test.go
+++ b/internal/provider/monitor_application_error_retries_test.go
@@ -1,0 +1,430 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/uptimerobot/terraform-provider-uptimerobot/internal/client"
+)
+
+func TestValidateConfigApplicationErrorRetries_AllowsHTTP(t *testing.T) {
+	t.Parallel()
+
+	resp := &resource.ValidateConfigResponse{}
+	validateConfigApplicationErrorRetries(MonitorTypeHTTP, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected no errors for HTTP monitor, got: %v", resp.Diagnostics)
+	}
+}
+
+func TestValidateConfigApplicationErrorRetries_AllowsKEYWORD(t *testing.T) {
+	t.Parallel()
+
+	resp := &resource.ValidateConfigResponse{}
+	validateConfigApplicationErrorRetries(MonitorTypeKEYWORD, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected no errors for KEYWORD monitor, got: %v", resp.Diagnostics)
+	}
+}
+
+func TestValidateConfigApplicationErrorRetries_AllowsAPI(t *testing.T) {
+	t.Parallel()
+
+	resp := &resource.ValidateConfigResponse{}
+	validateConfigApplicationErrorRetries(MonitorTypeAPI, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected no errors for API monitor, got: %v", resp.Diagnostics)
+	}
+}
+
+func TestValidateConfigApplicationErrorRetries_RejectsUnsupportedTypes(t *testing.T) {
+	t.Parallel()
+
+	for _, typ := range []string{
+		MonitorTypePING,
+		MonitorTypePORT,
+		MonitorTypeDNS,
+		MonitorTypeHEARTBEAT,
+		MonitorTypeUDP,
+	} {
+		typ := typ
+		t.Run(typ, func(t *testing.T) {
+			resp := &resource.ValidateConfigResponse{}
+			validateConfigApplicationErrorRetries(typ, resp)
+			if !resp.Diagnostics.HasError() {
+				t.Fatalf("expected error for monitor type %q", typ)
+			}
+		})
+	}
+}
+
+func TestValidateConfig_ApplicationErrorRetriesOnUnsupportedTypeRejected(t *testing.T) {
+	t.Parallel()
+
+	resp := &resource.ValidateConfigResponse{}
+	data := &monitorResourceModel{
+		Config: types.ObjectValueMust(configObjectType().AttrTypes, map[string]attr.Value{
+			"ssl_expiration_period_days": types.SetNull(types.Int64Type),
+			"dns_records":                types.ObjectNull(dnsRecordsObjectType().AttrTypes),
+			"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
+			"ip_version":                 types.StringNull(),
+			"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+			"application_error_retries":  types.Int64Value(2),
+		}),
+	}
+
+	validateConfig(context.TODO(), MonitorTypePING, data, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected validation error for application_error_retries on PING")
+	}
+	found := false
+	for _, d := range resp.Diagnostics.Errors() {
+		if strings.Contains(d.Summary(), "application_error_retries") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected diagnostic mentioning application_error_retries, got: %v", resp.Diagnostics)
+	}
+}
+
+func TestExpandConfigToAPI_ApplicationErrorRetriesValueIsSent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cfg := types.ObjectValueMust(configObjectType().AttrTypes, map[string]attr.Value{
+		"ssl_expiration_period_days": types.SetNull(types.Int64Type),
+		"dns_records":                types.ObjectNull(dnsRecordsObjectType().AttrTypes),
+		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
+		"ip_version":                 types.StringNull(),
+		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Value(3),
+	})
+
+	out, touched, diags := expandConfigToAPI(ctx, cfg)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+	if !touched {
+		t.Fatalf("expected touched=true when application_error_retries is set")
+	}
+	if out == nil || len(out.ApplicationErrorRetries) == 0 {
+		t.Fatalf("expected ApplicationErrorRetries raw to be set")
+	}
+	if string(out.ApplicationErrorRetries) != "3" {
+		t.Fatalf("expected raw payload \"3\", got %q", string(out.ApplicationErrorRetries))
+	}
+
+	body, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	v, ok := decoded["applicationErrorRetries"]
+	if !ok {
+		t.Fatalf("expected applicationErrorRetries key in JSON, got %v", decoded)
+	}
+	if num, _ := v.(float64); int(num) != 3 {
+		t.Fatalf("expected JSON value 3, got %v", v)
+	}
+}
+
+func TestExpandConfigToAPI_ApplicationErrorRetriesNullSendsJSONNull(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cfg := types.ObjectValueMust(configObjectType().AttrTypes, map[string]attr.Value{
+		"ssl_expiration_period_days": types.SetNull(types.Int64Type),
+		"dns_records":                types.ObjectNull(dnsRecordsObjectType().AttrTypes),
+		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
+		"ip_version":                 types.StringNull(),
+		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Null(),
+	})
+
+	out, touched, diags := expandConfigToAPI(ctx, cfg)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+	if !touched {
+		t.Fatalf("expected touched=true for explicit null clear")
+	}
+	if string(out.ApplicationErrorRetries) != "null" {
+		t.Fatalf("expected raw payload \"null\", got %q", string(out.ApplicationErrorRetries))
+	}
+
+	body, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	v, ok := decoded["applicationErrorRetries"]
+	if !ok {
+		t.Fatalf("expected applicationErrorRetries key in JSON for explicit null clear, got %v", decoded)
+	}
+	if v != nil {
+		t.Fatalf("expected JSON null, got %v", v)
+	}
+}
+
+func TestExpandConfigToAPI_ApplicationErrorRetriesUnknownIsOmitted(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cfg := types.ObjectValueMust(configObjectType().AttrTypes, map[string]attr.Value{
+		"ssl_expiration_period_days": types.SetNull(types.Int64Type),
+		"dns_records":                types.ObjectNull(dnsRecordsObjectType().AttrTypes),
+		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
+		"ip_version":                 types.StringNull(),
+		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
+	})
+
+	out, touched, diags := expandConfigToAPI(ctx, cfg)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+	if touched {
+		t.Fatalf("expected touched=false when application_error_retries is Unknown (omitted on create)")
+	}
+
+	body, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := decoded["applicationErrorRetries"]; ok {
+		t.Fatalf("expected applicationErrorRetries to be omitted from JSON, got %v", decoded)
+	}
+}
+
+func TestFlattenConfigToState_ApplicationErrorRetriesRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	prev := types.ObjectValueMust(configObjectType().AttrTypes, map[string]attr.Value{
+		"ssl_expiration_period_days": types.SetNull(types.Int64Type),
+		"dns_records":                types.ObjectNull(dnsRecordsObjectType().AttrTypes),
+		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
+		"ip_version":                 types.StringNull(),
+		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
+	})
+
+	apiCfg := &client.MonitorConfig{ApplicationErrorRetries: json.RawMessage("2")}
+	stateObj, diags := flattenConfigToState(ctx, true, prev, apiCfg)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+
+	var cfg configTF
+	if d := stateObj.As(ctx, &cfg, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true}); d.HasError() {
+		t.Fatalf("unexpected object decode diagnostics: %+v", d)
+	}
+	if cfg.ApplicationErrorRetries.IsNull() || cfg.ApplicationErrorRetries.IsUnknown() {
+		t.Fatalf("expected application_error_retries to be set from API")
+	}
+	if cfg.ApplicationErrorRetries.ValueInt64() != 2 {
+		t.Fatalf("expected application_error_retries=2, got %d", cfg.ApplicationErrorRetries.ValueInt64())
+	}
+}
+
+func TestFlattenConfigToState_ApplicationErrorRetriesNullFromAPIBecomesNull(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	prev := types.ObjectValueMust(configObjectType().AttrTypes, map[string]attr.Value{
+		"ssl_expiration_period_days": types.SetNull(types.Int64Type),
+		"dns_records":                types.ObjectNull(dnsRecordsObjectType().AttrTypes),
+		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
+		"ip_version":                 types.StringNull(),
+		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Value(3),
+	})
+
+	apiCfg := &client.MonitorConfig{ApplicationErrorRetries: json.RawMessage("null")}
+	stateObj, diags := flattenConfigToState(ctx, true, prev, apiCfg)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+
+	var cfg configTF
+	if d := stateObj.As(ctx, &cfg, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true}); d.HasError() {
+		t.Fatalf("unexpected object decode diagnostics: %+v", d)
+	}
+	if !cfg.ApplicationErrorRetries.IsNull() {
+		t.Fatalf("expected application_error_retries to be null when API returns null, got %d", cfg.ApplicationErrorRetries.ValueInt64())
+	}
+}
+
+func TestFlattenConfigToState_ApplicationErrorRetriesAbsentFromAPIBecomesNull(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	prev := types.ObjectValueMust(configObjectType().AttrTypes, map[string]attr.Value{
+		"ssl_expiration_period_days": types.SetNull(types.Int64Type),
+		"dns_records":                types.ObjectNull(dnsRecordsObjectType().AttrTypes),
+		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
+		"ip_version":                 types.StringNull(),
+		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Value(3),
+	})
+
+	apiCfg := &client.MonitorConfig{}
+	stateObj, diags := flattenConfigToState(ctx, true, prev, apiCfg)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+
+	var cfg configTF
+	if d := stateObj.As(ctx, &cfg, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true}); d.HasError() {
+		t.Fatalf("unexpected object decode diagnostics: %+v", d)
+	}
+	if !cfg.ApplicationErrorRetries.IsNull() {
+		t.Fatalf("expected application_error_retries null when API omits, got %d", cfg.ApplicationErrorRetries.ValueInt64())
+	}
+}
+
+func TestWantFromCreateReq_IncludesApplicationErrorRetriesWhenExplicit(t *testing.T) {
+	t.Parallel()
+
+	want := wantFromCreateReq(&client.CreateMonitorRequest{
+		Type: client.MonitorTypeHTTP,
+		Config: &client.MonitorConfig{
+			ApplicationErrorRetries: json.RawMessage("2"),
+		},
+	})
+
+	if want.ApplicationErrorRetries == nil {
+		t.Fatalf("expected comparable ApplicationErrorRetries to be set")
+	}
+	if *want.ApplicationErrorRetries != 2 {
+		t.Fatalf("expected 2, got %d", *want.ApplicationErrorRetries)
+	}
+}
+
+func TestWantFromUpdateReq_ExpectsApplicationErrorRetriesUnsetWhenNullSent(t *testing.T) {
+	t.Parallel()
+
+	want := wantFromUpdateReq(&client.UpdateMonitorRequest{
+		Type: client.MonitorTypeHTTP,
+		Config: &client.MonitorConfig{
+			ApplicationErrorRetries: json.RawMessage("null"),
+		},
+	})
+
+	if !want.ExpectApplicationErrorRetriesUnset {
+		t.Fatalf("expected ExpectApplicationErrorRetriesUnset=true when null is sent")
+	}
+	if want.ApplicationErrorRetries != nil {
+		t.Fatalf("expected ApplicationErrorRetries to be nil when null is sent, got %d", *want.ApplicationErrorRetries)
+	}
+}
+
+func TestBuildComparableFromAPI_DecodesApplicationErrorRetries(t *testing.T) {
+	t.Parallel()
+
+	got := buildComparableFromAPI(&client.Monitor{
+		Type: string(client.MonitorTypeHTTP),
+		Config: &client.MonitorConfig{
+			ApplicationErrorRetries: json.RawMessage("1"),
+		},
+	})
+
+	if got.ApplicationErrorRetries == nil || *got.ApplicationErrorRetries != 1 {
+		t.Fatalf("expected ApplicationErrorRetries=1 from API, got %#v", got.ApplicationErrorRetries)
+	}
+}
+
+func TestEqualComparable_RequiresApplicationErrorRetriesMatch(t *testing.T) {
+	t.Parallel()
+
+	two := int64(2)
+	three := int64(3)
+	want := monComparable{ApplicationErrorRetries: &two}
+
+	if equalComparable(want, monComparable{ApplicationErrorRetries: &three}) {
+		t.Fatalf("expected mismatch for different retry counts")
+	}
+	if !equalComparable(want, monComparable{ApplicationErrorRetries: &two}) {
+		t.Fatalf("expected match for identical retry counts")
+	}
+}
+
+func TestEqualComparable_RequiresApplicationErrorRetriesUnsetWhenExpected(t *testing.T) {
+	t.Parallel()
+
+	v := int64(2)
+	want := monComparable{ExpectApplicationErrorRetriesUnset: true}
+
+	if equalComparable(want, monComparable{ApplicationErrorRetries: &v}) {
+		t.Fatalf("expected mismatch when API still returns a value")
+	}
+	if !equalComparable(want, monComparable{ApplicationErrorRetries: nil}) {
+		t.Fatalf("expected match when value is unset on API side")
+	}
+}
+
+func TestMonitorReadStabilizationWant_IncludesApplicationErrorRetries(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	want := monitorReadStabilizationWant(ctx, monitorResourceModel{
+		Config: types.ObjectValueMust(configObjectType().AttrTypes, map[string]attr.Value{
+			"ssl_expiration_period_days": types.SetNull(types.Int64Type),
+			"dns_records":                types.ObjectNull(dnsRecordsObjectType().AttrTypes),
+			"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
+			"ip_version":                 types.StringNull(),
+			"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+			"application_error_retries":  types.Int64Value(2),
+		}),
+	})
+
+	if want.ApplicationErrorRetries == nil || *want.ApplicationErrorRetries != 2 {
+		t.Fatalf("expected read stabilization to assert application_error_retries=2, got %#v", want.ApplicationErrorRetries)
+	}
+	if !hasMonitorReadStabilizationAssertions(want) {
+		t.Fatalf("expected application_error_retries to require read stabilization")
+	}
+}
+
+func TestMonitorReadStabilizationWant_ExpectsApplicationErrorRetriesUnset(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	want := monitorReadStabilizationWant(ctx, monitorResourceModel{
+		Config: types.ObjectValueMust(configObjectType().AttrTypes, map[string]attr.Value{
+			"ssl_expiration_period_days": types.SetNull(types.Int64Type),
+			"dns_records":                types.ObjectNull(dnsRecordsObjectType().AttrTypes),
+			"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
+			"ip_version":                 types.StringNull(),
+			"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+			"application_error_retries":  types.Int64Null(),
+		}),
+	})
+
+	if !want.ExpectApplicationErrorRetriesUnset {
+		t.Fatalf("expected read stabilization to assert application_error_retries unset")
+	}
+	if !hasMonitorReadStabilizationAssertions(want) {
+		t.Fatalf("expected application_error_retries unset to require read stabilization")
+	}
+}

--- a/internal/provider/monitor_compare.go
+++ b/internal/provider/monitor_compare.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"bytes"
 	"encoding/json"
 	"html"
 	"sort"
@@ -40,13 +41,15 @@ type monComparable struct {
 	MaintenanceWindowIDs []int64
 	skipMWIDsCompare     bool
 	// Config children which we manage
-	SSLExpirationPeriodDays []int64
-	DNSRecords              map[string][]string
-	IPVersion               *string
-	ExpectIPVersionUnset    bool
-	APIAssertions           *apiAssertionsComparable
-	UDPConfig               *udpComparable
-	AssignedAlertContacts   []alertContactComparable
+	SSLExpirationPeriodDays            []int64
+	DNSRecords                         map[string][]string
+	IPVersion                          *string
+	ExpectIPVersionUnset               bool
+	ApplicationErrorRetries            *int64
+	ExpectApplicationErrorRetriesUnset bool
+	APIAssertions                      *apiAssertionsComparable
+	UDPConfig                          *udpComparable
+	AssignedAlertContacts              []alertContactComparable
 }
 
 type apiAssertionsComparable struct {
@@ -232,6 +235,9 @@ func wantFromCreateReq(req *client.CreateMonitorRequest) monComparable {
 	if req.Config != nil && req.Config.IPVersion == nil {
 		c.ExpectIPVersionUnset = true
 	}
+	if req.Config != nil {
+		applyApplicationErrorRetriesExpectation(&c, req.Config.ApplicationErrorRetries)
+	}
 	if req.Config != nil && req.Config.APIAssertions != nil {
 		c.APIAssertions = normalizeAPIAssertions(req.Config.APIAssertions)
 	}
@@ -394,6 +400,9 @@ func wantFromUpdateReq(req *client.UpdateMonitorRequest) monComparable {
 	if req.Config != nil && req.Config.IPVersion == nil {
 		c.ExpectIPVersionUnset = true
 	}
+	if req.Config != nil {
+		applyApplicationErrorRetriesExpectation(&c, req.Config.ApplicationErrorRetries)
+	}
 	if req.Config != nil && req.Config.APIAssertions != nil {
 		c.APIAssertions = normalizeAPIAssertions(req.Config.APIAssertions)
 	}
@@ -555,6 +564,9 @@ func buildComparableFromAPI(m *client.Monitor) monComparable {
 			if normalized, keep := normalizeIPVersionForAPI(*m.Config.IPVersion); keep {
 				c.IPVersion = &normalized
 			}
+		}
+		if v, ok := decodeApplicationErrorRetries(m.Config.ApplicationErrorRetries); ok {
+			c.ApplicationErrorRetries = &v
 		}
 		if m.Config.APIAssertions != nil {
 			c.APIAssertions = normalizeAPIAssertions(m.Config.APIAssertions)
@@ -843,6 +855,12 @@ func equalComparable(want, got monComparable) bool {
 	if want.ExpectIPVersionUnset && got.IPVersion != nil {
 		return false
 	}
+	if want.ApplicationErrorRetries != nil && (got.ApplicationErrorRetries == nil || *want.ApplicationErrorRetries != *got.ApplicationErrorRetries) {
+		return false
+	}
+	if want.ExpectApplicationErrorRetriesUnset && got.ApplicationErrorRetries != nil {
+		return false
+	}
 	if want.APIAssertions != nil && !equalAPIAssertions(want.APIAssertions, got.APIAssertions) {
 		return false
 	}
@@ -965,6 +983,12 @@ func fieldsStillDifferent(want, got monComparable) []string {
 	if want.ExpectIPVersionUnset && got.IPVersion != nil {
 		f = append(f, "config.ip_version")
 	}
+	if want.ApplicationErrorRetries != nil && (got.ApplicationErrorRetries == nil || *want.ApplicationErrorRetries != *got.ApplicationErrorRetries) {
+		f = append(f, "config.application_error_retries")
+	}
+	if want.ExpectApplicationErrorRetriesUnset && got.ApplicationErrorRetries != nil {
+		f = append(f, "config.application_error_retries")
+	}
 	if want.APIAssertions != nil && !equalAPIAssertions(want.APIAssertions, got.APIAssertions) {
 		f = append(f, "config.api_assertions")
 	}
@@ -1048,6 +1072,33 @@ func normalizeUDPConfig(in *client.UDPMonitorConfig) *udpComparable {
 		out.PacketLossThreshold = &v
 	}
 	return out
+}
+
+func decodeApplicationErrorRetries(raw json.RawMessage) (int64, bool) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return 0, false
+	}
+	var v int64
+	if err := json.Unmarshal(trimmed, &v); err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+func applyApplicationErrorRetriesExpectation(c *monComparable, raw json.RawMessage) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		c.ExpectApplicationErrorRetriesUnset = true
+		return
+	}
+	var v int64
+	if err := json.Unmarshal(trimmed, &v); err == nil {
+		c.ApplicationErrorRetries = &v
+	}
 }
 
 func equalAPIAssertions(want, got *apiAssertionsComparable) bool {

--- a/internal/provider/monitor_crud_read.go
+++ b/internal/provider/monitor_crud_read.go
@@ -403,6 +403,7 @@ func monitorReadStabilizationWant(ctx context.Context, state monitorResourceMode
 			if cfg.APIAssertions != nil {
 				want.APIAssertions = normalizeAPIAssertions(cfg.APIAssertions)
 			}
+			applyApplicationErrorRetriesExpectation(&want, cfg.ApplicationErrorRetries)
 		}
 	}
 
@@ -453,6 +454,8 @@ func hasMonitorReadStabilizationAssertions(want monComparable) bool {
 		want.RegionalData != nil ||
 		want.DNSRecords != nil ||
 		want.SSLExpirationPeriodDays != nil ||
+		want.ApplicationErrorRetries != nil ||
+		want.ExpectApplicationErrorRetriesUnset ||
 		want.APIAssertions != nil {
 		return true
 	}

--- a/internal/provider/monitor_ip_version_test.go
+++ b/internal/provider/monitor_ip_version_test.go
@@ -100,6 +100,7 @@ func TestExpandConfigToAPI_IPVersionIPv4OnlyIsSent(t *testing.T) {
 		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 		"ip_version":                 types.StringValue(IPVersionIPv4Only),
 		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
 	})
 
 	out, touched, diags := expandConfigToAPI(ctx, cfg)
@@ -127,6 +128,7 @@ func TestExpandConfigToAPI_IPVersionEmptyStringIsIgnored(t *testing.T) {
 		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 		"ip_version":                 types.StringValue(""),
 		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
 	})
 
 	out, touched, diags := expandConfigToAPI(ctx, cfg)
@@ -154,6 +156,7 @@ func TestFlattenConfigToState_IPVersionIPv6OnlyRoundTrips(t *testing.T) {
 		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 		"ip_version":                 types.StringNull(),
 		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
 	})
 
 	ipVersion := IPVersionIPv6Only
@@ -185,6 +188,7 @@ func TestFlattenConfigToState_IPVersionInvalidFromAPIBecomesNull(t *testing.T) {
 		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 		"ip_version":                 types.StringNull(),
 		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
 	})
 
 	invalid := "invalidValue"
@@ -213,6 +217,7 @@ func TestFlattenConfigToState_IPVersionEmptyStringSentinelIsPreservedWhenAPIOmit
 		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 		"ip_version":                 types.StringValue(""),
 		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
 	})
 
 	stateObj, diags := flattenConfigToState(ctx, true, prev, &client.MonitorConfig{})
@@ -245,6 +250,7 @@ func TestShouldClearIPVersionOnUpdate_TransitionToUnset(t *testing.T) {
 		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 		"ip_version":                 types.StringNull(),
 		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
 	})
 	prevCfg := types.ObjectValueMust(configObjectType().AttrTypes, map[string]attr.Value{
 		"ssl_expiration_period_days": types.SetNull(types.Int64Type),
@@ -252,6 +258,7 @@ func TestShouldClearIPVersionOnUpdate_TransitionToUnset(t *testing.T) {
 		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 		"ip_version":                 types.StringValue(IPVersionIPv4Only),
 		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
 	})
 
 	clearIPVersion, diags := shouldClearIPVersionOnUpdate(context.Background(), planCfg, prevCfg)
@@ -272,6 +279,7 @@ func TestShouldClearIPVersionOnUpdate_NoTransition(t *testing.T) {
 		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 		"ip_version":                 types.StringValue(IPVersionIPv6Only),
 		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
 	})
 	prevCfg := types.ObjectValueMust(configObjectType().AttrTypes, map[string]attr.Value{
 		"ssl_expiration_period_days": types.SetNull(types.Int64Type),
@@ -279,6 +287,7 @@ func TestShouldClearIPVersionOnUpdate_NoTransition(t *testing.T) {
 		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 		"ip_version":                 types.StringValue(IPVersionIPv4Only),
 		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
 	})
 
 	clearIPVersion, diags := shouldClearIPVersionOnUpdate(context.Background(), planCfg, prevCfg)
@@ -299,6 +308,7 @@ func TestShouldClearIPVersionOnUpdate_TransitionToEmptyString(t *testing.T) {
 		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 		"ip_version":                 types.StringValue(""),
 		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
 	})
 	prevCfg := types.ObjectValueMust(configObjectType().AttrTypes, map[string]attr.Value{
 		"ssl_expiration_period_days": types.SetNull(types.Int64Type),
@@ -306,6 +316,7 @@ func TestShouldClearIPVersionOnUpdate_TransitionToEmptyString(t *testing.T) {
 		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 		"ip_version":                 types.StringValue(IPVersionIPv4Only),
 		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
 	})
 
 	clearIPVersion, diags := shouldClearIPVersionOnUpdate(context.Background(), planCfg, prevCfg)
@@ -325,10 +336,11 @@ func TestConfigPayloadForIPVersionClear_PreservesOtherFields(t *testing.T) {
 			types.Int64Value(7),
 			types.Int64Value(30),
 		}),
-		"dns_records":    types.ObjectNull(dnsRecordsObjectType().AttrTypes),
-		"api_assertions": types.ObjectNull(apiAssertionsObjectType().AttrTypes),
-		"ip_version":     types.StringValue(IPVersionIPv4Only),
-		"udp":            types.ObjectNull(udpObjectType().AttrTypes),
+		"dns_records":               types.ObjectNull(dnsRecordsObjectType().AttrTypes),
+		"api_assertions":            types.ObjectNull(apiAssertionsObjectType().AttrTypes),
+		"ip_version":                types.StringValue(IPVersionIPv4Only),
+		"udp":                       types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries": types.Int64Unknown(),
 	})
 
 	cfg, diags := configPayloadForIPVersionClear(context.Background(), prevCfg)

--- a/internal/provider/monitor_model.go
+++ b/internal/provider/monitor_model.go
@@ -73,6 +73,7 @@ type configTF struct {
 	IPVersion               types.String `tfsdk:"ip_version"`
 	APIAssertions           types.Object `tfsdk:"api_assertions"`
 	UDP                     types.Object `tfsdk:"udp"`
+	ApplicationErrorRetries types.Int64  `tfsdk:"application_error_retries"`
 }
 
 type apiAssertionsTF struct {
@@ -175,6 +176,7 @@ func configObjectType() types.ObjectType {
 			"ip_version":                 types.StringType,
 			"api_assertions":             apiAssertionsObjectType(),
 			"udp":                        udpObjectType(),
+			"application_error_retries":  types.Int64Type,
 		},
 	}
 }

--- a/internal/provider/monitor_plan_modify.go
+++ b/internal/provider/monitor_plan_modify.go
@@ -58,11 +58,15 @@ func (m configNullIfOmitted) PlanModifyObject(ctx context.Context, req planmodif
 	}
 
 	// Normalize: iterate over schema attributes, preserve existing values,
-	// default missing ones to null
+	// default missing ones to null. application_error_retries is the one
+	// config field where missing and explicit null intentionally differ:
+	// missing omits the API field, while null clears the remote override.
 	normalized := make(map[string]attr.Value, len(want))
 	for name, attrType := range want {
 		if existing, ok := attrs[name]; ok {
 			normalized[name] = existing
+		} else if name == "application_error_retries" {
+			normalized[name] = types.Int64Unknown()
 		} else {
 			normalized[name] = nullValueForType(attrType)
 		}

--- a/internal/provider/monitor_resource_acc_test.go
+++ b/internal/provider/monitor_resource_acc_test.go
@@ -3187,6 +3187,16 @@ resource "uptimerobot_monitor" "test" {
 }
 `, name, url, v)
 	}
+	cfgOmitAttr := fmt.Sprintf(`
+resource "uptimerobot_monitor" "test" {
+  name     = "%s"
+  type     = "HTTP"
+  url      = "%s"
+  interval = 300
+
+  config = {}
+}
+`, name, url)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -3209,6 +3219,17 @@ resource "uptimerobot_monitor" "test" {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(res, "config.application_error_retries", "2"),
 				),
+			},
+			{
+				Config: cfgOmitAttr,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(res, "config.application_error_retries", "2"),
+				),
+			},
+			{
+				Config:             cfgOmitAttr,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 			{
 				Config:             cfgValue(2),

--- a/internal/provider/monitor_resource_acc_test.go
+++ b/internal/provider/monitor_resource_acc_test.go
@@ -3168,6 +3168,243 @@ resource "uptimerobot_monitor" "test" {
 	})
 }
 
+func TestAcc_Monitor_Config_ApplicationErrorRetries_SetAndUpdate(t *testing.T) {
+	name := acctest.RandomWithPrefix("acc-app-err-retries")
+	url := testAccUniqueURL(name)
+	res := "uptimerobot_monitor.test"
+
+	cfgValue := func(v int) string {
+		return fmt.Sprintf(`
+resource "uptimerobot_monitor" "test" {
+  name     = "%s"
+  type     = "HTTP"
+  url      = "%s"
+  interval = 300
+
+  config = {
+    application_error_retries = %d
+  }
+}
+`, name, url, v)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfgValue(0),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(res, "config.application_error_retries", "0"),
+				),
+			},
+			{
+				ResourceName:            res,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeout", "status", "group_id", "name", "is_paused"},
+			},
+			{
+				Config: cfgValue(2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(res, "config.application_error_retries", "2"),
+				),
+			},
+			{
+				Config:             cfgValue(2),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAcc_Monitor_Config_ApplicationErrorRetries_ClearToDefault(t *testing.T) {
+	name := acctest.RandomWithPrefix("acc-app-err-retries-clear")
+	url := testAccUniqueURL(name)
+	res := "uptimerobot_monitor.test"
+
+	cfgWithValue := fmt.Sprintf(`
+resource "uptimerobot_monitor" "test" {
+  name     = "%s"
+  type     = "HTTP"
+  url      = "%s"
+  interval = 300
+
+  config = {
+    application_error_retries = 3
+  }
+}
+`, name, url)
+
+	cfgCleared := fmt.Sprintf(`
+resource "uptimerobot_monitor" "test" {
+  name     = "%s"
+  type     = "HTTP"
+  url      = "%s"
+  interval = 300
+
+  config = {
+    application_error_retries = null
+  }
+}
+`, name, url)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfgWithValue,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(res, "config.application_error_retries", "3"),
+				),
+			},
+			{
+				Config: cfgCleared,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// The update sends JSON null and clears the stored override. Read responses can
+					// still expose the computed effective default, so assert stability below.
+					resource.TestCheckResourceAttrSet(res, "config.application_error_retries"),
+				),
+			},
+			{
+				Config:             cfgCleared,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAcc_Monitor_Config_ApplicationErrorRetries_AllowedForKEYWORDAndAPI(t *testing.T) {
+	keywordName := acctest.RandomWithPrefix("acc-kw-app-err-retries")
+	apiName := acctest.RandomWithPrefix("acc-api-app-err-retries")
+	keywordURL := testAccUniqueURL(keywordName)
+	apiURL := testAccUniqueURL(apiName)
+
+	cfgKEYWORD := fmt.Sprintf(`
+resource "uptimerobot_monitor" "kw" {
+  name          = "%s"
+  type          = "KEYWORD"
+  url           = "%s"
+  interval      = 300
+  keyword_value = "ok"
+  keyword_type  = "ALERT_EXISTS"
+  keyword_case_type = "CaseInsensitive"
+
+  config = {
+    application_error_retries = 1
+  }
+}
+`, keywordName, keywordURL)
+
+	cfgAPI := fmt.Sprintf(`
+resource "uptimerobot_monitor" "api" {
+  name     = "%s"
+  type     = "API"
+  url      = "%s"
+  interval = 300
+  timeout  = 30
+
+  config = {
+    application_error_retries = 2
+    api_assertions = {
+      logic = "AND"
+      checks = [{
+        property   = "$.status"
+        comparison = "is_not_null"
+      }]
+    }
+  }
+}
+`, apiName, apiURL)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfgKEYWORD,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_monitor.kw", "config.application_error_retries", "1"),
+				),
+			},
+			{
+				Config: cfgAPI,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_monitor.api", "config.application_error_retries", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAcc_Monitor_Config_ApplicationErrorRetries_Validators(t *testing.T) {
+	name := acctest.RandomWithPrefix("acc-app-err-retries-validate")
+	httpURL := testAccUniqueURL(name)
+	dnsDomain := testAccUniqueDomain(name)
+
+	cfgInvalidForDNS := fmt.Sprintf(`
+resource "uptimerobot_monitor" "test" {
+  name     = "%s"
+  type     = "DNS"
+  url      = "%s"
+  interval = 300
+
+  config = {
+    dns_records               = {}
+    application_error_retries = 1
+  }
+}
+`, name, dnsDomain)
+
+	cfgInvalidForPING := fmt.Sprintf(`
+resource "uptimerobot_monitor" "test" {
+  name     = "%s"
+  type     = "PING"
+  url      = "1.1.1.1"
+  interval = 300
+
+  config = {
+    application_error_retries = 1
+  }
+}
+`, name)
+
+	cfgOutOfRange := fmt.Sprintf(`
+resource "uptimerobot_monitor" "test" {
+  name     = "%s"
+  type     = "HTTP"
+  url      = "%s"
+  interval = 300
+
+  config = {
+    application_error_retries = 4
+  }
+}
+`, name, httpURL)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      cfgInvalidForDNS,
+				ExpectError: regexp.MustCompile(`(?i)application_error_retries[\s\S]*only[\s\S]*HTTP/KEYWORD/API`),
+			},
+			{
+				Config:      cfgInvalidForPING,
+				ExpectError: regexp.MustCompile(`(?i)application_error_retries[\s\S]*only[\s\S]*HTTP/KEYWORD/API`),
+			},
+			{
+				Config:      cfgOutOfRange,
+				ExpectError: regexp.MustCompile(`(?i)application_error_retries`),
+			},
+		},
+	})
+}
+
 func TestAcc_Monitor_Config_DNSRecords_EmptyList_StaysEmpty(t *testing.T) {
 	name := acctest.RandomWithPrefix("acc-dns-empty")
 	domain := testAccUniqueDomain(name)

--- a/internal/provider/monitor_schema.go
+++ b/internal/provider/monitor_schema.go
@@ -90,8 +90,12 @@ func (r *monitorResource) Metadata(_ context.Context, req resource.MetadataReque
 
 // Schema defines the schema for the resource.
 func (r *monitorResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = schema.Schema{
-		Version:     5,
+	resp.Schema = monitorSchema(6, true)
+}
+
+func monitorSchema(version int64, includeApplicationErrorRetries bool) schema.Schema {
+	s := schema.Schema{
+		Version:     version,
 		Description: "Manages an UptimeRobot monitor.",
 		Attributes: map[string]schema.Attribute{
 			"type": schema.StringAttribute{
@@ -623,6 +627,16 @@ Advanced monitor configuration.
 			},
 		},
 	}
+
+	if !includeApplicationErrorRetries {
+		configAttr, ok := s.Attributes["config"].(schema.SingleNestedAttribute)
+		if ok {
+			delete(configAttr.Attributes, "application_error_retries")
+			s.Attributes["config"] = configAttr
+		}
+	}
+
+	return s
 }
 
 func (r *monitorResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
@@ -942,6 +956,24 @@ func (r *monitorResource) UpgradeState(ctx context.Context) map[int64]resource.S
 				}
 
 				upgraded, diags := upgradeMonitorFromV4(ctx, prior)
+				resp.Diagnostics.Append(diags...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, upgraded)...)
+			},
+		},
+		5: {
+			PriorSchema: priorSchemaV5(),
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var prior monitorResourceModel
+				resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				upgraded, diags := upgradeMonitorFromV5(ctx, prior)
 				resp.Diagnostics.Append(diags...)
 				if resp.Diagnostics.HasError() {
 					return

--- a/internal/provider/monitor_schema.go
+++ b/internal/provider/monitor_schema.go
@@ -618,9 +618,6 @@ Advanced monitor configuration.
 						Validators: []validator.Int64{
 							int64validator.Between(0, 3),
 						},
-						PlanModifiers: []planmodifier.Int64{
-							int64planmodifier.UseStateForUnknown(),
-						},
 					},
 				},
 			},

--- a/internal/provider/monitor_schema.go
+++ b/internal/provider/monitor_schema.go
@@ -973,11 +973,7 @@ func (r *monitorResource) UpgradeState(ctx context.Context) map[int64]resource.S
 					return
 				}
 
-				upgraded, diags := upgradeMonitorFromV5(ctx, prior)
-				resp.Diagnostics.Append(diags...)
-				if resp.Diagnostics.HasError() {
-					return
-				}
+				upgraded := upgradeMonitorFromV5(prior)
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, upgraded)...)
 			},

--- a/internal/provider/monitor_schema.go
+++ b/internal/provider/monitor_schema.go
@@ -471,6 +471,7 @@ Advanced monitor configuration.
 - ` + "`ssl_expiration_period_days = []`" + ` → **clear** days on the server; non-empty list sets exactly those days (max 10).
 - Removing ` + "`ip_version`" + ` from a managed ` + "`config`" + ` block clears remote ` + "`ipVersion`" + ` (reverts to API default dual-stack behavior).
 - Setting ` + "`ip_version = \"\"`" + ` also acts as an explicit clear/default signal.
+- Omit ` + "`application_error_retries`" + ` to preserve the remote value; set ` + "`application_error_retries = null`" + ` to clear the remote override so the API applies its own default. Connection errors always retry (this setting only governs application/content failures).
 
 **Validation**
 - For ` + "`type = \"DNS\"`" + ` on create, ` + "`config`" + ` is required (use ` + "`config = {}`" + ` for defaults).
@@ -480,6 +481,7 @@ Advanced monitor configuration.
 - ` + "`ip_version`" + ` is only valid for HTTP/KEYWORD/PING/PORT/API monitors.
 - ` + "`config.api_assertions`" + ` is only valid for API monitors.
 - ` + "`config.udp`" + ` is only valid for UDP monitors.
+- ` + "`config.application_error_retries`" + ` is only valid for HTTP/KEYWORD/API monitors and must be 0..3.
 - Top-level ` + "`ssl_expiration_reminder`" + ` and ` + "`check_ssl_errors`" + ` are valid for HTTPS URLs on HTTP/KEYWORD/API monitors.
 `,
 
@@ -602,6 +604,22 @@ Advanced monitor configuration.
 						},
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.UseStateForUnknown(),
+						},
+					},
+					"application_error_retries": schema.Int64Attribute{
+						Description: "Number of additional retries (0..3) before declaring an application or content failure for HTTP/KEYWORD/API monitors. Connection errors are unaffected and always retry. Omit to preserve the remote value, or set to null to clear the override and let the API apply its default.",
+						MarkdownDescription: "Number of additional retries before declaring an application or content failure (response status, body assertion, keyword, etc.) " +
+							"for `HTTP`, `KEYWORD`, and `API` monitors. Connection errors (DNS, TCP, TLS, timeouts) are unaffected and always retry.\n\n" +
+							"- Allowed range: `0..3`.\n" +
+							"- Omit the attribute → **preserve** the remote value.\n" +
+							"- Set to `null` → **clear** the override; the API applies its own default.\n",
+						Optional: true,
+						Computed: true,
+						Validators: []validator.Int64{
+							int64validator.Between(0, 3),
+						},
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
 						},
 					},
 				},

--- a/internal/provider/monitor_transform.go
+++ b/internal/provider/monitor_transform.go
@@ -549,7 +549,11 @@ func flattenConfigToState(
 		c.IPVersion = types.StringValue("")
 	}
 
-	c.ApplicationErrorRetries = applicationErrorRetriesFromAPI(api)
+	prevApplicationErrorRetries := types.Int64Null()
+	if !c.ApplicationErrorRetries.IsNull() && !c.ApplicationErrorRetries.IsUnknown() {
+		prevApplicationErrorRetries = c.ApplicationErrorRetries
+	}
+	c.ApplicationErrorRetries = applicationErrorRetriesFromAPI(prevApplicationErrorRetries, api)
 
 	// API assertions
 	prevAPIAssertions := types.ObjectNull(apiAssertionsObjectType().AttrTypes)
@@ -671,17 +675,20 @@ func setInt64sRespectingShape(prev types.Set, api []int64) types.Set {
 	return types.SetValueMust(types.Int64Type, elems)
 }
 
-func applicationErrorRetriesFromAPI(api *client.MonitorConfig) types.Int64 {
+func applicationErrorRetriesFromAPI(prev types.Int64, api *client.MonitorConfig) types.Int64 {
 	if api == nil {
-		return types.Int64Null()
+		return prev
 	}
 	raw := bytes.TrimSpace(api.ApplicationErrorRetries)
-	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+	if len(raw) == 0 {
+		return prev
+	}
+	if bytes.Equal(raw, []byte("null")) {
 		return types.Int64Null()
 	}
 	var n int64
 	if err := json.Unmarshal(raw, &n); err != nil {
-		return types.Int64Null()
+		return prev
 	}
 	return types.Int64Value(n)
 }

--- a/internal/provider/monitor_transform.go
+++ b/internal/provider/monitor_transform.go
@@ -1,10 +1,12 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -268,6 +270,15 @@ func expandConfigToAPI(
 			out.IPVersion = &normalized
 			touched = true
 		}
+	}
+
+	if !c.ApplicationErrorRetries.IsUnknown() {
+		if c.ApplicationErrorRetries.IsNull() {
+			out.ApplicationErrorRetries = json.RawMessage("null")
+		} else {
+			out.ApplicationErrorRetries = json.RawMessage(strconv.FormatInt(c.ApplicationErrorRetries.ValueInt64(), 10))
+		}
+		touched = true
 	}
 
 	// api_assertions
@@ -538,6 +549,8 @@ func flattenConfigToState(
 		c.IPVersion = types.StringValue("")
 	}
 
+	c.ApplicationErrorRetries = applicationErrorRetriesFromAPI(api)
+
 	// API assertions
 	prevAPIAssertions := types.ObjectNull(apiAssertionsObjectType().AttrTypes)
 	if !c.APIAssertions.IsNull() && !c.APIAssertions.IsUnknown() {
@@ -656,6 +669,21 @@ func setInt64sRespectingShape(prev types.Set, api []int64) types.Set {
 		elems = append(elems, types.Int64Value(v))
 	}
 	return types.SetValueMust(types.Int64Type, elems)
+}
+
+func applicationErrorRetriesFromAPI(api *client.MonitorConfig) types.Int64 {
+	if api == nil {
+		return types.Int64Null()
+	}
+	raw := bytes.TrimSpace(api.ApplicationErrorRetries)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return types.Int64Null()
+	}
+	var n int64
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return types.Int64Null()
+	}
+	return types.Int64Value(n)
 }
 
 // normalizeIPVersionForAPI returns a canonical provider value and whether it should be sent/stored.

--- a/internal/provider/monitor_transform_test.go
+++ b/internal/provider/monitor_transform_test.go
@@ -38,6 +38,7 @@ func TestExpandConfigToAPI_DNSRecordsEmptyObjectMarksTouched(t *testing.T) {
 		"ip_version":                 types.StringNull(),
 		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
 	})
 
 	out, touched, diags := expandConfigToAPI(ctx, cfg)
@@ -65,6 +66,7 @@ func TestFlattenConfigToState_NoAPIAndPrevNullDNS_StaysNull(t *testing.T) {
 		"ip_version":                 types.StringNull(),
 		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
 	})
 
 	stateObj, diags := flattenConfigToState(ctx, true, prev, nil)
@@ -95,6 +97,7 @@ func TestReadApplyConfig_ManagedEmptyBlock_APINil_PreservesBlock(t *testing.T) {
 			"ip_version":                 types.StringNull(),
 			"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 			"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+			"application_error_retries":  types.Int64Unknown(),
 		}),
 	}
 	m := &client.Monitor{
@@ -136,6 +139,7 @@ func TestApplyUpdatedMonitorToState_ManagedEmptyConfig_NotSent_Preserved(t *test
 			"ip_version":                 types.StringNull(),
 			"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 			"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+			"application_error_retries":  types.Int64Unknown(),
 		}),
 	}
 	prev := monitorResourceModel{}
@@ -260,6 +264,7 @@ func TestFlattenConfigToState_DNSFromAPI_PopulatesSets(t *testing.T) {
 		"ip_version":                 types.StringNull(),
 		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
 	})
 
 	a := []string{"1.1.1.1"}
@@ -328,8 +333,9 @@ func TestExpandConfigToAPI_APIAssertionsTouched(t *testing.T) {
 			"logic":  types.StringValue("AND"),
 			"checks": types.ListValueMust(apiAssertionCheckObjectType(), []attr.Value{check}),
 		}),
-		"ip_version": types.StringNull(),
-		"udp":        types.ObjectNull(udpObjectType().AttrTypes),
+		"ip_version":                types.StringNull(),
+		"udp":                       types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries": types.Int64Unknown(),
 	})
 
 	out, touched, diags := expandConfigToAPI(ctx, cfg)
@@ -364,6 +370,7 @@ func TestFlattenConfigToState_APIAssertionsFromAPI_PopulatesObject(t *testing.T)
 		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 		"ip_version":                 types.StringNull(),
 		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
 	})
 
 	stateObj, diags := flattenConfigToState(ctx, true, prev, &client.MonitorConfig{
@@ -450,6 +457,7 @@ func TestExpandConfigToAPI_UDPTouched(t *testing.T) {
 			"payload":               types.StringValue("ping"),
 			"packet_loss_threshold": types.Int64Value(50),
 		}),
+		"application_error_retries": types.Int64Unknown(),
 	})
 
 	out, touched, diags := expandConfigToAPI(ctx, cfg)
@@ -520,6 +528,7 @@ func TestFlattenConfigToState_UDPFromAPI_PopulatesObject(t *testing.T) {
 		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 		"ip_version":                 types.StringNull(),
 		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
 	})
 	payload := "ping"
 	packetLossThreshold := int64(50)

--- a/internal/provider/monitor_upgrade.go
+++ b/internal/provider/monitor_upgrade.go
@@ -1378,9 +1378,7 @@ func priorSchemaV5() *schema.Schema {
 	return &s
 }
 
-func upgradeMonitorFromV5(ctx context.Context, prior monitorResourceModel) (monitorResourceModel, diag.Diagnostics) {
-	var diags diag.Diagnostics
-
+func upgradeMonitorFromV5(prior monitorResourceModel) monitorResourceModel {
 	prior.Config = retypeConfigToCurrent(prior.Config)
-	return prior, diags
+	return prior
 }

--- a/internal/provider/monitor_upgrade.go
+++ b/internal/provider/monitor_upgrade.go
@@ -1370,3 +1370,17 @@ func upgradeMonitorFromV4(ctx context.Context, prior monitorV4Model) (monitorRes
 
 	return up, diags
 }
+
+// V5 -> V6
+
+func priorSchemaV5() *schema.Schema {
+	s := monitorSchema(5, false)
+	return &s
+}
+
+func upgradeMonitorFromV5(ctx context.Context, prior monitorResourceModel) (monitorResourceModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	prior.Config = retypeConfigToCurrent(prior.Config)
+	return prior, diags
+}

--- a/internal/provider/monitor_upgrade_test.go
+++ b/internal/provider/monitor_upgrade_test.go
@@ -333,7 +333,6 @@ func TestUpgradeFromV4_Config_WithSSLDays(t *testing.T) {
 
 func TestUpgradeFromV5_Config_BackfillsApplicationErrorRetries(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	v5ConfigTypes := map[string]attr.Type{
 		"ssl_expiration_period_days": types.SetType{ElemType: types.Int64Type},
@@ -352,8 +351,7 @@ func TestUpgradeFromV5_Config_BackfillsApplicationErrorRetries(t *testing.T) {
 		}),
 	}
 
-	up, diags := upgradeMonitorFromV5(ctx, prior)
-	require.False(t, diags.HasError(), "diags: %+v", diags)
+	up := upgradeMonitorFromV5(prior)
 
 	require.False(t, up.Config.IsNull(), "config should not be null")
 	attrs := up.Config.Attributes()

--- a/internal/provider/monitor_upgrade_test.go
+++ b/internal/provider/monitor_upgrade_test.go
@@ -71,6 +71,21 @@ func TestStateUpgrader_PriorSchema_TagsIsList(t *testing.T) {
 	}
 }
 
+func TestStateUpgrader_PriorSchemaV5_OmitsApplicationErrorRetries(t *testing.T) {
+	t.Parallel()
+
+	r := &monitorResource{}
+	upgraders := r.UpgradeState(context.Background())
+
+	u5, ok := upgraders[5]
+	require.True(t, ok, "missing state upgrader for version 5")
+
+	require.EqualValues(t, 5, u5.PriorSchema.Version)
+	configAttr, ok := u5.PriorSchema.Attributes["config"].(schema.SingleNestedAttribute)
+	require.True(t, ok, "prior v5 schema config must be SingleNestedAttribute")
+	require.NotContains(t, configAttr.Attributes, "application_error_retries")
+}
+
 func TestUpgradeFromV0_Tags_NullToNullSet(t *testing.T) {
 	ctx := context.Background()
 	prior := monitorV0Model{
@@ -314,6 +329,43 @@ func TestUpgradeFromV4_Config_WithSSLDays(t *testing.T) {
 	udp, ok := attrs["udp"].(types.Object)
 	require.True(t, ok, "udp should be types.Object")
 	require.True(t, udp.IsNull(), "udp should be null")
+}
+
+func TestUpgradeFromV5_Config_BackfillsApplicationErrorRetries(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	v5ConfigTypes := map[string]attr.Type{
+		"ssl_expiration_period_days": types.SetType{ElemType: types.Int64Type},
+		"dns_records":                dnsRecordsObjectType(),
+		"ip_version":                 types.StringType,
+		"api_assertions":             apiAssertionsObjectType(),
+		"udp":                        udpObjectType(),
+	}
+	prior := monitorResourceModel{
+		Config: types.ObjectValueMust(v5ConfigTypes, map[string]attr.Value{
+			"ssl_expiration_period_days": types.SetNull(types.Int64Type),
+			"dns_records":                types.ObjectNull(dnsRecordsObjectType().AttrTypes),
+			"ip_version":                 types.StringValue(IPVersionIPv4Only),
+			"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
+			"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		}),
+	}
+
+	up, diags := upgradeMonitorFromV5(ctx, prior)
+	require.False(t, diags.HasError(), "diags: %+v", diags)
+
+	require.False(t, up.Config.IsNull(), "config should not be null")
+	attrs := up.Config.Attributes()
+	require.Contains(t, attrs, "application_error_retries")
+
+	retries, ok := attrs["application_error_retries"].(types.Int64)
+	require.True(t, ok, "application_error_retries should be types.Int64")
+	require.True(t, retries.IsNull(), "application_error_retries should be null")
+
+	ipVersion, ok := attrs["ip_version"].(types.String)
+	require.True(t, ok, "ip_version should be types.String")
+	require.Equal(t, IPVersionIPv4Only, ipVersion.ValueString())
 }
 
 func TestUpgradeFromV3_Config_WithSSLDays(t *testing.T) {

--- a/internal/provider/monitor_validate.go
+++ b/internal/provider/monitor_validate.go
@@ -370,6 +370,10 @@ func validateConfig(
 		validateConfigIPVersion(monitorType, data.URL, cfg.IPVersion, resp)
 	}
 
+	if !cfg.ApplicationErrorRetries.IsNull() && !cfg.ApplicationErrorRetries.IsUnknown() {
+		validateConfigApplicationErrorRetries(monitorType, resp)
+	}
+
 	// Omitting the whole config block preserves/clears remote.
 	// If DNS config block is present but has no managed fields, warn.
 	if monitorType == MonitorTypeDNS &&
@@ -608,6 +612,21 @@ func validateConfigIPVersion(
 	}
 
 	validateIPVersionURLLiteralCompatibility(urlValue, ipVersion, resp)
+}
+
+func validateConfigApplicationErrorRetries(
+	monitorType string,
+	resp *resource.ValidateConfigResponse,
+) {
+	if monitorType != MonitorTypeHTTP &&
+		monitorType != MonitorTypeKEYWORD &&
+		monitorType != MonitorTypeAPI {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("config").AtName("application_error_retries"),
+			"application_error_retries only allowed for HTTP/KEYWORD/API monitors",
+			"Set type = HTTP, KEYWORD, or API to manage config.application_error_retries, or remove it for this monitor type.",
+		)
+	}
 }
 
 func validateIPVersionURLLiteralCompatibility(urlValue, ipVersion types.String, resp *resource.ValidateConfigResponse) {

--- a/internal/provider/monitor_validate_test.go
+++ b/internal/provider/monitor_validate_test.go
@@ -347,8 +347,9 @@ func TestValidateCreateHighLevel_APIType_AllowsAPIAssertions(t *testing.T) {
 				"logic":  types.StringValue("AND"),
 				"checks": types.ListValueMust(apiAssertionCheckObjectType(), []attr.Value{check}),
 			}),
-			"ip_version": types.StringNull(),
-			"udp":        types.ObjectNull(udpObjectType().AttrTypes),
+			"ip_version":                types.StringNull(),
+			"udp":                       types.ObjectNull(udpObjectType().AttrTypes),
+			"application_error_retries": types.Int64Unknown(),
 		}),
 	}
 
@@ -369,6 +370,7 @@ func TestValidateCreateHighLevel_UDPType_RequiresUDPConfig(t *testing.T) {
 			"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 			"ip_version":                 types.StringNull(),
 			"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+			"application_error_retries":  types.Int64Unknown(),
 		}),
 	}
 
@@ -395,6 +397,7 @@ func TestValidateCreateHighLevel_UDPType_AllowsUDPConfig(t *testing.T) {
 				"payload":               types.StringValue("ping"),
 				"packet_loss_threshold": types.Int64Value(50),
 			}),
+			"application_error_retries": types.Int64Unknown(),
 		}),
 	}
 
@@ -416,6 +419,7 @@ func TestValidateConfig_API_AllowsUnknownAPIAssertionsAtPlanTime(t *testing.T) {
 			"api_assertions":             types.ObjectUnknown(apiAssertionsObjectType().AttrTypes),
 			"ip_version":                 types.StringNull(),
 			"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+			"application_error_retries":  types.Int64Unknown(),
 		}),
 	}
 
@@ -436,8 +440,9 @@ func TestValidateConfig_API_AllowsUnknownAPIAssertionFieldsAtPlanTime(t *testing
 				"logic":  types.StringUnknown(),
 				"checks": types.ListUnknown(apiAssertionCheckObjectType()),
 			}),
-			"ip_version": types.StringNull(),
-			"udp":        types.ObjectNull(udpObjectType().AttrTypes),
+			"ip_version":                types.StringNull(),
+			"udp":                       types.ObjectNull(udpObjectType().AttrTypes),
+			"application_error_retries": types.Int64Unknown(),
 		}),
 	}
 
@@ -457,6 +462,7 @@ func TestValidateConfig_UDP_AllowsUnknownUDPConfigAtPlanTime(t *testing.T) {
 			"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
 			"ip_version":                 types.StringNull(),
 			"udp":                        types.ObjectUnknown(udpObjectType().AttrTypes),
+			"application_error_retries":  types.Int64Unknown(),
 		}),
 	}
 
@@ -479,6 +485,7 @@ func TestValidateConfig_UDP_AllowsUnknownPacketLossThresholdAtPlanTime(t *testin
 				"payload":               types.StringNull(),
 				"packet_loss_threshold": types.Int64Unknown(),
 			}),
+			"application_error_retries": types.Int64Unknown(),
 		}),
 	}
 
@@ -515,10 +522,11 @@ func TestValidateConfig_SSLDays_AllowsHTTP(t *testing.T) {
 				types.Int64Value(7),
 				types.Int64Value(30),
 			}),
-			"dns_records":    types.ObjectNull(dnsRecordsObjectType().AttrTypes),
-			"api_assertions": types.ObjectNull(apiAssertionsObjectType().AttrTypes),
-			"ip_version":     types.StringNull(),
-			"udp":            types.ObjectNull(udpObjectType().AttrTypes),
+			"dns_records":               types.ObjectNull(dnsRecordsObjectType().AttrTypes),
+			"api_assertions":            types.ObjectNull(apiAssertionsObjectType().AttrTypes),
+			"ip_version":                types.StringNull(),
+			"udp":                       types.ObjectNull(udpObjectType().AttrTypes),
+			"application_error_retries": types.Int64Unknown(),
 		}),
 	}
 
@@ -548,8 +556,9 @@ func TestValidateConfig_SSLDays_AllowsAPI(t *testing.T) {
 				"logic":  types.StringValue("AND"),
 				"checks": types.ListValueMust(apiAssertionCheckObjectType(), []attr.Value{check}),
 			}),
-			"ip_version": types.StringNull(),
-			"udp":        types.ObjectNull(udpObjectType().AttrTypes),
+			"ip_version":                types.StringNull(),
+			"udp":                       types.ObjectNull(udpObjectType().AttrTypes),
+			"application_error_retries": types.Int64Unknown(),
 		}),
 	}
 
@@ -569,10 +578,11 @@ func TestValidateConfig_SSLDays_RejectsDNS(t *testing.T) {
 			"ssl_expiration_period_days": types.SetValueMust(types.Int64Type, []attr.Value{
 				types.Int64Value(7),
 			}),
-			"dns_records":    types.ObjectNull(dnsRecordsObjectType().AttrTypes),
-			"api_assertions": types.ObjectNull(apiAssertionsObjectType().AttrTypes),
-			"ip_version":     types.StringNull(),
-			"udp":            types.ObjectNull(udpObjectType().AttrTypes),
+			"dns_records":               types.ObjectNull(dnsRecordsObjectType().AttrTypes),
+			"api_assertions":            types.ObjectNull(apiAssertionsObjectType().AttrTypes),
+			"ip_version":                types.StringNull(),
+			"udp":                       types.ObjectNull(udpObjectType().AttrTypes),
+			"application_error_retries": types.Int64Unknown(),
 		}),
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added config.application_error_retries for HTTP/KEYWORD/API monitors (0–3); setting null clears the override. Added structured region_data for multi-region monitors with optional per-region thresholds; legacy single-region regional_data deprecated. Schema version bumped to include the new attribute.

* **Documentation**
  * Updated monitor docs, changelog, and examples demonstrating application_error_retries and region_data semantics and override/null behavior.

* **Tests**
  * Added and expanded unit and acceptance tests covering validation, encoding/round-trip, clearing behavior, upgrade/migration, and read stabilization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->