### PR TITLE
Feat/webhook custom headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added `uptimerobot_monitor_group` resource for creating, updating, importing, and deleting monitor groups, including `monitors_new_group_id` support to move monitors to another group on deletion.
 - Added `custom_fields` support for `uptimerobot_monitor` metadata, including create, update, import, clear, validation, docs, and examples.
+- Added `custom_headers` support for webhook `uptimerobot_integration` resources, including create, update, import, and clear handling.
 - Added structured `region_data` support for `uptimerobot_monitor`, including multi-region `regions` and optional per-region response-time `thresholds`.
 - Added `config.application_error_retries` support for `uptimerobot_monitor` HTTP, KEYWORD, and API monitors, including `0..3` validation, import/read/update round-tripping, and explicit `null` clearing to restore the API default.
 

--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -59,6 +59,11 @@ resource "uptimerobot_integration" "api_webhook" {
   send_as_json         = true
   send_as_query_string = false
 
+  custom_headers = {
+    Authorization = "Bearer ${var.webhook_auth_token}"
+    "X-Source"    = "uptimerobot"
+  }
+
   post_value = jsonencode({
     message    = "Alert: $monitorURL is $alertType"
     status     = "$monitorStatusFullName"
@@ -79,6 +84,12 @@ resource "uptimerobot_integration" "simple_webhook" {
   # Send as query string
   send_as_json         = false
   send_as_query_string = true
+}
+
+variable "webhook_auth_token" {
+  description = "Bearer token sent in the webhook Authorization header"
+  type        = string
+  sensitive   = true
 }
 ```
 
@@ -230,6 +241,9 @@ resource "uptimerobot_integration" "webhook" {
   ssl_expiration_reminder  = true
 
   send_as_json = true
+  custom_headers = {
+    "X-Source" = "uptimerobot"
+  }
   post_value = jsonencode({
     message    = "Monitor $monitorFriendlyName is $alertType"
     timestamp  = "$alertDateTime"
@@ -349,6 +363,7 @@ terraform import uptimerobot_integration.example 123456
 ### Optional
 
 - `auto_resolve` (Boolean) PagerDuty: auto-resolve incidents after up event.
+- `custom_headers` (Map of String, Sensitive) Custom HTTP headers to send with webhook notifications. Only valid for webhook integrations. Set `{}` to clear managed custom headers.
 - `custom_value` (String) The custom value for the integration. Only valid for slack (#channel), telegram (chat_id), and pushover (device name). Not used for webhook integrations (webhook settings are stored in dedicated fields).
 - `location` (String) PagerDuty service region. One of: `us`, `eu`.
 - `post_value` (String) The POST value to send with the webhook. Only valid for webhook integrations.

--- a/examples/resources/uptimerobot_integration/multiple.tf
+++ b/examples/resources/uptimerobot_integration/multiple.tf
@@ -26,6 +26,9 @@ resource "uptimerobot_integration" "webhook" {
   ssl_expiration_reminder  = true
 
   send_as_json = true
+  custom_headers = {
+    "X-Source" = "uptimerobot"
+  }
   post_value = jsonencode({
     message    = "Monitor $monitorFriendlyName is $alertType"
     timestamp  = "$alertDateTime"

--- a/examples/resources/uptimerobot_integration/webhook.tf
+++ b/examples/resources/uptimerobot_integration/webhook.tf
@@ -10,6 +10,11 @@ resource "uptimerobot_integration" "api_webhook" {
   send_as_json         = true
   send_as_query_string = false
 
+  custom_headers = {
+    Authorization = "Bearer ${var.webhook_auth_token}"
+    "X-Source"    = "uptimerobot"
+  }
+
   post_value = jsonencode({
     message    = "Alert: $monitorURL is $alertType"
     status     = "$monitorStatusFullName"
@@ -30,4 +35,10 @@ resource "uptimerobot_integration" "simple_webhook" {
   # Send as query string
   send_as_json         = false
   send_as_query_string = true
+}
+
+variable "webhook_auth_token" {
+  description = "Bearer token sent in the webhook Authorization header"
+  type        = string
+  sensitive   = true
 }

--- a/internal/client/integration.go
+++ b/internal/client/integration.go
@@ -21,10 +21,11 @@ type Integration struct {
 	SSLExpirationReminder  bool   `json:"sslExpirationReminder"`
 
 	// Webhook specific fields
-	SendAsJSON           *bool  `json:"sendAsJSON,omitempty"`
-	SendAsQueryString    *bool  `json:"sendAsQueryString,omitempty"`
-	SendAsPostParameters *bool  `json:"sendAsPostParameters,omitempty"`
-	PostValue            string `json:"postValue,omitempty"`
+	SendAsJSON           *bool             `json:"sendAsJSON,omitempty"`
+	SendAsQueryString    *bool             `json:"sendAsQueryString,omitempty"`
+	SendAsPostParameters *bool             `json:"sendAsPostParameters,omitempty"`
+	PostValue            string            `json:"postValue,omitempty"`
+	CustomHeaders        map[string]string `json:"customHeaders,omitempty"`
 
 	// Pushover specific field
 	Priority string `json:"priority,omitempty"`
@@ -76,15 +77,16 @@ type DiscordIntegrationData struct {
 
 // WebhookIntegrationData represents the data structure for Webhook integrations.
 type WebhookIntegrationData struct {
-	FriendlyName           string `json:"friendlyName,omitempty"`
-	URLToNotify            string `json:"urlToNotify"`
-	CustomValue            string `json:"customValue,omitempty"`
-	EnableNotificationsFor string `json:"enableNotificationsFor,omitempty"`
-	SSLExpirationReminder  bool   `json:"sslExpirationReminder,omitempty"`
-	PostValue              string `json:"postValue"`
-	SendAsQueryString      bool   `json:"sendAsQueryString,omitempty"`
-	SendAsJSON             bool   `json:"sendAsJSON,omitempty"`
-	SendAsPostParameters   bool   `json:"sendAsPostParameters,omitempty"`
+	FriendlyName           string             `json:"friendlyName,omitempty"`
+	URLToNotify            string             `json:"urlToNotify"`
+	CustomValue            string             `json:"customValue,omitempty"`
+	EnableNotificationsFor string             `json:"enableNotificationsFor,omitempty"`
+	SSLExpirationReminder  bool               `json:"sslExpirationReminder,omitempty"`
+	PostValue              string             `json:"postValue"`
+	SendAsQueryString      bool               `json:"sendAsQueryString,omitempty"`
+	SendAsJSON             bool               `json:"sendAsJSON,omitempty"`
+	SendAsPostParameters   bool               `json:"sendAsPostParameters,omitempty"`
+	CustomHeaders          *map[string]string `json:"customHeaders,omitempty"`
 }
 
 // ZapierIntegrationData represents the data structure for Zapier integrations.

--- a/internal/client/request_marshal_test.go
+++ b/internal/client/request_marshal_test.go
@@ -71,6 +71,52 @@ func TestMonitorRequests_CustomFields_JSON(t *testing.T) {
 	}
 }
 
+func TestWebhookIntegrationData_CustomHeaders_JSON(t *testing.T) {
+	req := WebhookIntegrationData{
+		FriendlyName: "webhook",
+		URLToNotify:  "https://example.com/webhook",
+		PostValue:    "{}",
+	}
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "customHeaders") {
+		t.Fatalf("expected nil customHeaders to be omitted, got %s", raw)
+	}
+
+	headers := map[string]string{
+		"Authorization": "Bearer token",
+		"X-Source":      "terraform",
+	}
+	req.CustomHeaders = &headers
+	raw, err = json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatal(err)
+	}
+	gotHeaders, ok := body["customHeaders"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected customHeaders object, got %s", raw)
+	}
+	if gotHeaders["Authorization"] != "Bearer token" || gotHeaders["X-Source"] != "terraform" {
+		t.Fatalf("unexpected customHeaders payload: %#v", gotHeaders)
+	}
+
+	empty := map[string]string{}
+	req.CustomHeaders = &empty
+	raw, err = json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"customHeaders":{}`) {
+		t.Fatalf("expected empty customHeaders object for clear, got %s", raw)
+	}
+}
+
 func TestMonitorRequests_EmptyURL_JSON(t *testing.T) {
 	updateReq := UpdateMonitorRequest{
 		Name:     "heartbeat",

--- a/internal/provider/integration_resource.go
+++ b/internal/provider/integration_resource.go
@@ -629,13 +629,13 @@ func (r *integrationResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	if t != "pagerduty" {
-		if !plan.Location.IsNull() && !plan.Location.IsUnknown() && plan.Location.ValueString() != "" {
+		if !config.Location.IsNull() && !config.Location.IsUnknown() && config.Location.ValueString() != "" {
 			resp.Diagnostics.AddWarning(
 				"Ignoring `location` for non-PagerDuty integration",
 				"The 'location' attribute only applies when type = 'pagerduty'. The provided value will be ignored.",
 			)
 		}
-		if !plan.AutoResolve.IsNull() && !plan.AutoResolve.IsUnknown() {
+		if !config.AutoResolve.IsNull() && !config.AutoResolve.IsUnknown() {
 			resp.Diagnostics.AddWarning(
 				"Ignoring `auto_resolve` for non-PagerDuty integration",
 				"The 'auto_resolve' attribute only applies when type = 'pagerduty'. The provided value will be ignored.",
@@ -1130,13 +1130,13 @@ func (r *integrationResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	if t != "pagerduty" {
-		if !plan.Location.IsNull() && !plan.Location.IsUnknown() && plan.Location.ValueString() != "" {
+		if !config.Location.IsNull() && !config.Location.IsUnknown() && config.Location.ValueString() != "" {
 			resp.Diagnostics.AddWarning(
 				"Ignoring `location` for non-PagerDuty integration",
 				"The 'location' attribute only applies when type = 'pagerduty'. The provided value will be ignored.",
 			)
 		}
-		if !plan.AutoResolve.IsNull() && !plan.AutoResolve.IsUnknown() {
+		if !config.AutoResolve.IsNull() && !config.AutoResolve.IsUnknown() {
 			resp.Diagnostics.AddWarning(
 				"Ignoring `auto_resolve` for non-PagerDuty integration",
 				"The 'auto_resolve' attribute only applies when type = 'pagerduty'. The provided value will be ignored.",

--- a/internal/provider/integration_resource.go
+++ b/internal/provider/integration_resource.go
@@ -608,6 +608,12 @@ func (r *integrationResource) Create(ctx context.Context, req resource.CreateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	var config integrationResourceModel
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	// Create new integration with the new API format
 	integrationTypeAPI := TransformIntegrationTypeToAPI(plan.Type.ValueString())
@@ -637,7 +643,7 @@ func (r *integrationResource) Create(ctx context.Context, req resource.CreateReq
 		}
 	}
 
-	customHeaders, diags := expandWebhookCustomHeaders(ctx, t, plan.CustomHeaders)
+	customHeaders, diags := expandWebhookCustomHeaders(ctx, t, config.CustomHeaders)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -1094,6 +1100,12 @@ func (r *integrationResource) Update(ctx context.Context, req resource.UpdateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	var config integrationResourceModel
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	id, err := strconv.ParseInt(plan.ID.ValueString(), 10, 64)
 	if err != nil {
@@ -1132,7 +1144,7 @@ func (r *integrationResource) Update(ctx context.Context, req resource.UpdateReq
 		}
 	}
 
-	customHeaders, diags := expandWebhookCustomHeaders(ctx, t, plan.CustomHeaders)
+	customHeaders, diags := expandWebhookCustomHeaders(ctx, t, config.CustomHeaders)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/integration_resource.go
+++ b/internal/provider/integration_resource.go
@@ -8,21 +8,27 @@ import (
 	"net"
 	"net/http"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/uptimerobot/terraform-provider-uptimerobot/internal/client"
 )
+
+var webhookHeaderNameRegexp = regexp.MustCompile(`^[!#$%&'*+\-.^_` + "`" + `|~0-9A-Za-z]+$`)
 
 // convertNotificationsForToString converts integer to API string format.
 func convertNotificationsForToString(value int64) string {
@@ -371,6 +377,66 @@ func webhookPostValueState(parsed types.String, known bool, prev types.String, t
 	return types.StringNull(), nil
 }
 
+func expandWebhookCustomHeaders(ctx context.Context, integrationType string, attr types.Map) (*map[string]string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if attr.IsNull() || attr.IsUnknown() {
+		return nil, diags
+	}
+
+	if strings.ToLower(strings.TrimSpace(integrationType)) != "webhook" {
+		diags.AddError(
+			"Invalid custom_headers for integration type",
+			"`custom_headers` is only valid when type = \"webhook\".",
+		)
+		return nil, diags
+	}
+
+	headers, d := stringMapFromAttrPreserveEmpty(ctx, attr)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	if err := validateWebhookCustomHeaders(headers); err != nil {
+		diags.AddError("Invalid custom_headers", err.Error())
+		return nil, diags
+	}
+
+	return &headers, diags
+}
+
+func validateWebhookCustomHeaders(headers map[string]string) error {
+	seen := make(map[string]string, len(headers))
+	for name := range headers {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			return fmt.Errorf("header names must not be empty")
+		}
+		if trimmed != name {
+			return fmt.Errorf("header name %q must not contain leading or trailing whitespace", name)
+		}
+		if !webhookHeaderNameRegexp.MatchString(name) {
+			return fmt.Errorf("header name %q must be a valid HTTP field name", name)
+		}
+		folded := strings.ToLower(name)
+		if previous, exists := seen[folded]; exists {
+			return fmt.Errorf("header names %q and %q differ only by case", previous, name)
+		}
+		seen[folded] = name
+	}
+	return nil
+}
+
+func webhookCustomHeadersState(ctx context.Context, prev types.Map, api map[string]string) (types.Map, diag.Diagnostics) {
+	if api != nil {
+		return types.MapValueFrom(ctx, types.StringType, api)
+	}
+	if !prev.IsNull() && !prev.IsUnknown() {
+		return prev, nil
+	}
+	return types.MapNull(types.StringType), nil
+}
+
 // Ensure the implementation satisfies the expected interfaces.
 var (
 	_ resource.Resource                = &integrationResource{}
@@ -401,6 +467,7 @@ type integrationResourceModel struct {
 	SendAsQueryString      types.Bool   `tfsdk:"send_as_query_string"`
 	SendAsPostParameters   types.Bool   `tfsdk:"send_as_post_parameters"`
 	PostValue              types.String `tfsdk:"post_value"`
+	CustomHeaders          types.Map    `tfsdk:"custom_headers"`
 	Priority               types.String `tfsdk:"priority"`
 	Location               types.String `tfsdk:"location"`
 	AutoResolve            types.Bool   `tfsdk:"auto_resolve"`
@@ -488,6 +555,22 @@ func (r *integrationResource) Schema(_ context.Context, _ resource.SchemaRequest
 					jsonEquivalentPlanModifier{},
 				},
 			},
+			"custom_headers": schema.MapAttribute{
+				Optional:            true,
+				Computed:            true,
+				Sensitive:           true,
+				ElementType:         types.StringType,
+				MarkdownDescription: "Custom HTTP headers to send with webhook notifications. Only valid for webhook integrations. Set `{}` to clear managed custom headers.",
+				Validators: []validator.Map{
+					mapvalidator.KeysAre(
+						stringvalidator.LengthAtLeast(1),
+						stringvalidator.RegexMatches(webhookHeaderNameRegexp, "must be a valid HTTP field name"),
+					),
+				},
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"priority": schema.StringAttribute{
 				Optional:            true,
 				MarkdownDescription: "Pushover priority (Lowest, Low, Normal, High, Emergency).",
@@ -554,6 +637,12 @@ func (r *integrationResource) Create(ctx context.Context, req resource.CreateReq
 		}
 	}
 
+	customHeaders, diags := expandWebhookCustomHeaders(ctx, t, plan.CustomHeaders)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	switch t {
 	case "slack":
 		integrationData = &client.SlackIntegrationData{
@@ -596,6 +685,7 @@ func (r *integrationResource) Create(ctx context.Context, req resource.CreateReq
 			SendAsQueryString:      plan.SendAsQueryString.ValueBool(),
 			SendAsJSON:             plan.SendAsJSON.ValueBool(),
 			SendAsPostParameters:   plan.SendAsPostParameters.ValueBool(),
+			CustomHeaders:          customHeaders,
 		}
 	case "zapier":
 		integrationData = &client.ZapierIntegrationData{
@@ -749,6 +839,18 @@ func (r *integrationResource) Create(ctx context.Context, req resource.CreateReq
 
 	// Map response body to schema and populate Computed attribute values
 	plan.ID = types.StringValue(strconv.FormatInt(newIntegration.ID, 10))
+	if t == "webhook" {
+		if plan.CustomHeaders.IsNull() || plan.CustomHeaders.IsUnknown() {
+			customHeadersState, diags := webhookCustomHeadersState(ctx, plan.CustomHeaders, newIntegration.CustomHeaders)
+			resp.Diagnostics.Append(diags...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			plan.CustomHeaders = customHeadersState
+		}
+	} else {
+		plan.CustomHeaders = types.MapNull(types.StringType)
+	}
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, plan)
@@ -893,6 +995,12 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 		}
 		state.PostValue = postValue
 		state.CustomValue = webhookFields.CustomValue
+		customHeaders, diags := webhookCustomHeadersState(ctx, prev.CustomHeaders, integration.CustomHeaders)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		state.CustomHeaders = customHeaders
 
 		state.Priority = types.StringNull()
 		state.Location = types.StringNull()
@@ -906,6 +1014,7 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 		state.SendAsQueryString = types.BoolNull()
 		state.SendAsPostParameters = types.BoolNull()
 		state.PostValue = types.StringNull()
+		state.CustomHeaders = types.MapNull(types.StringType)
 		state.Priority = types.StringNull()
 		state.Location = types.StringNull()
 		state.AutoResolve = types.BoolNull()
@@ -925,6 +1034,7 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 		state.SendAsQueryString = types.BoolNull()
 		state.SendAsPostParameters = types.BoolNull()
 		state.PostValue = types.StringNull()
+		state.CustomHeaders = types.MapNull(types.StringType)
 		state.Location = types.StringNull()
 		state.AutoResolve = types.BoolNull()
 
@@ -946,6 +1056,7 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 		state.SendAsQueryString = types.BoolNull()
 		state.SendAsPostParameters = types.BoolNull()
 		state.PostValue = types.StringNull()
+		state.CustomHeaders = types.MapNull(types.StringType)
 
 	default:
 		// For non-webhook integrations, normalize empty to null to avoid perpetual diffs
@@ -960,6 +1071,7 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 		state.SendAsQueryString = types.BoolNull()
 		state.SendAsPostParameters = types.BoolNull()
 		state.PostValue = types.StringNull()
+		state.CustomHeaders = types.MapNull(types.StringType)
 		state.Priority = types.StringNull()
 		state.Location = types.StringNull()
 		state.AutoResolve = types.BoolNull()
@@ -1020,6 +1132,12 @@ func (r *integrationResource) Update(ctx context.Context, req resource.UpdateReq
 		}
 	}
 
+	customHeaders, diags := expandWebhookCustomHeaders(ctx, t, plan.CustomHeaders)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	switch t {
 	case "slack":
 		integrationData = &client.SlackIntegrationData{
@@ -1063,6 +1181,7 @@ func (r *integrationResource) Update(ctx context.Context, req resource.UpdateReq
 			SendAsQueryString:      plan.SendAsQueryString.ValueBool(),
 			SendAsJSON:             plan.SendAsJSON.ValueBool(),
 			SendAsPostParameters:   plan.SendAsPostParameters.ValueBool(),
+			CustomHeaders:          customHeaders,
 		}
 	case "zapier":
 		integrationData = &client.ZapierIntegrationData{
@@ -1190,12 +1309,30 @@ func (r *integrationResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	if _, err := r.waitIntegrationSettled(ctx, id, plan.Name.ValueString(), 90*time.Second); err != nil {
+	settled, err := r.waitIntegrationSettled(ctx, id, plan.Name.ValueString(), 90*time.Second)
+	if err != nil {
 		resp.Diagnostics.AddError(
 			"Integration update did not settle in time",
 			err.Error(),
 		)
 		return
+	}
+
+	if t == "webhook" {
+		if plan.CustomHeaders.IsNull() || plan.CustomHeaders.IsUnknown() {
+			var apiHeaders map[string]string
+			if settled != nil {
+				apiHeaders = settled.CustomHeaders
+			}
+			customHeadersState, diags := webhookCustomHeadersState(ctx, plan.CustomHeaders, apiHeaders)
+			resp.Diagnostics.Append(diags...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			plan.CustomHeaders = customHeadersState
+		}
+	} else {
+		plan.CustomHeaders = types.MapNull(types.StringType)
 	}
 
 	// Set state to fully populated data

--- a/internal/provider/integration_resource_acc_test.go
+++ b/internal/provider/integration_resource_acc_test.go
@@ -3,13 +3,18 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/uptimerobot/terraform-provider-uptimerobot/internal/client"
 )
 
 // Configs
@@ -32,6 +37,28 @@ resource "uptimerobot_integration" "webhook" {
 `, name, value)
 }
 
+func testAccWebhookIntegrationConfigWithCustomHeaders(name, value string, headers *map[string]string) string {
+	customHeaders := ""
+	if headers != nil {
+		customHeaders = "\n  custom_headers = " + hclStringMap(*headers)
+	}
+
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "uptimerobot_integration" "webhook" {
+  name                     = %q
+  type                     = "webhook"
+  value                    = %q
+  enable_notifications_for = 1
+  ssl_expiration_reminder  = true
+
+  send_as_json             = true
+  send_as_query_string     = false
+  send_as_post_parameters  = false
+  post_value               = jsonencode({ message = "Alert: $monitorURL is $alertType" })%s
+}
+`, name, value, customHeaders)
+}
+
 func testAccIntegrationPreCheck(t *testing.T) {
 	if v := os.Getenv("UPTIMEROBOT_API_KEY"); v == "" {
 		t.Skip("UPTIMEROBOT_API_KEY must be set to run integration acceptance tests")
@@ -44,6 +71,57 @@ provider "uptimerobot" {
   api_key = "%s"
 }
 `, os.Getenv("UPTIMEROBOT_API_KEY"))
+}
+
+func testAccCheckWebhookCustomHeaders(resourceName string, expected map[string]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found", resourceName)
+		}
+
+		id, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		if err != nil {
+			return fmt.Errorf("could not parse integration ID %q: %w", rs.Primary.ID, err)
+		}
+
+		apiClient := client.NewClient(os.Getenv("UPTIMEROBOT_API_KEY"))
+		if apiURL := os.Getenv("UPTIMEROBOT_API_URL"); apiURL != "" {
+			apiClient.SetBaseURL(apiURL)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		defer cancel()
+
+		backoff := 500 * time.Millisecond
+		var lastErr error
+		for {
+			integration, err := apiClient.GetIntegration(ctx, id)
+			if err != nil {
+				lastErr = err
+			} else if equalStringMap(integration.CustomHeaders, expected) {
+				return nil
+			} else {
+				lastErr = fmt.Errorf("expected custom_headers %#v, got %#v", expected, integration.CustomHeaders)
+			}
+
+			select {
+			case <-ctx.Done():
+				if lastErr != nil {
+					return lastErr
+				}
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+
+			if backoff < 5*time.Second {
+				backoff *= 2
+				if backoff > 5*time.Second {
+					backoff = 5 * time.Second
+				}
+			}
+		}
+	}
 }
 
 // Helpers
@@ -168,6 +246,67 @@ resource "uptimerobot_integration" "test" {
 			},
 			{
 				Config:             cfg2,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAcc_Integration_Webhook_CustomHeaders(t *testing.T) {
+	suffix := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	name := "tfacc-webhook-headers-" + suffix
+	value := fmt.Sprintf("https://httpbin.org/anything?tfacc_headers=%s", suffix)
+	resourceName := "uptimerobot_integration.webhook"
+
+	initialHeaders := map[string]string{
+		"Authorization": "Bearer initial",
+		"X-Source":      "terraform",
+	}
+	updatedHeaders := map[string]string{
+		"Authorization": "Bearer updated",
+		"X-Trace-ID":    suffix,
+	}
+	emptyHeaders := map[string]string{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckIntegrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWebhookIntegrationConfigWithCustomHeaders(name, value, &initialHeaders),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "custom_headers.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "custom_headers.Authorization", "Bearer initial"),
+					resource.TestCheckResourceAttr(resourceName, "custom_headers.X-Source", "terraform"),
+					testAccCheckWebhookCustomHeaders(resourceName, initialHeaders),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccWebhookIntegrationConfigWithCustomHeaders(name, value, &updatedHeaders),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "custom_headers.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "custom_headers.Authorization", "Bearer updated"),
+					resource.TestCheckResourceAttr(resourceName, "custom_headers.X-Trace-ID", suffix),
+					resource.TestCheckNoResourceAttr(resourceName, "custom_headers.X-Source"),
+					testAccCheckWebhookCustomHeaders(resourceName, updatedHeaders),
+				),
+			},
+			{
+				Config: testAccWebhookIntegrationConfigWithCustomHeaders(name, value, &emptyHeaders),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "custom_headers.%", "0"),
+					testAccCheckWebhookCustomHeaders(resourceName, emptyHeaders),
+				),
+			},
+			{
+				Config:             testAccWebhookIntegrationConfigWithCustomHeaders(name, value, &emptyHeaders),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},

--- a/internal/provider/integration_resource_test.go
+++ b/internal/provider/integration_resource_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/uptimerobot/terraform-provider-uptimerobot/internal/client"
 )
@@ -198,6 +199,103 @@ func TestStickyStringPreferPrevOnMismatch(t *testing.T) {
 	got = stickyStringPreferPrevOnMismatch(types.StringNull(), "us", nil)
 	if got.ValueString() != "us" {
 		t.Fatalf("expected api value when previous is null, got=%q", got.ValueString())
+	}
+}
+
+func TestExpandWebhookCustomHeaders(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	headers := types.MapValueMust(types.StringType, map[string]attr.Value{
+		"Authorization": types.StringValue("Bearer token"),
+		"X-Source":      types.StringValue("terraform"),
+	})
+
+	got, diags := expandWebhookCustomHeaders(ctx, "webhook", headers)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+	if got == nil {
+		t.Fatal("expected custom headers pointer")
+	}
+	if (*got)["Authorization"] != "Bearer token" || (*got)["X-Source"] != "terraform" {
+		t.Fatalf("unexpected custom headers: %#v", *got)
+	}
+
+	empty, diags := expandWebhookCustomHeaders(ctx, "webhook", types.MapValueMust(types.StringType, map[string]attr.Value{}))
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics for empty map: %+v", diags)
+	}
+	if empty == nil || len(*empty) != 0 {
+		t.Fatalf("expected empty map pointer for clear, got %#v", empty)
+	}
+}
+
+func TestExpandWebhookCustomHeadersRejectsInvalidUsage(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	headers := types.MapValueMust(types.StringType, map[string]attr.Value{
+		"Authorization": types.StringValue("Bearer token"),
+	})
+
+	if _, diags := expandWebhookCustomHeaders(ctx, "slack", headers); !diags.HasError() {
+		t.Fatal("expected diagnostics for non-webhook custom_headers")
+	}
+
+	invalidName := types.MapValueMust(types.StringType, map[string]attr.Value{
+		"Bad Header": types.StringValue("value"),
+	})
+	if _, diags := expandWebhookCustomHeaders(ctx, "webhook", invalidName); !diags.HasError() {
+		t.Fatal("expected diagnostics for invalid header name")
+	}
+
+	duplicate := types.MapValueMust(types.StringType, map[string]attr.Value{
+		"X-Test": types.StringValue("one"),
+		"x-test": types.StringValue("two"),
+	})
+	if _, diags := expandWebhookCustomHeaders(ctx, "webhook", duplicate); !diags.HasError() {
+		t.Fatal("expected diagnostics for case-insensitive duplicate header names")
+	}
+}
+
+func TestWebhookCustomHeadersState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	prev := types.MapValueMust(types.StringType, map[string]attr.Value{
+		"Authorization": types.StringValue("Bearer old"),
+	})
+
+	got, diags := webhookCustomHeadersState(ctx, prev, map[string]string{
+		"Authorization": "Bearer new",
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+	var gotMap map[string]string
+	diags.Append(got.ElementsAs(ctx, &gotMap, false)...)
+	if diags.HasError() {
+		t.Fatalf("unexpected map diagnostics: %+v", diags)
+	}
+	if gotMap["Authorization"] != "Bearer new" {
+		t.Fatalf("expected API headers to win, got %#v", gotMap)
+	}
+
+	got, diags = webhookCustomHeadersState(ctx, prev, nil)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+	if got.IsNull() || got.IsUnknown() {
+		t.Fatal("expected previous headers to be preserved when API omits customHeaders")
+	}
+
+	got, diags = webhookCustomHeadersState(ctx, types.MapNull(types.StringType), nil)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+	if !got.IsNull() {
+		t.Fatalf("expected null headers when API and state omit customHeaders, got %#v", got)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monitor group support with automatic monitor reassignment on deletion; HTTP monitor retry configuration and structured region/threshold data support.

* **Documentation**
  * Docs and examples updated for webhook `custom_headers` usage and schema; examples show auth header usage and clearing behavior.

* **Deprecated**
  * `regional_data` replaced by `region_data` (conflicting attribute resolved).

* **Bug Fixes**
  * Improved read-after-write stability for monitors and maintenance windows.

* **Tests**
  * Added coverage for custom headers, region data, and related request serialization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uptimerobot/terraform-provider-uptimerobot/pull/220)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->