### PR TITLE
Clarify monitor integration assignment docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## 1.7.1 — 2026-05-18
+
+### Changed
+
+- Clarified documentation for assigning integrations to monitors through `uptimerobot_monitor.assigned_alert_contacts`.
+
 ## 1.7.0 — 2026-05-18
 
 ### Added

--- a/docs/data-sources/integration.md
+++ b/docs/data-sources/integration.md
@@ -11,12 +11,14 @@ Looks up an existing UptimeRobot integration without taking ownership of it. Use
 
 The data source can look up an integration by `id`, or by the exact `name` and `type` pair. Secret integration values and custom headers are intentionally not exposed.
 
+Integrations are assigned to monitors through `uptimerobot_monitor.assigned_alert_contacts`. Use the integration ID as `alert_contact_id`; `threshold` is the notification delay in minutes, and `recurrence` is the repeat interval in minutes.
+
 ## Example Usage
 
 ```terraform
-data "uptimerobot_integration" "webhook" {
-  name = "Production Webhook"
-  type = "webhook"
+data "uptimerobot_integration" "pagerduty" {
+  name = "Production PagerDuty"
+  type = "pagerduty"
 }
 
 resource "uptimerobot_monitor" "website" {
@@ -27,9 +29,9 @@ resource "uptimerobot_monitor" "website" {
 
   assigned_alert_contacts = [
     {
-      alert_contact_id = data.uptimerobot_integration.webhook.id
-      threshold        = 0
-      recurrence       = 0
+      alert_contact_id = data.uptimerobot_integration.pagerduty.id
+      threshold        = 5
+      recurrence       = 30
     }
   ]
 }

--- a/docs/data-sources/integration.md
+++ b/docs/data-sources/integration.md
@@ -11,7 +11,7 @@ Looks up an existing UptimeRobot integration without taking ownership of it. Use
 
 The data source can look up an integration by `id`, or by the exact `name` and `type` pair. Secret integration values and custom headers are intentionally not exposed.
 
-Integrations are assigned to monitors through `uptimerobot_monitor.assigned_alert_contacts`. Use the integration ID as `alert_contact_id`; `threshold` is the notification delay in minutes, and `recurrence` is the repeat interval in minutes.
+Integrations are assigned to monitors through `uptimerobot_monitor.assigned_alert_contacts`. Use the integration ID as `alert_contact_id`; `threshold` is the delay in minutes before the first notification after the monitor is DOWN, and `recurrence` is the repeat interval in minutes while the incident remains open.
 
 ## Example Usage
 

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -379,7 +379,7 @@ resource "uptimerobot_monitor" "website_no_contacts" {
 
 ### Integration Notifications Example
 
-Integrations such as PagerDuty, Slack, webhook, Telegram, Discord, and similar channels are assigned with the same `assigned_alert_contacts` block used for other monitor notification contacts. Use the integration ID as `alert_contact_id`; `threshold` is the delay in minutes before the first notification, and `recurrence` is the repeat interval in minutes while the incident remains open.
+Integrations such as PagerDuty, Slack, webhook, Telegram, Discord, and similar channels are assigned with the same `assigned_alert_contacts` block used for other monitor notification contacts. Use the integration ID as `alert_contact_id`; `threshold` is the delay in minutes before the first notification after the monitor is DOWN, and `recurrence` is the repeat interval in minutes while the incident remains open.
 
 ```terraform
 data "uptimerobot_integration" "pagerduty" {
@@ -706,7 +706,7 @@ terraform import 'uptimerobot_monitor.monitors["www_production"]' 800123456
 **Semantics**
 - Terraform sends exactly what you specify; the provider does not inject hidden defaults.
 - Each notification method has its own alert-contact id. For example, Email and MobileAppOld/push are separate ids; include every id returned by `GET /user/alert-contacts` that should be checked for the monitor.
-- Integrations such as PagerDuty, Slack, webhook, Telegram, Discord, and similar channels are assigned here too. Use the integration ID as `alert_contact_id`; `threshold` is the delay in minutes, and `recurrence` is the repeat interval in minutes.
+- Integrations such as PagerDuty, Slack, webhook, Telegram, Discord, and similar channels are assigned here too. Use the integration ID as `alert_contact_id`; `threshold` is the delay in minutes before the first notification after the monitor is DOWN, and `recurrence` is the repeat interval in minutes while the incident remains open.
 - **Free plan**: set `threshold = 0`, `recurrence = 0`.
 - **Paid plans**: any non-negative minutes for both fields. (see [below for nested schema](#nestedatt--assigned_alert_contacts))
 - `auth_type` (String) Authentication type. Allowed: NONE, HTTP_BASIC, DIGEST, BEARER.

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -377,6 +377,33 @@ resource "uptimerobot_monitor" "website_no_contacts" {
 }
 ```
 
+### Integration Notifications Example
+
+Integrations such as PagerDuty, Slack, webhook, Telegram, Discord, and similar channels are assigned with the same `assigned_alert_contacts` block used for other monitor notification contacts. Use the integration ID as `alert_contact_id`; `threshold` is the delay in minutes before the first notification, and `recurrence` is the repeat interval in minutes while the incident remains open.
+
+```terraform
+data "uptimerobot_integration" "pagerduty" {
+  name = "Production PagerDuty"
+  type = "pagerduty"
+}
+
+resource "uptimerobot_monitor" "website_with_pagerduty" {
+  name     = "Example Website"
+  type     = "HTTP"
+  url      = "https://example.com"
+  interval = 300
+  timeout  = 30
+
+  assigned_alert_contacts = [
+    {
+      alert_contact_id = data.uptimerobot_integration.pagerduty.id
+      threshold        = 5
+      recurrence       = 30
+    }
+  ]
+}
+```
+
 ### Heartbeat Example
 
 ```terraform
@@ -674,11 +701,12 @@ terraform import 'uptimerobot_monitor.monitors["www_production"]' 800123456
 
 ### Optional
 
-- `assigned_alert_contacts` (Attributes Set) Alert contacts assigned to this monitor.
+- `assigned_alert_contacts` (Attributes Set) Alert contacts and integrations assigned to this monitor.
 
 **Semantics**
 - Terraform sends exactly what you specify; the provider does not inject hidden defaults.
 - Each notification method has its own alert-contact id. For example, Email and MobileAppOld/push are separate ids; include every id returned by `GET /user/alert-contacts` that should be checked for the monitor.
+- Integrations such as PagerDuty, Slack, webhook, Telegram, Discord, and similar channels are assigned here too. Use the integration ID as `alert_contact_id`; `threshold` is the delay in minutes, and `recurrence` is the repeat interval in minutes.
 - **Free plan**: set `threshold = 0`, `recurrence = 0`.
 - **Paid plans**: any non-negative minutes for both fields. (see [below for nested schema](#nestedatt--assigned_alert_contacts))
 - `auth_type` (String) Authentication type. Allowed: NONE, HTTP_BASIC, DIGEST, BEARER.

--- a/examples/resources/uptimerobot_monitor/integration_notifications.tf
+++ b/examples/resources/uptimerobot_monitor/integration_notifications.tf
@@ -3,11 +3,12 @@ data "uptimerobot_integration" "pagerduty" {
   type = "pagerduty"
 }
 
-resource "uptimerobot_monitor" "website" {
+resource "uptimerobot_monitor" "website_with_pagerduty" {
   name     = "Example Website"
   type     = "HTTP"
   url      = "https://example.com"
   interval = 300
+  timeout  = 30
 
   assigned_alert_contacts = [
     {

--- a/internal/provider/integration/data_source.go
+++ b/internal/provider/integration/data_source.go
@@ -49,7 +49,7 @@ func (d *integrationDataSource) Metadata(_ context.Context, req datasource.Metad
 
 func (d *integrationDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = datasourceschema.Schema{
-		MarkdownDescription: "Looks up an existing UptimeRobot integration without managing it.",
+		MarkdownDescription: "Looks up an existing UptimeRobot integration without managing it. Use the returned ID in `uptimerobot_monitor.assigned_alert_contacts` when assigning the integration to monitor notifications.",
 		Attributes: map[string]datasourceschema.Attribute{
 			"id": datasourceschema.StringAttribute{
 				Optional:            true,

--- a/internal/provider/monitor/monitor_schema.go
+++ b/internal/provider/monitor/monitor_schema.go
@@ -374,14 +374,15 @@ func monitorSchema(version int64, includeApplicationErrorRetries bool) schema.Sc
 				},
 			},
 			"assigned_alert_contacts": schema.SetNestedAttribute{
-				Description: "Alert contacts to assign. Each item must include `alert_contact_id`, `threshold`, and `recurrence`." +
+				Description: "Alert contacts or integrations to assign. Each item must include `alert_contact_id`, `threshold`, and `recurrence`." +
 					"Free plan have to use 0 for threshold and recurrence",
 				MarkdownDescription: `
-Alert contacts assigned to this monitor.
+Alert contacts and integrations assigned to this monitor.
 
 **Semantics**
 - Terraform sends exactly what you specify; the provider does not inject hidden defaults.
 - Each notification method has its own alert-contact id. For example, Email and MobileAppOld/push are separate ids; include every id returned by ` + "`GET /user/alert-contacts`" + ` that should be checked for the monitor.
+- Integrations such as PagerDuty, Slack, webhook, Telegram, Discord, and similar channels are assigned here too. Use the integration ID as ` + "`alert_contact_id`" + `; ` + "`threshold`" + ` is the delay in minutes, and ` + "`recurrence`" + ` is the repeat interval in minutes.
 - **Free plan**: set ` + "`threshold = 0`" + `, ` + "`recurrence = 0`" + `.
 - **Paid plans**: any non-negative minutes for both fields.
 `,

--- a/internal/provider/monitor/monitor_schema.go
+++ b/internal/provider/monitor/monitor_schema.go
@@ -382,7 +382,7 @@ Alert contacts and integrations assigned to this monitor.
 **Semantics**
 - Terraform sends exactly what you specify; the provider does not inject hidden defaults.
 - Each notification method has its own alert-contact id. For example, Email and MobileAppOld/push are separate ids; include every id returned by ` + "`GET /user/alert-contacts`" + ` that should be checked for the monitor.
-- Integrations such as PagerDuty, Slack, webhook, Telegram, Discord, and similar channels are assigned here too. Use the integration ID as ` + "`alert_contact_id`" + `; ` + "`threshold`" + ` is the delay in minutes, and ` + "`recurrence`" + ` is the repeat interval in minutes.
+- Integrations such as PagerDuty, Slack, webhook, Telegram, Discord, and similar channels are assigned here too. Use the integration ID as ` + "`alert_contact_id`" + `; ` + "`threshold`" + ` is the delay in minutes before the first notification after the monitor is DOWN, and ` + "`recurrence`" + ` is the repeat interval in minutes while the incident remains open.
 - **Free plan**: set ` + "`threshold = 0`" + `, ` + "`recurrence = 0`" + `.
 - **Paid plans**: any non-negative minutes for both fields.
 `,

--- a/templates/data-sources/integration.md.tmpl
+++ b/templates/data-sources/integration.md.tmpl
@@ -11,6 +11,8 @@ Looks up an existing UptimeRobot integration without taking ownership of it. Use
 
 The data source can look up an integration by `id`, or by the exact `name` and `type` pair. Secret integration values and custom headers are intentionally not exposed.
 
+Integrations are assigned to monitors through `uptimerobot_monitor.assigned_alert_contacts`. Use the integration ID as `alert_contact_id`; `threshold` is the notification delay in minutes, and `recurrence` is the repeat interval in minutes.
+
 ## Example Usage
 
 {{tffile "examples/data-sources/uptimerobot_integration/data-source.tf"}}

--- a/templates/data-sources/integration.md.tmpl
+++ b/templates/data-sources/integration.md.tmpl
@@ -11,7 +11,7 @@ Looks up an existing UptimeRobot integration without taking ownership of it. Use
 
 The data source can look up an integration by `id`, or by the exact `name` and `type` pair. Secret integration values and custom headers are intentionally not exposed.
 
-Integrations are assigned to monitors through `uptimerobot_monitor.assigned_alert_contacts`. Use the integration ID as `alert_contact_id`; `threshold` is the notification delay in minutes, and `recurrence` is the repeat interval in minutes.
+Integrations are assigned to monitors through `uptimerobot_monitor.assigned_alert_contacts`. Use the integration ID as `alert_contact_id`; `threshold` is the delay in minutes before the first notification after the monitor is DOWN, and `recurrence` is the repeat interval in minutes while the incident remains open.
 
 ## Example Usage
 

--- a/templates/resources/monitor.md.tmpl
+++ b/templates/resources/monitor.md.tmpl
@@ -61,7 +61,7 @@ description: |-
 
 ### Integration Notifications Example
 
-Integrations such as PagerDuty, Slack, webhook, Telegram, Discord, and similar channels are assigned with the same `assigned_alert_contacts` block used for other monitor notification contacts. Use the integration ID as `alert_contact_id`; `threshold` is the delay in minutes before the first notification, and `recurrence` is the repeat interval in minutes while the incident remains open.
+Integrations such as PagerDuty, Slack, webhook, Telegram, Discord, and similar channels are assigned with the same `assigned_alert_contacts` block used for other monitor notification contacts. Use the integration ID as `alert_contact_id`; `threshold` is the delay in minutes before the first notification after the monitor is DOWN, and `recurrence` is the repeat interval in minutes while the incident remains open.
 
 {{tffile "examples/resources/uptimerobot_monitor/integration_notifications.tf"}}
 

--- a/templates/resources/monitor.md.tmpl
+++ b/templates/resources/monitor.md.tmpl
@@ -59,6 +59,12 @@ description: |-
 
 {{tffile "examples/resources/uptimerobot_monitor/alert_contacts.tf"}}
 
+### Integration Notifications Example
+
+Integrations such as PagerDuty, Slack, webhook, Telegram, Discord, and similar channels are assigned with the same `assigned_alert_contacts` block used for other monitor notification contacts. Use the integration ID as `alert_contact_id`; `threshold` is the delay in minutes before the first notification, and `recurrence` is the repeat interval in minutes while the incident remains open.
+
+{{tffile "examples/resources/uptimerobot_monitor/integration_notifications.tf"}}
+
 ### Heartbeat Example
 
 {{tffile "examples/resources/uptimerobot_monitor/heartbeat.tf"}}


### PR DESCRIPTION
Clarifies that integrations are assigned to monitors through `assigned_alert_contacts`, updates examples, and regenerates provider documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced docs and examples showing how to assign integrations (PagerDuty, Slack, webhooks, Telegram, Discord, etc.) to UptimeRobot monitors using integration IDs.
  * Clarified that threshold and recurrence are expressed in minutes (initial notification delay and repeat interval).
  * Added an “Integration Notifications” example and updated related usage examples.
* **Changelog**
  * Added release notes entry for v1.7.1 (2026-05-18).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uptimerobot/terraform-provider-uptimerobot/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->