### PR TITLE
fix(monitor): avoid stale retry config updates

### DIFF
--- a/internal/provider/monitor_application_error_retries_test.go
+++ b/internal/provider/monitor_application_error_retries_test.go
@@ -217,6 +217,58 @@ func TestExpandConfigToAPI_ApplicationErrorRetriesUnknownIsOmitted(t *testing.T)
 	}
 }
 
+func TestConfigAttributeOmitted_DetectsMissingApplicationErrorRetries(t *testing.T) {
+	t.Parallel()
+
+	rawConfig := types.ObjectValueMust(
+		map[string]attr.Type{
+			"ip_version": types.StringType,
+		},
+		map[string]attr.Value{
+			"ip_version": types.StringValue(IPVersionIPv6Only),
+		},
+	)
+
+	if !configAttributeOmitted(rawConfig, "application_error_retries") {
+		t.Fatalf("expected application_error_retries to be omitted")
+	}
+	if configAttributeOmitted(rawConfig, "ip_version") {
+		t.Fatalf("expected ip_version to be present")
+	}
+}
+
+func TestConfigWithApplicationErrorRetriesUnknown_OmitsStateCopiedValue(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cfg := types.ObjectValueMust(configObjectType().AttrTypes, map[string]attr.Value{
+		"ssl_expiration_period_days": types.SetNull(types.Int64Type),
+		"dns_records":                types.ObjectNull(dnsRecordsObjectType().AttrTypes),
+		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
+		"ip_version":                 types.StringValue(IPVersionIPv6Only),
+		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Value(2),
+	})
+
+	sanitized, diags := configWithApplicationErrorRetriesUnknown(cfg)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+	out, touched, diags := expandConfigToAPI(ctx, sanitized)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+	if !touched {
+		t.Fatalf("expected touched=true because ip_version is set")
+	}
+	if out.IPVersion == nil || *out.IPVersion != IPVersionIPv6Only {
+		t.Fatalf("expected ip_version=%q, got %#v", IPVersionIPv6Only, out.IPVersion)
+	}
+	if len(out.ApplicationErrorRetries) != 0 {
+		t.Fatalf("expected state-copied application_error_retries to be omitted, got %q", string(out.ApplicationErrorRetries))
+	}
+}
+
 func TestConfigNullIfOmitted_ApplicationErrorRetriesMissingStaysUnknown(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/monitor_crud_update.go
+++ b/internal/provider/monitor_crud_update.go
@@ -35,6 +35,7 @@ func (r *monitorResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 	configOmitted := configVal.IsNull() || configVal.IsUnknown()
+	applicationErrorRetriesOmitted := configAttributeOmitted(configVal, "application_error_retries")
 
 	id, err := strconv.ParseInt(plan.ID.ValueString(), 10, 64)
 	if err != nil {
@@ -46,7 +47,7 @@ func (r *monitorResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	updateReq, effMethod := buildUpdateRequest(ctx, plan, state, configOmitted, resp)
+	updateReq, effMethod := buildUpdateRequest(ctx, plan, state, configOmitted, applicationErrorRetriesOmitted, resp)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -264,6 +265,7 @@ func buildUpdateRequest(
 	plan monitorResourceModel,
 	state monitorResourceModel,
 	configOmitted bool,
+	applicationErrorRetriesOmitted bool,
 	resp *resource.UpdateResponse,
 ) (*client.UpdateMonitorRequest, string) {
 	req := &client.UpdateMonitorRequest{
@@ -383,9 +385,17 @@ func buildUpdateRequest(
 	}
 
 	// Config
-	expandOrClearConfigOnUpdate(ctx, plan, state.Config, configOmitted, req, resp)
+	expandOrClearConfigOnUpdate(ctx, plan, state.Config, configOmitted, applicationErrorRetriesOmitted, req, resp)
 
 	return req, effMethod
+}
+
+func configAttributeOmitted(config basetypes.ObjectValue, name string) bool {
+	if config.IsNull() || config.IsUnknown() {
+		return true
+	}
+	_, ok := config.Attributes()[name]
+	return !ok
 }
 
 func setTimeoutAndGraceOnUpdate(_ context.Context, plan monitorResourceModel, req *client.UpdateMonitorRequest) {
@@ -896,6 +906,7 @@ func expandOrClearConfigOnUpdate(
 	plan monitorResourceModel,
 	priorConfig types.Object,
 	configOmitted bool,
+	applicationErrorRetriesOmitted bool,
 	req *client.UpdateMonitorRequest,
 	resp *resource.UpdateResponse,
 ) {
@@ -910,7 +921,17 @@ func expandOrClearConfigOnUpdate(
 		// Explicit null - preserve remote
 		return
 	default:
-		out, touched, diags := expandConfigToAPI(ctx, plan.Config)
+		configForAPI := plan.Config
+		if applicationErrorRetriesOmitted {
+			var diags diag.Diagnostics
+			configForAPI, diags = configWithApplicationErrorRetriesUnknown(plan.Config)
+			resp.Diagnostics.Append(diags...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+		}
+
+		out, touched, diags := expandConfigToAPI(ctx, configForAPI)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -934,6 +955,32 @@ func expandOrClearConfigOnUpdate(
 			req.Config = cfg
 		}
 	}
+}
+
+func configWithApplicationErrorRetriesUnknown(cfg types.Object) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if cfg.IsNull() || cfg.IsUnknown() {
+		return cfg, diags
+	}
+
+	want := configObjectType().AttrTypes
+	attrs := cfg.Attributes()
+	normalized := make(map[string]attr.Value, len(want))
+	for name, attrType := range want {
+		if name == "application_error_retries" {
+			normalized[name] = types.Int64Unknown()
+			continue
+		}
+		if existing, ok := attrs[name]; ok {
+			normalized[name] = existing
+		} else {
+			normalized[name] = nullValueForType(attrType)
+		}
+	}
+
+	out, d := types.ObjectValue(want, normalized)
+	diags.Append(d...)
+	return out, diags
 }
 
 func configPayloadForIPVersionClear(

--- a/internal/provider/monitor_schema.go
+++ b/internal/provider/monitor_schema.go
@@ -623,8 +623,10 @@ Advanced monitor configuration.
 							int64validator.Between(0, 3),
 						},
 						PlanModifiers: []planmodifier.Int64{
-							// Keep omitted optional+computed values stable in plans. Update request
-							// construction uses raw config to avoid sending stale state when omitted.
+							// Keep omitted optional+computed values stable in plans by copying state.
+							// buildUpdateRequest -> expandOrClearConfigOnUpdate uses configAttributeOmitted
+							// and configWithApplicationErrorRetriesUnknown in monitor_crud_update.go to
+							// force omitted values back to Unknown before API expansion.
 							int64planmodifier.UseStateForUnknown(),
 						},
 					},

--- a/internal/provider/monitor_schema.go
+++ b/internal/provider/monitor_schema.go
@@ -622,6 +622,11 @@ Advanced monitor configuration.
 						Validators: []validator.Int64{
 							int64validator.Between(0, 3),
 						},
+						PlanModifiers: []planmodifier.Int64{
+							// Keep omitted optional+computed values stable in plans. Update request
+							// construction uses raw config to avoid sending stale state when omitted.
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 			},

--- a/internal/provider/monitor_transform_test.go
+++ b/internal/provider/monitor_transform_test.go
@@ -236,7 +236,7 @@ func TestBuildUpdateRequest_HeartbeatOmitsServerGeneratedURL(t *testing.T) {
 	}
 	resp := &resource.UpdateResponse{}
 
-	req, _ := buildUpdateRequest(ctx, plan, monitorResourceModel{}, true, resp)
+	req, _ := buildUpdateRequest(ctx, plan, monitorResourceModel{}, true, true, resp)
 	if resp.Diagnostics.HasError() {
 		t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Monitor updates now correctly detect when the application_error_retries attribute is omitted and avoid sending stale values.

* **Chores**
  * Improved schema handling so omitted optional+computed fields are treated stably during planning/updates.

* **Tests**
  * Added and adjusted tests covering omission detection and sanitization of unknown/omitted attribute values.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uptimerobot/terraform-provider-uptimerobot/pull/217)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->