### PR TITLE
Add PSP monitor sort support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added `uptimerobot_psp_announcement` resource for creating, updating, importing, and archiving public status page announcements.
 - Added `is_pinned` support to `uptimerobot_psp_announcement` for declarative PSP announcement pin and unpin management.
+- Added `monitor_sort` support to `uptimerobot_psp` for managing public status page monitor ordering.
 
 ## 1.6.0 — 2026-05-16
 

--- a/docs/resources/psp.md
+++ b/docs/resources/psp.md
@@ -33,6 +33,7 @@ resource "uptimerobot_monitor" "api" {
 resource "uptimerobot_psp" "public_status" {
   name          = "Example.com Status"
   homepage_link = "https://example.com"
+  monitor_sort  = "friendly_name_asc"
   monitor_ids = [
     uptimerobot_monitor.website.id,
     uptimerobot_monitor.api.id,
@@ -173,6 +174,14 @@ You can include specific monitors in your status page by providing their IDs in 
 - Create different status pages for different audiences
 - Group related services together
 
+Use `monitor_sort` to control how monitors are ordered on the public status page. Supported values are:
+- `friendly_name_asc`
+- `friendly_name_desc`
+- `status_up_down_paused`
+- `status_down_up_paused`
+
+The provider sends this as the API v3 PSP `sort` request field. API deployments that return `sort` in PSP responses are read back into state. When `monitor_sort` is configured but the API omits `sort`, the provider keeps the configured Terraform value in state so plans stay stable; removing `monitor_sort` stops Terraform from managing the remote sort value.
+
 ## Import
 
 Existing public status pages created in the UptimeRobot UI or through the UptimeRobot API can be imported into Terraform state by their numeric public status page ID. After importing, add matching Terraform configuration and run `terraform plan` to review any differences.
@@ -208,6 +217,7 @@ This field accepts only local filesystem paths. If you need a remote file, downl
 
 Set to an empty string (`""`) to clear the existing logo.
 - `monitor_ids` (Set of Number) Set of monitor IDs
+- `monitor_sort` (String) Sort order for monitors displayed on the PSP. Supported values are `friendly_name_asc`, `friendly_name_desc`, `status_up_down_paused`, and `status_down_up_paused`.
 - `no_index` (Boolean) Whether to prevent indexing
 - `password` (String, Sensitive) Password for accessing the PSP page.
 - Redacted in CLI output and logs.

--- a/examples/resources/uptimerobot_psp/basic.tf
+++ b/examples/resources/uptimerobot_psp/basic.tf
@@ -17,6 +17,7 @@ resource "uptimerobot_monitor" "api" {
 resource "uptimerobot_psp" "public_status" {
   name          = "Example.com Status"
   homepage_link = "https://example.com"
+  monitor_sort  = "friendly_name_asc"
   monitor_ids = [
     uptimerobot_monitor.website.id,
     uptimerobot_monitor.api.id,

--- a/internal/client/psp.go
+++ b/internal/client/psp.go
@@ -31,6 +31,7 @@ type PSP struct {
 	Subscription               bool                `json:"subscription"`
 	ShowCookieBar              bool                `json:"showCookieBar"`
 	PinnedAnnouncementID       *int64              `json:"pinnedAnnouncementId,omitempty"`
+	Sort                       *int                `json:"sort,omitempty"`
 	CustomSettings             *CustomSettingsResp `json:"customSettings,omitempty"`
 }
 
@@ -90,6 +91,7 @@ type CreatePSPRequest struct {
 	HideURLLinks               bool            `json:"hideUrlLinks"`
 	ShowCookieBar              bool            `json:"showCookieBar"`
 	PinnedAnnouncementID       *int64          `json:"pinnedAnnouncementId,omitempty"`
+	Sort                       *int            `json:"sort,omitempty"`
 	CustomSettings             *CustomSettings `json:"customSettings,omitempty"`
 }
 
@@ -139,6 +141,7 @@ type UpdatePSPRequest struct {
 	Subscription               *bool           `json:"subscription,omitempty"`
 	ShowCookieBar              *bool           `json:"showCookieBar,omitempty"`
 	PinnedAnnouncementID       *int64          `json:"pinnedAnnouncementId,omitempty"`
+	Sort                       *int            `json:"sort,omitempty"`
 	CustomSettings             *CustomSettings `json:"customSettings,omitempty"`
 }
 

--- a/internal/client/request_marshal_test.go
+++ b/internal/client/request_marshal_test.go
@@ -515,6 +515,61 @@ func TestMaintenanceWindowRequest_AutoAddMonitors_JSON(t *testing.T) {
 	}
 }
 
+func TestPSPRequest_MonitorSort_JSON(t *testing.T) {
+	createReq := CreatePSPRequest{Name: "psp"}
+	raw, err := json.Marshal(createReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var createMap map[string]any
+	if err := json.Unmarshal(raw, &createMap); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := createMap["sort"]; ok {
+		t.Fatalf("sort should be omitted when nil, got %s", raw)
+	}
+
+	sort := 4
+	createReq.Sort = &sort
+	raw, err = json.Marshal(createReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	createMap = map[string]any{}
+	if err := json.Unmarshal(raw, &createMap); err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := createMap["sort"].(float64); !ok || int(v) != sort {
+		t.Fatalf("expected sort=%d in create request, got %#v", sort, createMap["sort"])
+	}
+
+	updateReq := UpdatePSPRequest{Name: "psp"}
+	raw, err = json.Marshal(updateReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var updateMap map[string]any
+	if err := json.Unmarshal(raw, &updateMap); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := updateMap["sort"]; ok {
+		t.Fatalf("sort should be omitted in update when nil, got %s", raw)
+	}
+
+	updateReq.Sort = &sort
+	raw, err = json.Marshal(updateReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updateMap = map[string]any{}
+	if err := json.Unmarshal(raw, &updateMap); err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := updateMap["sort"].(float64); !ok || int(v) != sort {
+		t.Fatalf("expected sort=%d in update request, got %#v", sort, updateMap["sort"])
+	}
+}
+
 func TestCreatePSPRequest_Marshal_CustomSettingsEmptyObjects(t *testing.T) {
 	req := &CreatePSPRequest{
 		Name:           "my-psp",

--- a/internal/provider/psp_monitor_sort_test.go
+++ b/internal/provider/psp_monitor_sort_test.go
@@ -1,0 +1,95 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/uptimerobot/terraform-provider-uptimerobot/internal/client"
+)
+
+func TestPSPMonitorSortMappings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		tf  string
+		api int
+	}{
+		{tf: "friendly_name_asc", api: 1},
+		{tf: "friendly_name_desc", api: 2},
+		{tf: "status_up_down_paused", api: 3},
+		{tf: "status_down_up_paused", api: 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tf, func(t *testing.T) {
+			gotAPI, err := apiPSPMonitorSort(tt.tf)
+			if err != nil {
+				t.Fatalf("apiPSPMonitorSort returned error: %v", err)
+			}
+			if gotAPI != tt.api {
+				t.Fatalf("apiPSPMonitorSort(%q) = %d, want %d", tt.tf, gotAPI, tt.api)
+			}
+
+			gotTF, ok := terraformPSPMonitorSort(&tt.api)
+			if !ok {
+				t.Fatalf("terraformPSPMonitorSort(%d) was not mapped", tt.api)
+			}
+			if gotTF != tt.tf {
+				t.Fatalf("terraformPSPMonitorSort(%d) = %q, want %q", tt.api, gotTF, tt.tf)
+			}
+		})
+	}
+}
+
+func TestPSPToResourceDataMonitorSort(t *testing.T) {
+	t.Parallel()
+
+	sortValue := 4
+	model := pspResourceModel{}
+	pspToResourceData(context.Background(), &client.PSP{
+		ID:                         123,
+		Name:                       "psp",
+		Status:                     "ENABLED",
+		URLKey:                     "abc123",
+		ShareAnalyticsConsent:      true,
+		UseSmallCookieConsentModal: false,
+		Sort:                       &sortValue,
+	}, &model)
+
+	if model.MonitorSort.IsNull() || model.MonitorSort.ValueString() != "status_down_up_paused" {
+		t.Fatalf("monitor_sort = %#v, want status_down_up_paused", model.MonitorSort)
+	}
+}
+
+func TestPSPToResourceDataMonitorSortOmitted(t *testing.T) {
+	t.Parallel()
+
+	model := pspResourceModel{MonitorSort: types.StringValue("friendly_name_desc")}
+	pspToResourceData(context.Background(), &client.PSP{
+		ID:                         123,
+		Name:                       "psp",
+		Status:                     "ENABLED",
+		URLKey:                     "abc123",
+		ShareAnalyticsConsent:      true,
+		UseSmallCookieConsentModal: false,
+	}, &model)
+
+	if !model.MonitorSort.IsNull() {
+		t.Fatalf("monitor_sort = %#v, want null when API omits sort", model.MonitorSort)
+	}
+}
+
+func TestPSPMonitorSortPtrMatchesTreatsMissingAPIAsUnverified(t *testing.T) {
+	t.Parallel()
+
+	want := 1
+	if !pspMonitorSortPtrMatches(nil, &want) {
+		t.Fatal("missing API sort should not fail settlement checks")
+	}
+
+	got := 2
+	if pspMonitorSortPtrMatches(&got, &want) {
+		t.Fatal("different reported API sort should fail settlement checks")
+	}
+}

--- a/internal/provider/psp_resource.go
+++ b/internal/provider/psp_resource.go
@@ -49,6 +49,7 @@ type pspResourceModel struct {
 	Password                   types.String         `tfsdk:"password"`
 	IsPasswordSet              types.Bool           `tfsdk:"is_password_set"`
 	MonitorIDs                 types.Set            `tfsdk:"monitor_ids"`
+	MonitorSort                types.String         `tfsdk:"monitor_sort"`
 	MonitorsCount              types.Int64          `tfsdk:"monitors_count"`
 	Status                     types.String         `tfsdk:"status"`
 	URLKey                     types.String         `tfsdk:"url_key"`
@@ -125,6 +126,9 @@ func maskOptionalTopLevelNullsFromPlan(plan *pspResourceModel, state *pspResourc
 	if plan.PinnedAnnouncementID.IsNull() {
 		state.PinnedAnnouncementID = types.Int64Null()
 	}
+	if plan.MonitorSort.IsNull() {
+		state.MonitorSort = types.StringNull()
+	}
 }
 
 func preferPlannedTopLevelValues(plan *pspResourceModel, state *pspResourceModel) {
@@ -154,6 +158,9 @@ func preferPlannedTopLevelValues(plan *pspResourceModel, state *pspResourceModel
 	}
 	if !plan.PinnedAnnouncementID.IsNull() && !plan.PinnedAnnouncementID.IsUnknown() {
 		state.PinnedAnnouncementID = plan.PinnedAnnouncementID
+	}
+	if hasConfiguredString(plan.MonitorSort) {
+		state.MonitorSort = plan.MonitorSort
 	}
 }
 
@@ -259,6 +266,29 @@ func ensureKnownTopLevelOptionals(state *pspResourceModel) {
 	}
 	if state.PinnedAnnouncementID.IsUnknown() {
 		state.PinnedAnnouncementID = types.Int64Null()
+	}
+	if state.MonitorSort.IsUnknown() {
+		state.MonitorSort = types.StringNull()
+	}
+}
+
+type pspMonitorSortOmittedPlanModifier struct{}
+
+func (m pspMonitorSortOmittedPlanModifier) Description(context.Context) string {
+	return "Treat omitted monitor_sort as unmanaged instead of keeping the prior state value."
+}
+
+func (m pspMonitorSortOmittedPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m pspMonitorSortOmittedPlanModifier) PlanModifyString(
+	_ context.Context,
+	req planmodifier.StringRequest,
+	resp *planmodifier.StringResponse,
+) {
+	if req.ConfigValue.IsNull() {
+		resp.PlanValue = types.StringNull()
 	}
 }
 
@@ -560,6 +590,20 @@ func (r *pspResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				// and observed from the API (including on import) when omitted.
 				Computed:    true,
 				ElementType: types.Int64Type,
+			},
+			"monitor_sort": schema.StringAttribute{
+				Description: "Sort order for monitors displayed on the PSP",
+				MarkdownDescription: "Sort order for monitors displayed on the PSP. Supported values are " +
+					"`friendly_name_asc`, `friendly_name_desc`, `status_up_down_paused`, and `status_down_up_paused`.",
+				Optional: true,
+				Computed: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf(AllPSPMonitorSorts()...),
+				},
+				PlanModifiers: []planmodifier.String{
+					pspMonitorSortOmittedPlanModifier{},
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			// monitors_count is computed by the API from the amount of monitors in the monitor_ids
 			// Do not use UseStateForUnknown because this field is managed completly by the API.
@@ -889,6 +933,15 @@ func (r *pspResource) Create(ctx context.Context, req resource.CreateRequest, re
 		value := plan.Subscription.ValueBool()
 		expectedSubscription = &value
 	}
+	var expectedMonitorSort *int
+	if hasConfiguredString(plan.MonitorSort) {
+		value, err := apiPSPMonitorSort(plan.MonitorSort.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid PSP monitor sort", err.Error())
+			return
+		}
+		expectedMonitorSort = &value
+	}
 
 	// Create new PSP
 	psp := &client.CreatePSPRequest{
@@ -918,6 +971,9 @@ func (r *pspResource) Create(ctx context.Context, req resource.CreateRequest, re
 
 	if !plan.GACode.IsNull() && !plan.GACode.IsUnknown() {
 		psp.GACode = plan.GACode.ValueStringPointer()
+	}
+	if expectedMonitorSort != nil {
+		psp.Sort = expectedMonitorSort
 	}
 
 	// According to the API DTO, we should only include customSettings if needed
@@ -1134,6 +1190,7 @@ func (r *pspResource) Create(ctx context.Context, req resource.CreateRequest, re
 		requestedMonitorIDs,
 		expectedHomepageLink,
 		expectedSubscription,
+		expectedMonitorSort,
 		120*time.Second,
 	); err == nil && settled != nil {
 		pspForState = settled
@@ -1264,6 +1321,13 @@ func (r *pspResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		value := state.Subscription.ValueBool()
 		expectedSubscription = &value
 	}
+	var expectedMonitorSort *int
+	if hasConfiguredString(state.MonitorSort) {
+		value, err := apiPSPMonitorSort(state.MonitorSort.ValueString())
+		if err == nil {
+			expectedMonitorSort = &value
+		}
+	}
 
 	nameMismatch := expectedName != "" && psp.Name != expectedName
 	monitorsMismatch := false
@@ -1273,10 +1337,11 @@ func (r *pspResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	}
 	homepageLinkMismatch := expectedHomepageLink != nil && !pspStringPtrMatches(psp.HomepageLink, expectedHomepageLink)
 	subscriptionMismatch := expectedSubscription != nil && psp.Subscription != *expectedSubscription
+	monitorSortMismatch := expectedMonitorSort != nil && psp.Sort != nil && *psp.Sort != *expectedMonitorSort
 
 	// PSP reads can be eventually consistent right after updates.
 	// If the API returns transient old values, re-poll briefly before accepting drift.
-	if !isImport && (nameMismatch || monitorsMismatch || homepageLinkMismatch || subscriptionMismatch) {
+	if !isImport && (nameMismatch || monitorsMismatch || homepageLinkMismatch || subscriptionMismatch || monitorSortMismatch) {
 		if settled, err := waitPSPSettled(
 			ctx,
 			r.client,
@@ -1285,6 +1350,7 @@ func (r *pspResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 			expectedMonitorIDs,
 			expectedHomepageLink,
 			expectedSubscription,
+			expectedMonitorSort,
 			20*time.Second,
 		); err == nil && settled != nil {
 			psp = settled
@@ -1305,6 +1371,9 @@ func (r *pspResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	if !isImport {
 		updatedState.Icon = state.Icon
 		updatedState.Logo = state.Logo
+		if psp.Sort == nil && hasConfiguredString(state.MonitorSort) {
+			updatedState.MonitorSort = state.MonitorSort
+		}
 	}
 
 	if len(psp.MonitorIDs) > 0 {
@@ -1378,6 +1447,15 @@ func (r *pspResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		value := plan.Subscription.ValueBool()
 		expectedSubscription = &value
 	}
+	var expectedMonitorSort *int
+	if hasConfiguredString(plan.MonitorSort) {
+		value, err := apiPSPMonitorSort(plan.MonitorSort.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid PSP monitor sort", err.Error())
+			return
+		}
+		expectedMonitorSort = &value
+	}
 
 	// Get current state
 	id, err := strconv.ParseInt(state.ID.ValueString(), 10, 64)
@@ -1439,6 +1517,11 @@ func (r *pspResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		(state.Status.IsNull() || state.Status.IsUnknown() || plan.Status.ValueString() != state.Status.ValueString()) {
 		status := plan.Status.ValueString()
 		psp.Status = &status
+	}
+
+	if expectedMonitorSort != nil &&
+		(state.MonitorSort.IsNull() || state.MonitorSort.IsUnknown() || plan.MonitorSort.ValueString() != state.MonitorSort.ValueString()) {
+		psp.Sort = expectedMonitorSort
 	}
 
 	if hasMonitorPlan {
@@ -1620,6 +1703,7 @@ func (r *pspResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		requestedMonitorIDs,
 		expectedHomepageLink,
 		expectedSubscription,
+		expectedMonitorSort,
 		120*time.Second,
 	); err == nil && settled != nil {
 		pspForState = settled
@@ -1706,6 +1790,7 @@ func waitPSPSettled(
 	expectedMonitorIDs []int64, // nil means omitted and should not be checked
 	expectedHomepageLink *string,
 	expectedSubscription *bool,
+	expectedMonitorSort *int,
 	timeout time.Duration,
 ) (*client.PSP, error) {
 
@@ -1743,8 +1828,9 @@ func waitPSPSettled(
 
 			homepageLinkOK := pspStringPtrMatches(psp.HomepageLink, expectedHomepageLink)
 			subscriptionOK := expectedSubscription == nil || psp.Subscription == *expectedSubscription
+			monitorSortOK := pspMonitorSortPtrMatches(psp.Sort, expectedMonitorSort)
 
-			if nameOK && monitorsOK && homepageLinkOK && subscriptionOK {
+			if nameOK && monitorsOK && homepageLinkOK && subscriptionOK && monitorSortOK {
 				consecutiveMatches++
 				if consecutiveMatches >= requiredConsecutiveMatches {
 					return psp, nil
@@ -1785,6 +1871,55 @@ func pspStringPtrMatches(got *string, want *string) bool {
 		return *want == ""
 	}
 	return *got == *want
+}
+
+func pspMonitorSortPtrMatches(got *int, want *int) bool {
+	if want == nil || got == nil {
+		return true
+	}
+	return *got == *want
+}
+
+func AllPSPMonitorSorts() []string {
+	return []string{
+		"friendly_name_asc",
+		"friendly_name_desc",
+		"status_up_down_paused",
+		"status_down_up_paused",
+	}
+}
+
+func apiPSPMonitorSort(value string) (int, error) {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "friendly_name_asc":
+		return 1, nil
+	case "friendly_name_desc":
+		return 2, nil
+	case "status_up_down_paused":
+		return 3, nil
+	case "status_down_up_paused":
+		return 4, nil
+	default:
+		return 0, fmt.Errorf("unsupported PSP monitor_sort %q", value)
+	}
+}
+
+func terraformPSPMonitorSort(value *int) (string, bool) {
+	if value == nil {
+		return "", false
+	}
+	switch *value {
+	case 1:
+		return "friendly_name_asc", true
+	case 2:
+		return "friendly_name_desc", true
+	case 3:
+		return "status_up_down_paused", true
+	case 4:
+		return "status_down_up_paused", true
+	default:
+		return "", false
+	}
 }
 
 func pspToResourceData(_ context.Context, psp *client.PSP, plan *pspResourceModel) {
@@ -1838,6 +1973,12 @@ func pspToResourceData(_ context.Context, psp *client.PSP, plan *pspResourceMode
 	} else {
 		// Keep as null if not set
 		plan.PinnedAnnouncementID = types.Int64Null()
+	}
+
+	if sortValue, ok := terraformPSPMonitorSort(psp.Sort); ok {
+		plan.MonitorSort = types.StringValue(sortValue)
+	} else {
+		plan.MonitorSort = types.StringNull()
 	}
 
 	// Handle CustomSettings if present in the API response

--- a/internal/provider/psp_resource_acc_test.go
+++ b/internal/provider/psp_resource_acc_test.go
@@ -220,6 +220,23 @@ resource "uptimerobot_psp" "test" {
 `, name)
 }
 
+func testAccPSPResourceConfigMonitorSort(name, monitorSort string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "uptimerobot_psp" "test" {
+  name         = %q
+  monitor_sort = %q
+}
+`, name, monitorSort)
+}
+
+func testAccPSPResourceConfigMonitorSortOmitted(name string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "uptimerobot_psp" "test" {
+  name = %q
+}
+`, name)
+}
+
 func testAccPSPResourceConfigHomepageLink(name, homepageLink string) string {
 	return testAccProviderConfig() + fmt.Sprintf(`
 resource "uptimerobot_psp" "test" {
@@ -534,6 +551,39 @@ func TestAccPSPResource_PinnedAnnouncementID_OmitDoesNotClear(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("uptimerobot_psp.test", "name", name),
 					resource.TestCheckResourceAttr("uptimerobot_psp.test", "pinned_announcement_id", idStr),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPSPResource_MonitorSort(t *testing.T) {
+	name := randomName("acc-psp-sort")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckPSPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPSPResourceConfigMonitorSort(name, "friendly_name_asc"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_psp.test", "name", name),
+					resource.TestCheckResourceAttr("uptimerobot_psp.test", "monitor_sort", "friendly_name_asc"),
+				),
+			},
+			{
+				Config: testAccPSPResourceConfigMonitorSort(name, "status_down_up_paused"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_psp.test", "name", name),
+					resource.TestCheckResourceAttr("uptimerobot_psp.test", "monitor_sort", "status_down_up_paused"),
+				),
+			},
+			{
+				Config: testAccPSPResourceConfigMonitorSortOmitted(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("uptimerobot_psp.test", "name", name),
+					resource.TestCheckNoResourceAttr("uptimerobot_psp.test", "monitor_sort"),
 				),
 			},
 		},

--- a/internal/provider/psp_resource_acc_test.go
+++ b/internal/provider/psp_resource_acc_test.go
@@ -586,6 +586,11 @@ func TestAccPSPResource_MonitorSort(t *testing.T) {
 					resource.TestCheckNoResourceAttr("uptimerobot_psp.test", "monitor_sort"),
 				),
 			},
+			{
+				Config:             testAccPSPResourceConfigMonitorSortOmitted(name),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
 		},
 	})
 }

--- a/templates/resources/psp.md.tmpl
+++ b/templates/resources/psp.md.tmpl
@@ -47,6 +47,14 @@ You can include specific monitors in your status page by providing their IDs in 
 - Create different status pages for different audiences
 - Group related services together
 
+Use `monitor_sort` to control how monitors are ordered on the public status page. Supported values are:
+- `friendly_name_asc`
+- `friendly_name_desc`
+- `status_up_down_paused`
+- `status_down_up_paused`
+
+The provider sends this as the API v3 PSP `sort` request field. API deployments that return `sort` in PSP responses are read back into state. When `monitor_sort` is configured but the API omits `sort`, the provider keeps the configured Terraform value in state so plans stay stable; removing `monitor_sort` stops Terraform from managing the remote sort value.
+
 ## Import
 
 Existing public status pages created in the UptimeRobot UI or through the UptimeRobot API can be imported into Terraform state by their numeric public status page ID. After importing, add matching Terraform configuration and run `terraform plan` to review any differences.


### PR DESCRIPTION
## Summary
- Add monitor_sort to uptimerobot_psp and map it to the API v3 PSP sort request field.
- Keep configured state stable when current API responses omit sort, while allowing config omission to stop managing it.
- Add docs, example, changelog entry, unit coverage, and acceptance coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a monitor_sort argument on uptimerobot_psp to manage monitor ordering on public status pages; supports multiple sort options and preserves configured ordering in state even when the API omits it.

* **Documentation**
  * Updated docs and example to show monitor_sort usage, supported values, and behavior when omitted (stops managing remote sort).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uptimerobot/terraform-provider-uptimerobot/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->