### PR TITLE
fix: preserve unchanged custom HTTP headers

### DIFF
--- a/internal/provider/monitor/monitor_crud_update.go
+++ b/internal/provider/monitor/monitor_crud_update.go
@@ -328,7 +328,7 @@ func buildUpdateRequest(
 	}
 
 	// headers
-	setHeadersOnUpdate(ctx, plan, req, resp)
+	setHeadersOnUpdate(ctx, plan, state, req, resp)
 	if resp.Diagnostics.HasError() {
 		return nil, ""
 	}
@@ -511,19 +511,35 @@ func setSuccessCodesOnUpdate(ctx context.Context, plan monitorResourceModel, req
 	}
 }
 
-func setHeadersOnUpdate(ctx context.Context, plan monitorResourceModel, req *client.UpdateMonitorRequest, resp *resource.UpdateResponse) {
+func setHeadersOnUpdate(ctx context.Context, plan, state monitorResourceModel, req *client.UpdateMonitorRequest, resp *resource.UpdateResponse) {
 	if plan.CustomHTTPHeaders.IsUnknown() {
 		return // omit and preserve on server
 	}
 	if plan.CustomHTTPHeaders.IsNull() {
+		if state.CustomHTTPHeaders.IsNull() || state.CustomHTTPHeaders.IsUnknown() {
+			return // omitted and previously unmanaged: preserve remote
+		}
 		empty := map[string]string{}
 		req.CustomHTTPHeaders = &empty // clear
 		return
 	}
-	m, d := mapFromAttr(ctx, plan.CustomHTTPHeaders)
+	m, d := stringMapFromAttrPreserveEmpty(ctx, plan.CustomHTTPHeaders)
 	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+	if !state.CustomHTTPHeaders.IsNull() && !state.CustomHTTPHeaders.IsUnknown() {
+		prior, d := stringMapFromAttrPreserveEmpty(ctx, state.CustomHTTPHeaders)
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if equalStringMap(
+			normalizeHeadersForUpdateDecision(m),
+			normalizeHeadersForUpdateDecision(prior),
+		) {
+			return // unchanged: omit and preserve remote, including ignore_changes cases
+		}
 	}
 	req.CustomHTTPHeaders = &m
 }

--- a/internal/provider/monitor/monitor_transform.go
+++ b/internal/provider/monitor/monitor_transform.go
@@ -893,6 +893,21 @@ func headersFromAPIForState(in map[string]string) map[string]string {
 	return m
 }
 
+func normalizeHeadersForUpdateDecision(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		k = strings.ToLower(strings.TrimSpace(k))
+		if k == "" {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
 func firstNonEmpty(values ...string) string {
 	for _, v := range values {
 		if v != "" {

--- a/internal/provider/monitor/monitor_transform_test.go
+++ b/internal/provider/monitor/monitor_transform_test.go
@@ -293,6 +293,110 @@ func TestBuildUpdateRequest_CustomFieldsSemantics(t *testing.T) {
 	})
 }
 
+func TestBuildUpdateRequest_CustomHTTPHeadersSemantics(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	basePlan := monitorResourceModel{
+		Type:     types.StringValue(MonitorTypeHTTP),
+		Name:     types.StringValue("headers"),
+		URL:      types.StringValue("https://example.com"),
+		Interval: types.Int64Value(300),
+		Config:   types.ObjectNull(configObjectType().AttrTypes),
+	}
+	headerMap := func(values map[string]string) types.Map {
+		attrs := make(map[string]attr.Value, len(values))
+		for k, v := range values {
+			attrs[k] = types.StringValue(v)
+		}
+		return types.MapValueMust(types.StringType, attrs)
+	}
+
+	tests := []struct {
+		name         string
+		planHeaders  types.Map
+		stateHeaders types.Map
+		wantSent     bool
+		want         map[string]string
+	}{
+		{
+			name:         "unchanged managed headers omit",
+			planHeaders:  headerMap(map[string]string{"x-monitor-token": ""}),
+			stateHeaders: headerMap(map[string]string{"x-monitor-token": ""}),
+			wantSent:     false,
+		},
+		{
+			name:         "unchanged header key case omits",
+			planHeaders:  headerMap(map[string]string{"X-Monitor-Token": ""}),
+			stateHeaders: headerMap(map[string]string{"x-monitor-token": ""}),
+			wantSent:     false,
+		},
+		{
+			name:         "changed header value sends",
+			planHeaders:  headerMap(map[string]string{"x-monitor-token": "two"}),
+			stateHeaders: headerMap(map[string]string{"x-monitor-token": "one"}),
+			wantSent:     true,
+			want:         map[string]string{"x-monitor-token": "two"},
+		},
+		{
+			name:         "content type change sends",
+			planHeaders:  headerMap(map[string]string{"content-type": "application/x-www-form-urlencoded"}),
+			stateHeaders: headerMap(map[string]string{"content-type": "application/json"}),
+			wantSent:     true,
+			want:         map[string]string{"content-type": "application/x-www-form-urlencoded"},
+		},
+		{
+			name:         "null with prior managed headers clears",
+			planHeaders:  types.MapNull(types.StringType),
+			stateHeaders: headerMap(map[string]string{"x-monitor-token": "one"}),
+			wantSent:     true,
+			want:         map[string]string{},
+		},
+		{
+			name:         "null without prior managed headers omits",
+			planHeaders:  types.MapNull(types.StringType),
+			stateHeaders: types.MapNull(types.StringType),
+			wantSent:     false,
+		},
+		{
+			name:         "empty map with prior managed headers clears",
+			planHeaders:  headerMap(map[string]string{}),
+			stateHeaders: headerMap(map[string]string{"x-monitor-token": "one"}),
+			wantSent:     true,
+			want:         map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			plan := basePlan
+			plan.CustomHTTPHeaders = tt.planHeaders
+			state := monitorResourceModel{CustomHTTPHeaders: tt.stateHeaders}
+			resp := &resource.UpdateResponse{}
+
+			req, _ := buildUpdateRequest(ctx, plan, state, true, true, resp)
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
+			}
+			if !tt.wantSent {
+				if req.CustomHTTPHeaders != nil {
+					t.Fatalf("expected custom_http_headers to be omitted, got %#v", *req.CustomHTTPHeaders)
+				}
+				return
+			}
+			if req.CustomHTTPHeaders == nil {
+				t.Fatalf("expected custom_http_headers payload")
+			}
+			if !equalStringMap(*req.CustomHTTPHeaders, tt.want) {
+				t.Fatalf("unexpected custom_http_headers payload: got %#v want %#v", *req.CustomHTTPHeaders, tt.want)
+			}
+		})
+	}
+}
+
 func TestPlanAlertContactsComparable_SkipsComparisonForIncompleteContact(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #246.

Summary:
- Omit `customHttpHeaders` from monitor PATCH requests when `custom_http_headers` is unchanged from prior state, including lifecycle `ignore_changes` cases.
- Preserve existing clear behavior when managed headers are removed or set to an empty map.
- Add focused monitor update request tests for unchanged, changed, content-type, null, and empty-map semantics.

Tests:
- `go test ./...`