### PR TITLE
Add monitor custom fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Added `uptimerobot_monitor_group` resource for creating, updating, importing, and deleting monitor groups, including `monitors_new_group_id` support to move monitors to another group on deletion.
+- Added `custom_fields` support for `uptimerobot_monitor` metadata, including create, update, import, clear, validation, docs, and examples.
 - Added structured `region_data` support for `uptimerobot_monitor`, including multi-region `regions` and optional per-region response-time `thresholds`.
 - Added `config.application_error_retries` support for `uptimerobot_monitor` HTTP, KEYWORD, and API monitors, including `0..3` validation, import/read/update round-tripping, and explicit `null` clearing to restore the API default.
 

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -232,6 +232,23 @@ resource "uptimerobot_monitor" "multi_region" {
 }
 ```
 
+### Monitor Custom Fields
+
+```terraform
+resource "uptimerobot_monitor" "metadata" {
+  name     = "API health with metadata"
+  type     = "HTTP"
+  url      = "https://example.com/health"
+  interval = 300
+  timeout  = 30
+
+  custom_fields = {
+    environment = "production"
+    team        = "platform"
+  }
+}
+```
+
 ### UDP Monitor
 
 ```terraform
@@ -686,6 +703,12 @@ terraform import 'uptimerobot_monitor.monitors["www_production"]' 800123456
 - `config.udp` is only valid for UDP monitors.
 - `config.application_error_retries` is only valid for HTTP/KEYWORD/API monitors and must be 0..3.
 - Top-level `ssl_expiration_reminder` and `check_ssl_errors` are valid for HTTPS URLs on HTTP/KEYWORD/API monitors. (see [below for nested schema](#nestedatt--config))
+- `custom_fields` (Map of String) Custom key-value metadata for the monitor.
+
+- Max 20 keys.
+- Keys may contain letters, numbers, underscores, and hyphens, up to 64 characters.
+- Values may be up to 255 characters.
+- Omit the attribute to leave custom fields unmanaged. Set `{}` to clear managed custom fields.
 - `custom_http_headers` (Map of String) Custom HTTP headers as key:value. **Keys are case-insensitive.** The provider normalizes keys to **lower-case** on read and during planning to avoid false diffs. Tip: add keys in lower-case (e.g., `"content-type" = "application/json"`).
 - `domain_expiration_reminder` (Boolean) Whether to enable domain expiration reminders
 - `follow_redirections` (Boolean) Whether to follow redirections

--- a/examples/resources/uptimerobot_monitor/custom_fields.tf
+++ b/examples/resources/uptimerobot_monitor/custom_fields.tf
@@ -1,0 +1,12 @@
+resource "uptimerobot_monitor" "metadata" {
+  name     = "API health with metadata"
+  type     = "HTTP"
+  url      = "https://example.com/health"
+  interval = 300
+  timeout  = 30
+
+  custom_fields = {
+    environment = "production"
+    team        = "platform"
+  }
+}

--- a/internal/client/monitor.go
+++ b/internal/client/monitor.go
@@ -41,6 +41,7 @@ type CreateMonitorRequest struct {
 	CheckSSLErrors           *bool                 `json:"checkSSLErrors,omitempty"`
 	SSLCheckEnabled          bool                  `json:"sslCheckEnabled,omitempty"`
 	CustomHTTPHeaders        map[string]string     `json:"customHttpHeaders,omitempty"`
+	CustomFields             map[string]string     `json:"customFields,omitempty"`
 	SuccessHTTPResponseCodes []string              `json:"successHttpResponseCodes,omitempty"`
 	MaintenanceWindowIDs     []int64               `json:"maintenanceWindowsIds,omitempty"`
 	Tags                     []string              `json:"tagNames"`
@@ -76,6 +77,7 @@ type UpdateMonitorRequest struct {
 	CheckSSLErrors           *bool                  `json:"checkSSLErrors,omitempty"`
 	SSLCheckEnabled          bool                   `json:"sslCheckEnabled,omitempty"`
 	CustomHTTPHeaders        *map[string]string     `json:"customHttpHeaders,omitempty"`
+	CustomFields             *map[string]string     `json:"customFields,omitempty"`
 	SuccessHTTPResponseCodes *[]string              `json:"successHttpResponseCodes,omitempty"`
 	MaintenanceWindowIDs     *[]int64               `json:"maintenanceWindowsIds,omitempty"`
 	Tags                     *[]string              `json:"tagNames,omitempty"`
@@ -107,6 +109,7 @@ type Monitor struct {
 	HTTPUsername             string              `json:"httpUsername"`
 	HTTPPassword             string              `json:"httpPassword"`
 	CustomHTTPHeaders        map[string]string   `json:"customHttpHeaders"`
+	CustomFields             map[string]string   `json:"customFields"`
 	HTTPMethodType           string              `json:"httpMethodType"`
 	SuccessHTTPResponseCodes []string            `json:"successHttpResponseCodes"`
 	Timeout                  int                 `json:"timeout"`

--- a/internal/client/request_marshal_test.go
+++ b/internal/client/request_marshal_test.go
@@ -33,6 +33,44 @@ func TestUpdateMonitorRequest_AssignedAlertContacts_JSON(t *testing.T) {
 	}
 }
 
+func TestMonitorRequests_CustomFields_JSON(t *testing.T) {
+	createReq := CreateMonitorRequest{
+		Name:     "metadata-monitor",
+		Type:     MonitorTypeHTTP,
+		Interval: 300,
+		CustomFields: map[string]string{
+			"environment": "production",
+			"team":        "platform",
+		},
+	}
+	createRaw, err := json.Marshal(createReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(createRaw), `"customFields":{"environment":"production","team":"platform"}`) &&
+		!strings.Contains(string(createRaw), `"customFields":{"team":"platform","environment":"production"}`) {
+		t.Fatalf("expected customFields object in create request, got %s", createRaw)
+	}
+
+	updateRaw, err := json.Marshal(UpdateMonitorRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(updateRaw), "customFields") {
+		t.Fatalf("expected nil update customFields to be omitted, got %s", updateRaw)
+	}
+
+	empty := map[string]string{}
+	updateReq := UpdateMonitorRequest{CustomFields: &empty}
+	updateRaw, err = json.Marshal(updateReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(updateRaw), `"customFields":{}`) {
+		t.Fatalf("expected empty customFields object in update request, got %s", updateRaw)
+	}
+}
+
 func TestMonitorRequests_EmptyURL_JSON(t *testing.T) {
 	updateReq := UpdateMonitorRequest{
 		Name:     "heartbeat",

--- a/internal/provider/monitor_compare.go
+++ b/internal/provider/monitor_compare.go
@@ -38,6 +38,7 @@ type monComparable struct {
 	SuccessCodes         []string
 	Tags                 []string
 	Headers              map[string]string
+	CustomFields         map[string]string
 	MaintenanceWindowIDs []int64
 	skipMWIDsCompare     bool
 	// Config children which we manage
@@ -196,6 +197,9 @@ func wantFromCreateReq(req *client.CreateMonitorRequest) monComparable {
 	if req.CustomHTTPHeaders != nil {
 		headers := normalizeHeadersForCompareNoCT(req.CustomHTTPHeaders)
 		c.Headers = headers
+	}
+	if len(req.CustomFields) > 0 {
+		c.CustomFields = normalizeCustomFieldsForCompare(req.CustomFields)
 	}
 	if len(req.Tags) > 0 {
 		c.Tags = normalizeTagSet(req.Tags)
@@ -372,6 +376,9 @@ func wantFromUpdateReq(req *client.UpdateMonitorRequest) monComparable {
 	if req.CustomHTTPHeaders != nil {
 		c.Headers = normalizeHeadersForCompareNoCT(*req.CustomHTTPHeaders)
 	}
+	if req.CustomFields != nil {
+		c.CustomFields = normalizeCustomFieldsForCompare(*req.CustomFields)
+	}
 	if req.MaintenanceWindowIDs == nil {
 		c.skipMWIDsCompare = true
 		c.MaintenanceWindowIDs = nil
@@ -538,6 +545,11 @@ func buildComparableFromAPI(m *client.Monitor) monComparable {
 		c.Headers = normalizeHeadersForCompareNoCT(m.CustomHTTPHeaders)
 	} else {
 		c.Headers = map[string]string{}
+	}
+	if m.CustomFields != nil {
+		c.CustomFields = normalizeCustomFieldsForCompare(m.CustomFields)
+	} else {
+		c.CustomFields = map[string]string{}
 	}
 
 	var apiIDs []int64
@@ -877,6 +889,9 @@ func equalComparable(want, got monComparable) bool {
 	if want.Headers != nil && !equalStringMap(want.Headers, got.Headers) {
 		return false
 	}
+	if want.CustomFields != nil && !equalStringMap(want.CustomFields, got.CustomFields) {
+		return false
+	}
 	if want.AssignedAlertContacts != nil && !equalAlertContacts(want.AssignedAlertContacts, got.AssignedAlertContacts) {
 		return false
 	}
@@ -943,6 +958,9 @@ func fieldsStillDifferent(want, got monComparable) []string {
 	}
 	if want.Headers != nil && !equalStringMap(want.Headers, got.Headers) {
 		f = append(f, "custom_http_headers")
+	}
+	if want.CustomFields != nil && !equalStringMap(want.CustomFields, got.CustomFields) {
+		f = append(f, "custom_fields")
 	}
 	if !want.skipMWIDsCompare && want.MaintenanceWindowIDs != nil && !equalInt64Set(want.MaintenanceWindowIDs, got.MaintenanceWindowIDs) {
 		f = append(f, "maintenance_window_ids")

--- a/internal/provider/monitor_compare_test.go
+++ b/internal/provider/monitor_compare_test.go
@@ -90,6 +90,37 @@ func TestEqualComparable_UsesGroupID(t *testing.T) {
 	}
 }
 
+func TestEqualComparable_UsesCustomFields(t *testing.T) {
+	t.Parallel()
+
+	want := monComparable{CustomFields: map[string]string{"environment": "production", "team": "platform"}}
+	gotSame := monComparable{CustomFields: map[string]string{"team": "platform", "environment": "production"}}
+	gotDiff := monComparable{CustomFields: map[string]string{"environment": "staging", "team": "platform"}}
+
+	if !equalComparable(want, gotSame) {
+		t.Fatalf("expected equalComparable to match same custom_fields")
+	}
+	if equalComparable(want, gotDiff) {
+		t.Fatalf("expected equalComparable mismatch for different custom_fields")
+	}
+}
+
+func TestWantFromUpdateReq_IncludesEmptyCustomFieldsForClear(t *testing.T) {
+	t.Parallel()
+
+	empty := map[string]string{}
+	want := wantFromUpdateReq(&client.UpdateMonitorRequest{
+		Type:         client.MonitorTypeHTTP,
+		CustomFields: &empty,
+	})
+	if want.CustomFields == nil {
+		t.Fatalf("expected empty custom_fields map to be asserted for clear")
+	}
+	if len(want.CustomFields) != 0 {
+		t.Fatalf("expected empty custom_fields map, got %#v", want.CustomFields)
+	}
+}
+
 func TestNormalizeAPIAssertions_SortsChecksForStableCompare(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/monitor_crud_create.go
+++ b/internal/provider/monitor_crud_create.go
@@ -284,6 +284,8 @@ func (r *monitorResource) buildCreateRequest(
 	r.applyMWIDsFromPlan(ctx, &plan, req, resp)
 	// Tags
 	r.applyTagsFromPlan(ctx, &plan, req, resp)
+	// Custom fields
+	r.applyCustomFieldsFromPlan(ctx, &plan, req, resp)
 	// Assigned alert contacts
 	r.applyAlertContactsFromPlan(ctx, &plan, req, resp)
 	// Flags ssl/domain/follow/check
@@ -432,6 +434,25 @@ func (r *monitorResource) applyTagsFromPlan(
 	}
 }
 
+func (r *monitorResource) applyCustomFieldsFromPlan(
+	ctx context.Context,
+	plan *monitorResourceModel,
+	req *client.CreateMonitorRequest,
+	resp *resource.CreateResponse,
+) {
+	if plan.CustomFields.IsNull() || plan.CustomFields.IsUnknown() {
+		return
+	}
+	m, d := stringMapFromAttrPreserveEmpty(ctx, plan.CustomFields)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if len(m) > 0 {
+		req.CustomFields = m
+	}
+}
+
 func (r *monitorResource) applyAlertContactsFromPlan(
 	ctx context.Context,
 	plan *monitorResourceModel,
@@ -551,6 +572,11 @@ func (r *monitorResource) buildStateAfterCreate(
 	// Headers. Keep null if omitted in plan
 	if plan.CustomHTTPHeaders.IsNull() || plan.CustomHTTPHeaders.IsUnknown() {
 		plan.CustomHTTPHeaders = types.MapNull(types.StringType)
+	}
+	customFields, d := customFieldsState(ctx, plan.CustomFields, api.CustomFields, false)
+	resp.Diagnostics.Append(d...)
+	if !resp.Diagnostics.HasError() {
+		plan.CustomFields = customFields
 	}
 
 	// Method presence in state only for HTTP/KEYWORD/API

--- a/internal/provider/monitor_crud_read.go
+++ b/internal/provider/monitor_crud_read.go
@@ -58,6 +58,7 @@ func (r *monitorResource) Read(ctx context.Context, req resource.ReadRequest, re
 	readApplyPausedState(&state, monitor, isImport)
 	readApplyRegionalData(ctx, resp, &state, monitor, isImport)
 	readApplyTagsHeadersAC(ctx, resp, &state, monitor, isImport)
+	readApplyCustomFields(ctx, resp, &state, monitor, isImport)
 	readApplySuccessCodes(ctx, resp, &state, monitor)
 	readApplyBooleans(&state, monitor, isImport)
 	readApplyMWIDs(ctx, resp, &state, monitor)
@@ -324,6 +325,14 @@ func readApplyTagsHeadersAC(ctx context.Context, resp *resource.ReadResponse, st
 	}
 }
 
+func readApplyCustomFields(ctx context.Context, resp *resource.ReadResponse, state *monitorResourceModel, m *client.Monitor, isImport bool) {
+	customFields, d := customFieldsState(ctx, state.CustomFields, m.CustomFields, isImport)
+	resp.Diagnostics.Append(d...)
+	if !resp.Diagnostics.HasError() {
+		state.CustomFields = customFields
+	}
+}
+
 func (r *monitorResource) stabilizeMonitorReadSnapshot(
 	ctx context.Context,
 	id int64,
@@ -450,6 +459,11 @@ func monitorReadStabilizationWant(ctx context.Context, state monitorResourceMode
 			want.AssignedAlertContacts = contacts
 		}
 	}
+	if !state.CustomFields.IsNull() && !state.CustomFields.IsUnknown() {
+		if fields, diags := stringMapFromAttrPreserveEmpty(ctx, state.CustomFields); !diags.HasError() {
+			want.CustomFields = normalizeCustomFieldsForCompare(fields)
+		}
+	}
 
 	if !state.RegionData.IsNull() && !state.RegionData.IsUnknown() {
 		if regionData, ok, diags := regionDataFromTF(ctx, state.RegionData); ok && !diags.HasError() {
@@ -475,6 +489,7 @@ func hasMonitorReadStabilizationAssertions(want monComparable) bool {
 		want.AssignedAlertContacts != nil ||
 		want.RegionData != nil ||
 		want.RegionalData != nil ||
+		want.CustomFields != nil ||
 		want.DNSRecords != nil ||
 		want.SSLExpirationPeriodDays != nil ||
 		want.IPVersion != nil ||

--- a/internal/provider/monitor_crud_update.go
+++ b/internal/provider/monitor_crud_update.go
@@ -345,7 +345,7 @@ func buildUpdateRequest(
 	}
 
 	// custom fields
-	setCustomFieldsOnUpdate(ctx, plan, state, req, resp)
+	setCustomFieldsOnUpdate(ctx, plan, req, resp)
 	if resp.Diagnostics.HasError() {
 		return nil, ""
 	}
@@ -576,7 +576,6 @@ func setTagsOnUpdate(ctx context.Context, plan monitorResourceModel, req *client
 func setCustomFieldsOnUpdate(
 	ctx context.Context,
 	plan monitorResourceModel,
-	state monitorResourceModel,
 	req *client.UpdateMonitorRequest,
 	resp *resource.UpdateResponse,
 ) {
@@ -584,11 +583,7 @@ func setCustomFieldsOnUpdate(
 	case plan.CustomFields.IsUnknown():
 		return
 	case plan.CustomFields.IsNull():
-		if state.CustomFields.IsNull() || state.CustomFields.IsUnknown() {
-			return
-		}
-		empty := map[string]string{}
-		req.CustomFields = &empty
+		// Omitted/null means unmanaged: preserve remote custom fields.
 		return
 	default:
 		m, d := stringMapFromAttrPreserveEmpty(ctx, plan.CustomFields)

--- a/internal/provider/monitor_crud_update.go
+++ b/internal/provider/monitor_crud_update.go
@@ -344,6 +344,12 @@ func buildUpdateRequest(
 		return nil, ""
 	}
 
+	// custom fields
+	setCustomFieldsOnUpdate(ctx, plan, state, req, resp)
+	if resp.Diagnostics.HasError() {
+		return nil, ""
+	}
+
 	// alert contacts
 	setAlertContactsOnUpdate(ctx, plan, req, resp)
 	if resp.Diagnostics.HasError() {
@@ -567,6 +573,33 @@ func setTagsOnUpdate(ctx context.Context, plan monitorResourceModel, req *client
 	}
 }
 
+func setCustomFieldsOnUpdate(
+	ctx context.Context,
+	plan monitorResourceModel,
+	state monitorResourceModel,
+	req *client.UpdateMonitorRequest,
+	resp *resource.UpdateResponse,
+) {
+	switch {
+	case plan.CustomFields.IsUnknown():
+		return
+	case plan.CustomFields.IsNull():
+		if state.CustomFields.IsNull() || state.CustomFields.IsUnknown() {
+			return
+		}
+		empty := map[string]string{}
+		req.CustomFields = &empty
+		return
+	default:
+		m, d := stringMapFromAttrPreserveEmpty(ctx, plan.CustomFields)
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		req.CustomFields = &m
+	}
+}
+
 func setAlertContactsOnUpdate(
 	ctx context.Context,
 	plan monitorResourceModel,
@@ -751,6 +784,11 @@ func applyUpdatedMonitorToState(
 		out.CustomHTTPHeaders = types.MapNull(types.StringType)
 	} else {
 		out.CustomHTTPHeaders = plan.CustomHTTPHeaders
+	}
+	customFields, d := customFieldsState(ctx, plan.CustomFields, m.CustomFields, false)
+	resp.Diagnostics.Append(d...)
+	if !resp.Diagnostics.HasError() {
+		out.CustomFields = customFields
 	}
 
 	// Maintenance windows

--- a/internal/provider/monitor_model.go
+++ b/internal/provider/monitor_model.go
@@ -17,6 +17,7 @@ type monitorResourceModel struct {
 	HTTPUsername             types.String         `tfsdk:"http_username"`
 	HTTPPassword             types.String         `tfsdk:"http_password"`
 	CustomHTTPHeaders        types.Map            `tfsdk:"custom_http_headers"`
+	CustomFields             types.Map            `tfsdk:"custom_fields"`
 	HTTPMethodType           types.String         `tfsdk:"http_method_type"`
 	SuccessHTTPResponseCodes types.Set            `tfsdk:"success_http_response_codes"`
 	Timeout                  types.Int64          `tfsdk:"timeout"`

--- a/internal/provider/monitor_resource_acc_test.go
+++ b/internal/provider/monitor_resource_acc_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -130,6 +131,24 @@ resource "uptimerobot_monitor" "test" {
   group_id  = %d
 }
 `, name, url, groupID)
+}
+
+func testAccMonitorResourceConfigWithCustomFields(name string, fields map[string]string) string {
+	url := testAccUniqueURL(name)
+	customFields := ""
+	if fields != nil {
+		customFields = "\n  custom_fields = " + hclStringMap(fields)
+	}
+
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "uptimerobot_monitor" "test" {
+  name     = %q
+  url      = "%s"
+  type     = "HTTP"
+  interval = 300
+  timeout  = 30%s
+}
+`, name, url, customFields)
 }
 
 // nolint:unparam // kept for symmetry with other helpers & future reuse
@@ -478,6 +497,27 @@ func joinInts(ints []int) string {
 	return result
 }
 
+func hclStringMap(values map[string]string) string {
+	if len(values) == 0 {
+		return "{}"
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	out := "{"
+	for i, key := range keys {
+		if i > 0 {
+			out += ","
+		}
+		out += fmt.Sprintf(" %q = %q", key, values[key])
+	}
+	out += " }"
+	return out
+}
+
 func mustAlertContactID(t *testing.T) string {
 	t.Helper()
 	id := os.Getenv("UPTIMEROBOT_TEST_ALERT_CONTACT_ID")
@@ -615,6 +655,64 @@ func TestAccMonitorResource_IsPaused_StartStop(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckNoResourceAttr("uptimerobot_monitor.test", "is_paused"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccMonitorResource_CustomFields(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-monitor-custom-fields")
+	initial := map[string]string{
+		"environment": "production",
+		"team":        "platform",
+	}
+	updated := map[string]string{
+		"environment": "staging",
+		"owner":       "sre",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMonitorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitorResourceConfigWithCustomFields(name, initial),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "custom_fields.%", "2"),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "custom_fields.environment", "production"),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "custom_fields.team", "platform"),
+				),
+			},
+			{
+				ResourceName:            "uptimerobot_monitor.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeout", "status", "group_id", "name", "is_paused"},
+			},
+			{
+				Config: testAccMonitorResourceConfigWithCustomFields(name, updated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "custom_fields.%", "2"),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "custom_fields.environment", "staging"),
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "custom_fields.owner", "sre"),
+					resource.TestCheckNoResourceAttr("uptimerobot_monitor.test", "custom_fields.team"),
+				),
+			},
+			{
+				Config: testAccMonitorResourceConfigWithCustomFields(name, map[string]string{}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "custom_fields.%", "0"),
+				),
+			},
+			{
+				Config:             testAccMonitorResourceConfigWithCustomFields(name, map[string]string{}),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config: testAccMonitorResourceConfigWithCustomFields(name, nil),
+				Check:  resource.TestCheckNoResourceAttr("uptimerobot_monitor.test", "custom_fields"),
 			},
 		},
 	})

--- a/internal/provider/monitor_resource_acc_test.go
+++ b/internal/provider/monitor_resource_acc_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/uptimerobot/terraform-provider-uptimerobot/internal/client"
 )
 
@@ -149,6 +151,43 @@ resource "uptimerobot_monitor" "test" {
   timeout  = 30%s
 }
 `, name, url, customFields)
+}
+
+func testAccCheckMonitorCustomFields(resourceName string, expected map[string]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found", resourceName)
+		}
+
+		id, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		if err != nil {
+			return fmt.Errorf("could not parse monitor ID %q: %w", rs.Primary.ID, err)
+		}
+
+		apiClient := client.NewClient(os.Getenv("UPTIMEROBOT_API_KEY"))
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		defer cancel()
+
+		monitor, err := apiClient.GetMonitor(ctx, id)
+		if err != nil {
+			return fmt.Errorf("could not read monitor %d: %w", id, err)
+		}
+
+		if len(monitor.CustomFields) != len(expected) {
+			return fmt.Errorf("expected custom_fields %#v, got %#v", expected, monitor.CustomFields)
+		}
+		for k, want := range expected {
+			got, ok := monitor.CustomFields[k]
+			if !ok {
+				return fmt.Errorf("expected custom_fields key %q to be present, got %#v", k, monitor.CustomFields)
+			}
+			if got != want {
+				return fmt.Errorf("expected custom_fields[%q] = %q, got %q", k, want, got)
+			}
+		}
+		return nil
+	}
 }
 
 // nolint:unparam // kept for symmetry with other helpers & future reuse
@@ -700,9 +739,17 @@ func TestAccMonitorResource_CustomFields(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccMonitorResourceConfigWithCustomFields(name, nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("uptimerobot_monitor.test", "custom_fields"),
+					testAccCheckMonitorCustomFields("uptimerobot_monitor.test", updated),
+				),
+			},
+			{
 				Config: testAccMonitorResourceConfigWithCustomFields(name, map[string]string{}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("uptimerobot_monitor.test", "custom_fields.%", "0"),
+					testAccCheckMonitorCustomFields("uptimerobot_monitor.test", map[string]string{}),
 				),
 			},
 			{

--- a/internal/provider/monitor_resource_acc_test.go
+++ b/internal/provider/monitor_resource_acc_test.go
@@ -166,6 +166,11 @@ func testAccCheckMonitorCustomFields(resourceName string, expected map[string]st
 		}
 
 		apiClient := client.NewClient(os.Getenv("UPTIMEROBOT_API_KEY"))
+		if apiURL := os.Getenv("UPTIMEROBOT_API_URL"); apiURL != "" {
+			apiClient.SetBaseURL(apiURL)
+		}
+		apiClient.SetUserAgent("terraform-provider-uptimerobot/acc-test")
+		apiClient.AddHeader("X-Terraform-Provider", "uptimerobot/acc-test")
 		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 		defer cancel()
 

--- a/internal/provider/monitor_schema.go
+++ b/internal/provider/monitor_schema.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -42,6 +43,10 @@ const (
 
 	IPVersionIPv4Only = "ipv4Only"
 	IPVersionIPv6Only = "ipv6Only"
+
+	customFieldsMaxKeys        = 20
+	customFieldsKeyMaxLength   = 64
+	customFieldsValueMaxLength = 255
 )
 
 // NewMonitorResource is a helper function to simplify the provider implementation.
@@ -176,6 +181,30 @@ func monitorSchema(version int64, includeApplicationErrorRetries bool) schema.Sc
 					"Tip: add keys in lower-case (e.g., `\"content-type\" = \"application/json\"`).",
 				Optional:    true,
 				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"custom_fields": schema.MapAttribute{
+				Description: "Custom key-value metadata for the monitor. Max 20 keys. Keys may contain letters, numbers, underscores, and hyphens. Values may be up to 255 characters.",
+				MarkdownDescription: "Custom key-value metadata for the monitor.\n\n" +
+					"- Max 20 keys.\n" +
+					"- Keys may contain letters, numbers, underscores, and hyphens, up to 64 characters.\n" +
+					"- Values may be up to 255 characters.\n" +
+					"- Omit the attribute to leave custom fields unmanaged. Set `{}` to clear managed custom fields.",
+				Optional:    true,
+				ElementType: types.StringType,
+				Validators: []validator.Map{
+					mapvalidator.SizeAtMost(customFieldsMaxKeys),
+					mapvalidator.KeysAre(
+						stringvalidator.LengthAtLeast(1),
+						stringvalidator.LengthAtMost(customFieldsKeyMaxLength),
+						stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must contain only letters, numbers, underscores, and hyphens"),
+					),
+					mapvalidator.ValueStringsAre(
+						stringvalidator.LengthAtMost(customFieldsValueMaxLength),
+					),
+				},
 				PlanModifiers: []planmodifier.Map{
 					mapplanmodifier.UseStateForUnknown(),
 				},

--- a/internal/provider/monitor_transform.go
+++ b/internal/provider/monitor_transform.go
@@ -826,11 +826,61 @@ func mapFromAttr(ctx context.Context, attr types.Map) (map[string]string, diag.D
 	return out, diags
 }
 
+func stringMapFromAttrPreserveEmpty(ctx context.Context, attr types.Map) (map[string]string, diag.Diagnostics) {
+	if attr.IsNull() || attr.IsUnknown() {
+		return nil, nil
+	}
+
+	var raw map[string]types.String
+	var diags diag.Diagnostics
+	diags.Append(attr.ElementsAs(ctx, &raw, false)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	out := make(map[string]string, len(raw))
+	for k, v := range raw {
+		if v.IsUnknown() || v.IsNull() {
+			continue
+		}
+		out[k] = v.ValueString()
+	}
+	return out, diags
+}
+
 func attrFromMap(ctx context.Context, m map[string]string) (types.Map, diag.Diagnostics) {
 	if m == nil {
 		return types.MapNull(types.StringType), nil
 	}
 	return types.MapValueFrom(ctx, types.StringType, m)
+}
+
+func customFieldsState(ctx context.Context, desired types.Map, api map[string]string, isImport bool) (types.Map, diag.Diagnostics) {
+	if isImport {
+		if len(api) == 0 {
+			return types.MapNull(types.StringType), nil
+		}
+		return types.MapValueFrom(ctx, types.StringType, api)
+	}
+
+	if desired.IsNull() || desired.IsUnknown() {
+		return types.MapNull(types.StringType), nil
+	}
+	if api == nil {
+		api = map[string]string{}
+	}
+	return types.MapValueFrom(ctx, types.StringType, api)
+}
+
+func normalizeCustomFieldsForCompare(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 // headersFromAPIForState drops added by server Content-Type headers so state stays clean

--- a/internal/provider/monitor_transform_test.go
+++ b/internal/provider/monitor_transform_test.go
@@ -203,6 +203,96 @@ func TestBuildCreateRequest_HeartbeatOmitsURL(t *testing.T) {
 	}
 }
 
+func TestBuildCreateRequest_CustomFields(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	plan := monitorResourceModel{
+		Type:     types.StringValue(MonitorTypeHTTP),
+		Name:     types.StringValue("metadata"),
+		URL:      types.StringValue("https://example.com"),
+		Interval: types.Int64Value(300),
+		CustomFields: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"environment": types.StringValue("production"),
+			"team":        types.StringValue("platform"),
+		}),
+	}
+	resp := &resource.CreateResponse{}
+
+	req, _ := (&monitorResource{}).buildCreateRequest(ctx, plan, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
+	}
+	if req == nil || len(req.CustomFields) != 2 {
+		t.Fatalf("expected custom fields in create request, got %#v", req)
+	}
+	if req.CustomFields["environment"] != "production" || req.CustomFields["team"] != "platform" {
+		t.Fatalf("unexpected custom fields: %#v", req.CustomFields)
+	}
+}
+
+func TestBuildUpdateRequest_CustomFieldsSemantics(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	basePlan := monitorResourceModel{
+		Type:     types.StringValue(MonitorTypeHTTP),
+		Name:     types.StringValue("metadata"),
+		URL:      types.StringValue("https://example.com"),
+		Interval: types.Int64Value(300),
+		Config:   types.ObjectNull(configObjectType().AttrTypes),
+	}
+
+	t.Run("unmanaged null omits", func(t *testing.T) {
+		plan := basePlan
+		plan.CustomFields = types.MapNull(types.StringType)
+		state := monitorResourceModel{CustomFields: types.MapNull(types.StringType)}
+		resp := &resource.UpdateResponse{}
+
+		req, _ := buildUpdateRequest(ctx, plan, state, true, true, resp)
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
+		}
+		if req.CustomFields != nil {
+			t.Fatalf("expected custom fields to be omitted, got %#v", *req.CustomFields)
+		}
+	})
+
+	t.Run("managed null clears", func(t *testing.T) {
+		plan := basePlan
+		plan.CustomFields = types.MapNull(types.StringType)
+		state := monitorResourceModel{CustomFields: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"environment": types.StringValue("production"),
+		})}
+		resp := &resource.UpdateResponse{}
+
+		req, _ := buildUpdateRequest(ctx, plan, state, true, true, resp)
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
+		}
+		if req.CustomFields == nil || len(*req.CustomFields) != 0 {
+			t.Fatalf("expected empty custom fields clear payload, got %#v", req.CustomFields)
+		}
+	})
+
+	t.Run("empty map clears", func(t *testing.T) {
+		plan := basePlan
+		plan.CustomFields = types.MapValueMust(types.StringType, map[string]attr.Value{})
+		state := monitorResourceModel{CustomFields: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"environment": types.StringValue("production"),
+		})}
+		resp := &resource.UpdateResponse{}
+
+		req, _ := buildUpdateRequest(ctx, plan, state, true, true, resp)
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
+		}
+		if req.CustomFields == nil || len(*req.CustomFields) != 0 {
+			t.Fatalf("expected empty custom fields clear payload, got %#v", req.CustomFields)
+		}
+	})
+}
+
 func TestPlanAlertContactsComparable_SkipsComparisonForIncompleteContact(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/monitor_transform_test.go
+++ b/internal/provider/monitor_transform_test.go
@@ -258,7 +258,7 @@ func TestBuildUpdateRequest_CustomFieldsSemantics(t *testing.T) {
 		}
 	})
 
-	t.Run("managed null clears", func(t *testing.T) {
+	t.Run("managed null preserves remote", func(t *testing.T) {
 		plan := basePlan
 		plan.CustomFields = types.MapNull(types.StringType)
 		state := monitorResourceModel{CustomFields: types.MapValueMust(types.StringType, map[string]attr.Value{
@@ -270,8 +270,8 @@ func TestBuildUpdateRequest_CustomFieldsSemantics(t *testing.T) {
 		if resp.Diagnostics.HasError() {
 			t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
 		}
-		if req.CustomFields == nil || len(*req.CustomFields) != 0 {
-			t.Fatalf("expected empty custom fields clear payload, got %#v", req.CustomFields)
+		if req.CustomFields != nil {
+			t.Fatalf("expected custom fields to be omitted, got %#v", *req.CustomFields)
 		}
 	})
 

--- a/templates/resources/monitor.md.tmpl
+++ b/templates/resources/monitor.md.tmpl
@@ -39,6 +39,10 @@ description: |-
 
 {{tffile "examples/resources/uptimerobot_monitor/region_data.tf"}}
 
+### Monitor Custom Fields
+
+{{tffile "examples/resources/uptimerobot_monitor/custom_fields.tf"}}
+
 ### UDP Monitor
 
 {{tffile "examples/resources/uptimerobot_monitor/udp.tf"}}


### PR DESCRIPTION
## Summary

- add `custom_fields` support to `uptimerobot_monitor`
- wire `customFields` through client create/update/read payloads
- support create, update, import, clear, and unmanaged omit semantics
- add validation, docs, example, unit tests, acceptance coverage, and changelog entry

## Verification

- `go test ./...`
- `golangci-lint run`
- `go generate ./...`
- `go mod verify`
- `TF_ACC=1 ... go test -tags acceptance ./internal/provider -run '^TestAccMonitorResource_CustomFields$' -v -count=1 -timeout 20m -parallel=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for monitor custom_fields: attach arbitrary key/value metadata (up to 20 keys; keys 1–64 chars, alphanumerics/_/-; values up to 255 chars). Supports create, update, import, and clearing (explicit empty map clears; omitting leaves unmanaged).

* **Documentation**
  * Docs and examples updated with a "Monitor Custom Fields" example demonstrating usage and clearing semantics.

* **Tests**
  * Unit and acceptance tests added to verify create/update/import/clear, comparison, and serialization behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uptimerobot/terraform-provider-uptimerobot/pull/219)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->