### PR TITLE
Add PSP announcement pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Added `uptimerobot_psp_announcement` resource for creating, updating, importing, and archiving public status page announcements.
+- Added `is_pinned` support to `uptimerobot_psp_announcement` for declarative PSP announcement pin and unpin management.
 
 ## 1.6.0 — 2026-05-16
 

--- a/docs/resources/psp_announcement.md
+++ b/docs/resources/psp_announcement.md
@@ -27,6 +27,7 @@ resource "uptimerobot_psp_announcement" "maintenance" {
   type       = "maintenance"
   start_date = "2030-01-01T00:00:00Z"
   end_date   = "2030-01-01T02:00:00Z"
+  is_pinned  = true
 }
 ```
 
@@ -38,6 +39,13 @@ Use a future `start_date` with `pending` when scheduling an announcement. Uptime
 `type` accepts `info`, `maintenance`, or `issue`.
 
 `end_date` is optional. Omit it or set it to `null` to keep the announcement without an end date.
+
+## Pin Ownership
+
+Set `is_pinned = true` to pin this announcement on its public status page, or `is_pinned = false` to unpin it when it is currently pinned.
+Omit `is_pinned` to leave pinned-announcement state unmanaged by this resource.
+
+Do not manage `is_pinned` on `uptimerobot_psp_announcement` and `pinned_announcement_id` on `uptimerobot_psp` for the same public status page at the same time. They both own the same remote API field.
 
 Delivery counters such as subscriber send counts are not exposed because they are runtime metadata and are not managed by Terraform.
 
@@ -66,6 +74,7 @@ terraform import uptimerobot_psp_announcement.example 123456:789012
 ### Optional
 
 - `end_date` (String) Optional announcement end date as an RFC3339 timestamp. Omit or set to null to leave the announcement without an end date.
+- `is_pinned` (Boolean) Whether this announcement is pinned on its public status page. Omit this attribute to leave pinned-announcement ownership unmanaged by this resource.
 - `status` (String) Announcement status. Valid values are offline, pending, published, and archived.
 - `type` (String) Announcement type. Valid values are info, maintenance, and issue.
 

--- a/examples/resources/uptimerobot_psp_announcement/resource.tf
+++ b/examples/resources/uptimerobot_psp_announcement/resource.tf
@@ -13,4 +13,5 @@ resource "uptimerobot_psp_announcement" "maintenance" {
   type       = "maintenance"
   start_date = "2030-01-01T00:00:00Z"
   end_date   = "2030-01-01T02:00:00Z"
+  is_pinned  = true
 }

--- a/internal/client/psp_announcement.go
+++ b/internal/client/psp_announcement.go
@@ -55,6 +55,10 @@ func pspAnnouncementPath(pspID, announcementID int64) string {
 	return fmt.Sprintf("%s/%d", pspAnnouncementEndpoint(pspID), announcementID)
 }
 
+func pspAnnouncementActionPath(pspID, announcementID int64, action string) string {
+	return fmt.Sprintf("%s/%s", pspAnnouncementPath(pspID, announcementID), action)
+}
+
 // ListPSPAnnouncements lists announcements for a PSP.
 func (c *Client) ListPSPAnnouncements(ctx context.Context, pspID int64, cursorID *int64) (*PSPAnnouncementListResponse, error) {
 	path := pspAnnouncementEndpoint(pspID)
@@ -114,6 +118,18 @@ func (c *Client) UpdatePSPAnnouncement(ctx context.Context, pspID, announcementI
 		return nil, fmt.Errorf("failed to unmarshal PSP announcement response: %w", err)
 	}
 	return &announcement, nil
+}
+
+// PinPSPAnnouncement pins an announcement on its PSP.
+func (c *Client) PinPSPAnnouncement(ctx context.Context, pspID, announcementID int64) error {
+	_, err := c.doRequest(ctx, http.MethodPost, pspAnnouncementActionPath(pspID, announcementID, "pin"), struct{}{})
+	return err
+}
+
+// UnpinPSPAnnouncement unpins an announcement from its PSP.
+func (c *Client) UnpinPSPAnnouncement(ctx context.Context, pspID, announcementID int64) error {
+	_, err := c.doRequest(ctx, http.MethodPost, pspAnnouncementActionPath(pspID, announcementID, "unpin"), struct{}{})
+	return err
 }
 
 // ArchivePSPAnnouncement archives a PSP announcement. The public API does not expose hard deletion.

--- a/internal/client/psp_announcement_test.go
+++ b/internal/client/psp_announcement_test.go
@@ -47,6 +47,16 @@ func TestClient_PSPAnnouncementCRUDPaths(t *testing.T) {
 				return jsonResponse(http.StatusOK, `{"id":101,"pspId":42,"userId":7,"title":"Updated","content":"Window","status":"Pending","type":"Maintenance","startDate":"2030-01-01T00:00:00.000Z","endDate":null,"creationDate":"2026-05-16T10:00:00.000Z"}`), nil
 			case "GET /psps/42/announcements?cursor=101":
 				return jsonResponse(http.StatusOK, `{"data":[],"nextLink":null}`), nil
+			case "POST /psps/42/announcements/101/pin":
+				if string(body) != "{}" {
+					t.Fatalf("unexpected pin body: %s", body)
+				}
+				return jsonResponse(http.StatusOK, `{}`), nil
+			case "POST /psps/42/announcements/101/unpin":
+				if string(body) != "{}" {
+					t.Fatalf("unexpected unpin body: %s", body)
+				}
+				return jsonResponse(http.StatusOK, `{}`), nil
 			default:
 				t.Fatalf("unexpected request %s", req.Method+" "+req.URL.RequestURI())
 				return nil, nil
@@ -100,6 +110,14 @@ func TestClient_PSPAnnouncementCRUDPaths(t *testing.T) {
 		t.Fatalf("ListPSPAnnouncements returned error: %v", err)
 	}
 
+	if err := c.PinPSPAnnouncement(context.Background(), 42, 101); err != nil {
+		t.Fatalf("PinPSPAnnouncement returned error: %v", err)
+	}
+
+	if err := c.UnpinPSPAnnouncement(context.Background(), 42, 101); err != nil {
+		t.Fatalf("UnpinPSPAnnouncement returned error: %v", err)
+	}
+
 	archived, err := c.ArchivePSPAnnouncement(context.Background(), 42, 101)
 	if err != nil {
 		t.Fatalf("ArchivePSPAnnouncement returned error: %v", err)
@@ -113,6 +131,8 @@ func TestClient_PSPAnnouncementCRUDPaths(t *testing.T) {
 		"GET /psps/42/announcements/101",
 		"PATCH /psps/42/announcements/101",
 		"GET /psps/42/announcements?cursor=101",
+		"POST /psps/42/announcements/101/pin",
+		"POST /psps/42/announcements/101/unpin",
 		"PATCH /psps/42/announcements/101",
 	}
 	if strings.Join(seen, "\n") != strings.Join(want, "\n") {

--- a/internal/provider/psp_announcement_resource.go
+++ b/internal/provider/psp_announcement_resource.go
@@ -214,7 +214,17 @@ func (r *pspAnnouncementResource) Create(ctx context.Context, req resource.Creat
 
 	if pspAnnouncementPinManaged(plan.IsPinned) {
 		if err := reconcilePSPAnnouncementPin(ctx, r.client, plan.PSPID.ValueInt64(), announcement.ID, plan.IsPinned.ValueBool(), false); err != nil {
-			resp.Diagnostics.AddError("Error managing PSP announcement pin state", err.Error())
+			if cleanupErr := archiveCreatedPSPAnnouncementAfterPinFailure(ctx, r.client, plan.PSPID.ValueInt64(), announcement.ID); cleanupErr != nil {
+				resp.Diagnostics.AddError(
+					"Error managing PSP announcement pin state",
+					fmt.Sprintf("%s. Terraform also failed to archive the newly created announcement %d during cleanup: %v", err.Error(), announcement.ID, cleanupErr),
+				)
+				return
+			}
+			resp.Diagnostics.AddError(
+				"Error managing PSP announcement pin state",
+				fmt.Sprintf("%s. Terraform archived the newly created announcement %d to avoid leaving it unmanaged.", err.Error(), announcement.ID),
+			)
 			return
 		}
 	}
@@ -478,8 +488,10 @@ func reconcilePSPAnnouncementPin(ctx context.Context, c *client.Client, pspID, a
 	if err != nil {
 		return err
 	}
-	if currentlyPinned == desired && !(forceUnpin && !desired) {
-		return nil
+	if currentlyPinned == desired {
+		if !forceUnpin || desired {
+			return nil
+		}
 	}
 
 	if desired {
@@ -490,6 +502,17 @@ func reconcilePSPAnnouncementPin(ctx context.Context, c *client.Client, pspID, a
 	}
 
 	return unpinPSPAnnouncement(ctx, c, pspID, announcementID, forceUnpin)
+}
+
+func archiveCreatedPSPAnnouncementAfterPinFailure(ctx context.Context, c *client.Client, pspID, announcementID int64) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+
+	_, err := c.ArchivePSPAnnouncement(cleanupCtx, pspID, announcementID)
+	if client.IsNotFound(err) {
+		return nil
+	}
+	return err
 }
 
 func unpinPSPAnnouncement(ctx context.Context, c *client.Client, pspID, announcementID int64, force bool) error {
@@ -521,7 +544,6 @@ func waitPSPAnnouncementPinSettled(
 	desired bool,
 	timeout time.Duration,
 ) error {
-	started := time.Now()
 	deadline := time.Now().Add(timeout)
 	settleDuration := 5 * time.Second
 	if !desired {
@@ -529,6 +551,7 @@ func waitPSPAnnouncementPinSettled(
 	}
 	backoff := 500 * time.Millisecond
 	var lastPinnedID *int64
+	var matchSince time.Time
 	consecutiveMatches := 0
 
 	for {
@@ -548,15 +571,18 @@ func waitPSPAnnouncementPinSettled(
 			lastPinnedID = psp.PinnedAnnouncementID
 			currentlyPinned := psp.PinnedAnnouncementID != nil && *psp.PinnedAnnouncementID == announcementID
 			if currentlyPinned == desired {
+				if consecutiveMatches == 0 {
+					matchSince = time.Now()
+				}
 				consecutiveMatches++
-				if consecutiveMatches >= 2 && time.Since(started) >= settleDuration {
+				if consecutiveMatches >= 2 && time.Since(matchSince) >= settleDuration {
 					return nil
 				}
 			} else {
+				matchSince = time.Time{}
 				consecutiveMatches = 0
 			}
 		} else if !client.IsNotFound(err) {
-			consecutiveMatches = 0
 			return err
 		}
 

--- a/internal/provider/psp_announcement_resource.go
+++ b/internal/provider/psp_announcement_resource.go
@@ -46,6 +46,7 @@ type pspAnnouncementResourceModel struct {
 	Type         types.String `tfsdk:"type"`
 	StartDate    types.String `tfsdk:"start_date"`
 	EndDate      types.String `tfsdk:"end_date"`
+	IsPinned     types.Bool   `tfsdk:"is_pinned"`
 	CreationDate types.String `tfsdk:"creation_date"`
 }
 
@@ -140,6 +141,10 @@ func (r *pspAnnouncementResource) Schema(_ context.Context, _ resource.SchemaReq
 				Description: "Optional announcement end date as an RFC3339 timestamp. Omit or set to null to leave the announcement without an end date.",
 				Optional:    true,
 			},
+			"is_pinned": schema.BoolAttribute{
+				Description: "Whether this announcement is pinned on its public status page. Omit this attribute to leave pinned-announcement ownership unmanaged by this resource.",
+				Optional:    true,
+			},
 			"creation_date": schema.StringAttribute{
 				Description: "Announcement creation timestamp returned by the API.",
 				Computed:    true,
@@ -207,6 +212,13 @@ func (r *pspAnnouncementResource) Create(ctx context.Context, req resource.Creat
 		announcementForState = settled
 	}
 
+	if pspAnnouncementPinManaged(plan.IsPinned) {
+		if err := reconcilePSPAnnouncementPin(ctx, r.client, plan.PSPID.ValueInt64(), announcement.ID, plan.IsPinned.ValueBool(), false); err != nil {
+			resp.Diagnostics.AddError("Error managing PSP announcement pin state", err.Error())
+			return
+		}
+	}
+
 	plan.applyAPI(announcementForState)
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
@@ -236,6 +248,14 @@ func (r *pspAnnouncementResource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	state.applyAPI(announcement)
+	if pspAnnouncementPinManaged(state.IsPinned) {
+		pinned, err := readPSPAnnouncementPinState(ctx, r.client, pspID, announcementID, state.IsPinned.ValueBool(), 30*time.Second)
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading PSP announcement pin state", err.Error())
+			return
+		}
+		state.IsPinned = types.BoolValue(pinned)
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -279,6 +299,14 @@ func (r *pspAnnouncementResource) Update(ctx context.Context, req resource.Updat
 		announcementForState = settled
 	}
 
+	if pspAnnouncementPinManaged(plan.IsPinned) {
+		forceUnpin := pspAnnouncementPinManaged(state.IsPinned) && state.IsPinned.ValueBool()
+		if err := reconcilePSPAnnouncementPin(ctx, r.client, plan.PSPID.ValueInt64(), announcementID, plan.IsPinned.ValueBool(), forceUnpin); err != nil {
+			resp.Diagnostics.AddError("Error managing PSP announcement pin state", err.Error())
+			return
+		}
+	}
+
 	plan.applyAPI(announcementForState)
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
@@ -293,6 +321,12 @@ func (r *pspAnnouncementResource) Delete(ctx context.Context, req resource.Delet
 	announcementID, err := state.announcementID()
 	if err != nil {
 		resp.Diagnostics.AddError("Invalid PSP announcement ID", err.Error())
+		return
+	}
+
+	forceUnpin := pspAnnouncementPinManaged(state.IsPinned) && state.IsPinned.ValueBool()
+	if err := unpinPSPAnnouncement(ctx, r.client, state.PSPID.ValueInt64(), announcementID, forceUnpin); err != nil {
+		resp.Diagnostics.AddError("Error unpinning PSP announcement before archive", err.Error())
 		return
 	}
 
@@ -437,6 +471,169 @@ func waitPSPAnnouncementSettled(
 			}
 		}
 	}
+}
+
+func reconcilePSPAnnouncementPin(ctx context.Context, c *client.Client, pspID, announcementID int64, desired bool, forceUnpin bool) error {
+	currentlyPinned, err := pspAnnouncementIsPinned(ctx, c, pspID, announcementID)
+	if err != nil {
+		return err
+	}
+	if currentlyPinned == desired && !(forceUnpin && !desired) {
+		return nil
+	}
+
+	if desired {
+		if err := c.PinPSPAnnouncement(ctx, pspID, announcementID); err != nil {
+			return err
+		}
+		return waitPSPAnnouncementPinSettled(ctx, c, pspID, announcementID, true, 90*time.Second)
+	}
+
+	return unpinPSPAnnouncement(ctx, c, pspID, announcementID, forceUnpin)
+}
+
+func unpinPSPAnnouncement(ctx context.Context, c *client.Client, pspID, announcementID int64, force bool) error {
+	currentlyPinned, err := pspAnnouncementIsPinned(ctx, c, pspID, announcementID)
+	if err != nil {
+		if client.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if !currentlyPinned && !force {
+		return nil
+	}
+
+	if err := c.UnpinPSPAnnouncement(ctx, pspID, announcementID); err != nil {
+		pinned, readErr := pspAnnouncementIsPinned(ctx, c, pspID, announcementID)
+		if readErr == nil && !pinned {
+			return nil
+		}
+		return err
+	}
+	return waitPSPAnnouncementPinSettled(ctx, c, pspID, announcementID, false, 90*time.Second)
+}
+
+func waitPSPAnnouncementPinSettled(
+	ctx context.Context,
+	c *client.Client,
+	pspID, announcementID int64,
+	desired bool,
+	timeout time.Duration,
+) error {
+	started := time.Now()
+	deadline := time.Now().Add(timeout)
+	settleDuration := 5 * time.Second
+	if !desired {
+		settleDuration = 30 * time.Second
+	}
+	backoff := 500 * time.Millisecond
+	var lastPinnedID *int64
+	consecutiveMatches := 0
+
+	for {
+		if ctx.Err() != nil || time.Now().After(deadline) {
+			message := fmt.Sprintf("timeout waiting for PSP announcement is_pinned=%t", desired)
+			if lastPinnedID != nil {
+				message = fmt.Sprintf("%s; last pinned_announcement_id=%d", message, *lastPinnedID)
+			}
+			if ctx.Err() != nil {
+				return fmt.Errorf("%s: %w", message, ctx.Err())
+			}
+			return fmt.Errorf("%s", message)
+		}
+
+		psp, err := c.GetPSP(ctx, pspID)
+		if err == nil {
+			lastPinnedID = psp.PinnedAnnouncementID
+			currentlyPinned := psp.PinnedAnnouncementID != nil && *psp.PinnedAnnouncementID == announcementID
+			if currentlyPinned == desired {
+				consecutiveMatches++
+				if consecutiveMatches >= 2 && time.Since(started) >= settleDuration {
+					return nil
+				}
+			} else {
+				consecutiveMatches = 0
+			}
+		} else if !client.IsNotFound(err) {
+			consecutiveMatches = 0
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout waiting for PSP announcement is_pinned=%t: %w", desired, ctx.Err())
+		case <-time.After(backoff):
+		}
+
+		if backoff < 5*time.Second {
+			backoff *= 2
+			if backoff > 5*time.Second {
+				backoff = 5 * time.Second
+			}
+		}
+	}
+}
+
+func readPSPAnnouncementPinState(
+	ctx context.Context,
+	c *client.Client,
+	pspID, announcementID int64,
+	preferred bool,
+	timeout time.Duration,
+) (bool, error) {
+	deadline := time.Now().Add(timeout)
+	backoff := 500 * time.Millisecond
+	lastPinned := false
+	var lastErr error
+
+	for {
+		pinned, err := pspAnnouncementIsPinned(ctx, c, pspID, announcementID)
+		if err == nil {
+			lastErr = nil
+			lastPinned = pinned
+			if pinned == preferred {
+				return pinned, nil
+			}
+		} else {
+			lastErr = err
+			if client.IsNotFound(err) {
+				return false, err
+			}
+		}
+
+		if ctx.Err() != nil || time.Now().After(deadline) {
+			if lastErr != nil {
+				return lastPinned, lastErr
+			}
+			return lastPinned, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return lastPinned, ctx.Err()
+		case <-time.After(backoff):
+		}
+
+		if backoff < 5*time.Second {
+			backoff *= 2
+			if backoff > 5*time.Second {
+				backoff = 5 * time.Second
+			}
+		}
+	}
+}
+
+func pspAnnouncementIsPinned(ctx context.Context, c *client.Client, pspID, announcementID int64) (bool, error) {
+	psp, err := c.GetPSP(ctx, pspID)
+	if err != nil {
+		return false, err
+	}
+	return psp.PinnedAnnouncementID != nil && *psp.PinnedAnnouncementID == announcementID, nil
+}
+
+func pspAnnouncementPinManaged(value types.Bool) bool {
+	return !value.IsNull() && !value.IsUnknown()
 }
 
 func pspAnnouncementMatches(announcement *client.PSPAnnouncement, expected pspAnnouncementExpected) bool {

--- a/internal/provider/psp_announcement_resource.go
+++ b/internal/provider/psp_announcement_resource.go
@@ -334,10 +334,12 @@ func (r *pspAnnouncementResource) Delete(ctx context.Context, req resource.Delet
 		return
 	}
 
-	forceUnpin := pspAnnouncementPinManaged(state.IsPinned) && state.IsPinned.ValueBool()
-	if err := unpinPSPAnnouncement(ctx, r.client, state.PSPID.ValueInt64(), announcementID, forceUnpin); err != nil {
-		resp.Diagnostics.AddError("Error unpinning PSP announcement before archive", err.Error())
-		return
+	if pspAnnouncementPinManaged(state.IsPinned) {
+		forceUnpin := state.IsPinned.ValueBool()
+		if err := unpinPSPAnnouncement(ctx, r.client, state.PSPID.ValueInt64(), announcementID, forceUnpin); err != nil {
+			resp.Diagnostics.AddError("Error unpinning PSP announcement before archive", err.Error())
+			return
+		}
 	}
 
 	archived, err := r.client.ArchivePSPAnnouncement(ctx, state.PSPID.ValueInt64(), announcementID)
@@ -547,6 +549,8 @@ func waitPSPAnnouncementPinSettled(
 	deadline := time.Now().Add(timeout)
 	settleDuration := 5 * time.Second
 	if !desired {
+		// Unpin can be observed as false before the API has finished propagating the write.
+		// Keep it stable longer so a later pin is not cleared by delayed unpin side effects.
 		settleDuration = 30 * time.Second
 	}
 	backoff := 500 * time.Millisecond

--- a/internal/provider/psp_announcement_resource_acc_test.go
+++ b/internal/provider/psp_announcement_resource_acc_test.go
@@ -97,16 +97,16 @@ func TestAccPSPAnnouncementResource_PinUnpin(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccPSPAnnouncementResourcePinConfig(name, pspAnnouncementBoolPtr(false)),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("uptimerobot_psp_announcement.test", "is_pinned", "false"),
-					testAccCheckPSPAnnouncementPinned("uptimerobot_psp_announcement.test", false),
-				),
-			},
-			{
 				Config: testAccPSPAnnouncementResourcePinConfig(name, nil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckNoResourceAttr("uptimerobot_psp_announcement.test", "is_pinned"),
+					testAccCheckPSPAnnouncementPinned("uptimerobot_psp_announcement.test", true),
+				),
+			},
+			{
+				Config: testAccPSPAnnouncementResourcePinConfig(name, pspAnnouncementBoolPtr(false)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_psp_announcement.test", "is_pinned", "false"),
 					testAccCheckPSPAnnouncementPinned("uptimerobot_psp_announcement.test", false),
 				),
 			},

--- a/internal/provider/psp_announcement_resource_acc_test.go
+++ b/internal/provider/psp_announcement_resource_acc_test.go
@@ -3,9 +3,12 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -74,6 +77,50 @@ func TestAccPSPAnnouncementResource(t *testing.T) {
 	})
 }
 
+func TestAccPSPAnnouncementResource_PinUnpin(t *testing.T) {
+	if os.Getenv("UPTIMEROBOT_TEST_PSP_ANNOUNCEMENT") != "1" {
+		t.Skip("set UPTIMEROBOT_TEST_PSP_ANNOUNCEMENT=1 to run PSP announcement acceptance tests")
+	}
+
+	name := randomName("acc-psp-ann-pin")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPSPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPSPAnnouncementResourcePinConfig(name, pspAnnouncementBoolPtr(true)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_psp_announcement.test", "is_pinned", "true"),
+					testAccCheckPSPAnnouncementPinned("uptimerobot_psp_announcement.test", true),
+				),
+			},
+			{
+				Config: testAccPSPAnnouncementResourcePinConfig(name, pspAnnouncementBoolPtr(false)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_psp_announcement.test", "is_pinned", "false"),
+					testAccCheckPSPAnnouncementPinned("uptimerobot_psp_announcement.test", false),
+				),
+			},
+			{
+				Config: testAccPSPAnnouncementResourcePinConfig(name, nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("uptimerobot_psp_announcement.test", "is_pinned"),
+					testAccCheckPSPAnnouncementPinned("uptimerobot_psp_announcement.test", false),
+				),
+			},
+			{
+				Config: testAccPSPAnnouncementResourcePinConfig(name, pspAnnouncementBoolPtr(true)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_psp_announcement.test", "is_pinned", "true"),
+					testAccCheckPSPAnnouncementPinned("uptimerobot_psp_announcement.test", true),
+				),
+			},
+		},
+	})
+}
+
 func testAccPSPAnnouncementResourceConfig(
 	name string,
 	title string,
@@ -105,6 +152,29 @@ resource "uptimerobot_psp_announcement" "test" {
 `, name, title, content, status, announcementType, startDate, endDateConfig)
 }
 
+func testAccPSPAnnouncementResourcePinConfig(name string, pinned *bool) string {
+	pinnedConfig := ""
+	if pinned != nil {
+		pinnedConfig = fmt.Sprintf("\n  is_pinned  = %t", *pinned)
+	}
+
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "uptimerobot_psp" "test" {
+  name         = %q
+  subscription = true
+}
+
+resource "uptimerobot_psp_announcement" "test" {
+  psp_id     = tonumber(uptimerobot_psp.test.id)
+  title      = "Pinned maintenance"
+  content    = "We will perform scheduled maintenance."
+  status     = "pending"
+  type       = "maintenance"
+  start_date = "2030-01-01T00:00:00Z"%s
+}
+`, name, pinnedConfig)
+}
+
 func testAccPSPAnnouncementImportStateID(s *terraform.State) (string, error) {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "uptimerobot_psp_announcement" {
@@ -117,4 +187,53 @@ func testAccPSPAnnouncementImportStateID(s *terraform.State) (string, error) {
 		return fmt.Sprintf("%s:%s", pspID, rs.Primary.ID), nil
 	}
 	return "", fmt.Errorf("uptimerobot_psp_announcement.test not found in state")
+}
+
+func testAccCheckPSPAnnouncementPinned(resourceName string, expected bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found", resourceName)
+		}
+
+		pspID, err := strconv.ParseInt(rs.Primary.Attributes["psp_id"], 10, 64)
+		if err != nil {
+			return fmt.Errorf("could not parse psp_id %q: %w", rs.Primary.Attributes["psp_id"], err)
+		}
+		announcementID, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		if err != nil {
+			return fmt.Errorf("could not parse announcement ID %q: %w", rs.Primary.ID, err)
+		}
+
+		apiClient := testAccAPIClient()
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		defer cancel()
+
+		var lastPinnedID *int64
+		for {
+			psp, err := apiClient.GetPSP(ctx, pspID)
+			if err != nil {
+				return fmt.Errorf("could not read PSP %d: %w", pspID, err)
+			}
+
+			lastPinnedID = psp.PinnedAnnouncementID
+			got := psp.PinnedAnnouncementID != nil && *psp.PinnedAnnouncementID == announcementID
+			if got == expected {
+				return nil
+			}
+
+			select {
+			case <-ctx.Done():
+				if lastPinnedID == nil {
+					return fmt.Errorf("expected is_pinned=%t, got nil pinned_announcement_id", expected)
+				}
+				return fmt.Errorf("expected is_pinned=%t for announcement %d, got pinned_announcement_id=%d", expected, announcementID, *lastPinnedID)
+			case <-time.After(2 * time.Second):
+			}
+		}
+	}
+}
+
+func pspAnnouncementBoolPtr(value bool) *bool {
+	return &value
 }

--- a/internal/provider/psp_announcement_resource_test.go
+++ b/internal/provider/psp_announcement_resource_test.go
@@ -180,3 +180,44 @@ func TestPSPAnnouncementMatches(t *testing.T) {
 		t.Fatal("expected type mismatch")
 	}
 }
+
+func TestPSPAnnouncementPinOwnershipIsOptional(t *testing.T) {
+	t.Parallel()
+
+	if pspAnnouncementPinManaged(types.BoolNull()) {
+		t.Fatal("expected null is_pinned to be unmanaged")
+	}
+	if !pspAnnouncementPinManaged(types.BoolValue(false)) {
+		t.Fatal("expected explicit false is_pinned to be managed")
+	}
+	if !pspAnnouncementPinManaged(types.BoolValue(true)) {
+		t.Fatal("expected explicit true is_pinned to be managed")
+	}
+}
+
+func TestPSPAnnouncementApplyAPIPreservesPinState(t *testing.T) {
+	t.Parallel()
+
+	title := "Maintenance"
+	content := "Window"
+	status := "Pending"
+	announcementType := "Maintenance"
+	startDate := "2030-01-01T00:00:00Z"
+
+	model := pspAnnouncementResourceModel{
+		IsPinned: types.BoolValue(true),
+	}
+	model.applyAPI(&client.PSPAnnouncement{
+		ID:        101,
+		PSPID:     42,
+		Title:     &title,
+		Content:   &content,
+		Status:    &status,
+		Type:      &announcementType,
+		StartDate: &startDate,
+	})
+
+	if model.IsPinned.IsNull() || !model.IsPinned.ValueBool() {
+		t.Fatalf("expected applyAPI to preserve managed pin state, got %#v", model.IsPinned)
+	}
+}

--- a/templates/resources/psp_announcement.md.tmpl
+++ b/templates/resources/psp_announcement.md.tmpl
@@ -22,6 +22,13 @@ Use a future `start_date` with `pending` when scheduling an announcement. Uptime
 
 `end_date` is optional. Omit it or set it to `null` to keep the announcement without an end date.
 
+## Pin Ownership
+
+Set `is_pinned = true` to pin this announcement on its public status page, or `is_pinned = false` to unpin it when it is currently pinned.
+Omit `is_pinned` to leave pinned-announcement state unmanaged by this resource.
+
+Do not manage `is_pinned` on `uptimerobot_psp_announcement` and `pinned_announcement_id` on `uptimerobot_psp` for the same public status page at the same time. They both own the same remote API field.
+
 Delivery counters such as subscriber send counts are not exposed because they are runtime metadata and are not managed by Terraform.
 
 The UptimeRobot v3 API does not expose hard deletion for PSP announcements. Destroying this Terraform resource archives the remote announcement and removes it from Terraform state.


### PR DESCRIPTION
## Summary
- Add optional is_pinned management to uptimerobot_psp_announcement using the API v3 pin/unpin endpoints.
- Stabilize PSP pinned announcement read-after-write behavior so rapid pin/unpin transitions do not drift.
- Document ownership boundaries with uptimerobot_psp.pinned_announcement_id and add acceptance coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added is_pinned argument to uptimerobot_psp_announcement for declarative pin/unpin management.

* **Documentation**
  * Updated resource docs, template, and examples with is_pinned usage and a "Pin Ownership" section explaining management constraints.

* **Tests**
  * Added unit and acceptance tests covering pin/unpin behavior and state reconciliation.

* **Chores**
  * Updated changelog noting is_pinned support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uptimerobot/terraform-provider-uptimerobot/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->