### PR TITLE
feat: support PSP tag ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Added `uptimerobot_alert_contact` resource for managing personal email and mobile app push alert contacts through API v3.
+- Added `tag_ids` support to `uptimerobot_psp` for tag-based public status page monitor selection.
 
 ## 1.8.1 — 2026-06-16
 

--- a/docs/data-sources/psp.md
+++ b/docs/data-sources/psp.md
@@ -59,6 +59,7 @@ output "status_page_url_key" {
 - `show_cookie_bar` (Boolean) Whether the cookie bar is shown.
 - `status` (String) Status of the PSP returned by the API.
 - `subscription` (Boolean) Whether public subscriptions are enabled.
+- `tag_ids` (Set of Number) Monitor tag IDs assigned to the PSP.
 - `url_key` (String) URL key for the PSP.
 - `use_small_cookie_consent_modal` (Boolean) Whether the small cookie consent modal is enabled.
 

--- a/docs/resources/psp.md
+++ b/docs/resources/psp.md
@@ -67,6 +67,22 @@ resource "uptimerobot_psp" "custom_domain_status" {
 }
 ```
 
+### Status Page with Tag-Based Monitor Selection
+
+```terraform
+data "uptimerobot_tag" "production" {
+  name = "production"
+}
+
+resource "uptimerobot_psp" "production_status" {
+  name = "Production Services"
+
+  tag_ids = [
+    tonumber(data.uptimerobot_tag.production.id),
+  ]
+}
+```
+
 ### Password Protected Status Page
 
 ```terraform
@@ -174,6 +190,8 @@ You can include specific monitors in your status page by providing their IDs in 
 - Create different status pages for different audiences
 - Group related services together
 
+You can also include monitors by tag with `tag_ids`. The UptimeRobot API resolves matching monitors server-side, and `tag_ids` are additive with `monitor_ids`.
+
 Use `monitor_sort` to control how monitors are ordered on the public status page. Supported values are:
 - `friendly_name_asc`
 - `friendly_name_desc`
@@ -232,6 +250,7 @@ Set to an empty string (`""`) to clear the existing logo.
 - `show_cookie_bar` (Boolean) Whether to show cookie bar
 - `status` (String) Status of the PSP
 - `subscription` (Boolean) Whether subscription is enabled
+- `tag_ids` (Set of Number) Set of monitor tag IDs. PSP monitors are resolved server-side from the configured tags and are additive with monitor_ids.
 - `use_small_cookie_consent_modal` (Boolean) Whether to use small cookie consent modal
 
 ### Read-Only

--- a/examples/resources/uptimerobot_psp/tag_ids.tf
+++ b/examples/resources/uptimerobot_psp/tag_ids.tf
@@ -1,0 +1,11 @@
+data "uptimerobot_tag" "production" {
+  name = "production"
+}
+
+resource "uptimerobot_psp" "production_status" {
+  name = "Production Services"
+
+  tag_ids = [
+    tonumber(data.uptimerobot_tag.production.id),
+  ]
+}

--- a/internal/client/psp.go
+++ b/internal/client/psp.go
@@ -18,6 +18,7 @@ type PSP struct {
 	CustomDomain               *string             `json:"customDomain,omitempty"`
 	IsPasswordSet              bool                `json:"isPasswordSet"`
 	MonitorIDs                 []int64             `json:"monitorIds,omitempty"`
+	TagIDs                     []int64             `json:"tagIds,omitempty"`
 	MonitorsCount              *int                `json:"monitorsCount,omitempty"`
 	Status                     string              `json:"status"`
 	URLKey                     string              `json:"urlKey"`
@@ -90,6 +91,7 @@ type CreatePSPRequest struct {
 	CustomDomain               *string         `json:"customDomain,omitempty"`
 	Password                   *string         `json:"password,omitempty"`
 	MonitorIDs                 *[]int64        `json:"monitorIds,omitempty"`
+	TagIDs                     *[]int64        `json:"tagIds,omitempty"`
 	Status                     *string         `json:"status,omitempty"`
 	GACode                     *string         `json:"gaCode,omitempty"`
 	ShareAnalyticsConsent      bool            `json:"shareAnalyticsConsent"`
@@ -138,6 +140,7 @@ type UpdatePSPRequest struct {
 	CustomDomain               *string         `json:"customDomain,omitempty"`
 	Password                   *string         `json:"password,omitempty"`
 	MonitorIDs                 *[]int64        `json:"monitorIds,omitempty"`
+	TagIDs                     *[]int64        `json:"tagIds,omitempty"`
 	Status                     *string         `json:"status,omitempty"`
 	HomepageLink               *string         `json:"homepageLink,omitempty"`
 	GACode                     *string         `json:"gaCode,omitempty"`

--- a/internal/client/request_marshal_test.go
+++ b/internal/client/request_marshal_test.go
@@ -570,6 +570,72 @@ func TestPSPRequest_MonitorSort_JSON(t *testing.T) {
 	}
 }
 
+func TestPSPRequest_TagIDs_JSON(t *testing.T) {
+	createReq := CreatePSPRequest{Name: "psp"}
+	raw, err := json.Marshal(createReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var createMap map[string]any
+	if err := json.Unmarshal(raw, &createMap); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := createMap["tagIds"]; ok {
+		t.Fatalf("tagIds should be omitted when nil, got %s", raw)
+	}
+
+	tagIDs := []int64{10, 20}
+	createReq.TagIDs = &tagIDs
+	raw, err = json.Marshal(createReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	createMap = map[string]any{}
+	if err := json.Unmarshal(raw, &createMap); err != nil {
+		t.Fatal(err)
+	}
+	gotCreateTagIDs, ok := createMap["tagIds"].([]any)
+	if !ok || len(gotCreateTagIDs) != 2 {
+		t.Fatalf("expected tagIds=[10,20] in create request, got %#v", createMap["tagIds"])
+	}
+	firstTagID, ok := gotCreateTagIDs[0].(float64)
+	if !ok || int(firstTagID) != 10 {
+		t.Fatalf("expected first tag ID to be 10, got %#v", gotCreateTagIDs[0])
+	}
+	secondTagID, ok := gotCreateTagIDs[1].(float64)
+	if !ok || int(secondTagID) != 20 {
+		t.Fatalf("expected second tag ID to be 20, got %#v", gotCreateTagIDs[1])
+	}
+
+	updateReq := UpdatePSPRequest{Name: "psp"}
+	raw, err = json.Marshal(updateReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var updateMap map[string]any
+	if err := json.Unmarshal(raw, &updateMap); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := updateMap["tagIds"]; ok {
+		t.Fatalf("tagIds should be omitted in update when nil, got %s", raw)
+	}
+
+	emptyTagIDs := []int64{}
+	updateReq.TagIDs = &emptyTagIDs
+	raw, err = json.Marshal(updateReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updateMap = map[string]any{}
+	if err := json.Unmarshal(raw, &updateMap); err != nil {
+		t.Fatal(err)
+	}
+	gotUpdateTagIDs, ok := updateMap["tagIds"].([]any)
+	if !ok || len(gotUpdateTagIDs) != 0 {
+		t.Fatalf("expected empty tagIds array in update request, got %#v", updateMap["tagIds"])
+	}
+}
+
 func TestCreatePSPRequest_Marshal_CustomSettingsEmptyObjects(t *testing.T) {
 	req := &CreatePSPRequest{
 		Name:           "my-psp",

--- a/internal/provider/psp/data_source.go
+++ b/internal/provider/psp/data_source.go
@@ -38,6 +38,7 @@ type pspDataSourceModel struct {
 	CustomDomain               types.String         `tfsdk:"custom_domain"`
 	IsPasswordSet              types.Bool           `tfsdk:"is_password_set"`
 	MonitorIDs                 types.Set            `tfsdk:"monitor_ids"`
+	TagIDs                     types.Set            `tfsdk:"tag_ids"`
 	MonitorSort                types.String         `tfsdk:"monitor_sort"`
 	MonitorsCount              types.Int64          `tfsdk:"monitors_count"`
 	Status                     types.String         `tfsdk:"status"`
@@ -99,6 +100,11 @@ func (d *pspDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, re
 				Computed:            true,
 				ElementType:         types.Int64Type,
 				MarkdownDescription: "Monitor IDs assigned to the PSP.",
+			},
+			"tag_ids": datasourceschema.SetAttribute{
+				Computed:            true,
+				ElementType:         types.Int64Type,
+				MarkdownDescription: "Monitor tag IDs assigned to the PSP.",
 			},
 			"monitor_sort": datasourceschema.StringAttribute{
 				Computed:            true,
@@ -390,6 +396,8 @@ func pspDataSourceState(ctx context.Context, statusPage *client.PSP) (pspDataSou
 
 	monitorIDs, setDiags := pspMonitorIDsSet(ctx, statusPage.MonitorIDs)
 	diags.Append(setDiags...)
+	tagIDs, setDiags := pspMonitorIDsSet(ctx, statusPage.TagIDs)
+	diags.Append(setDiags...)
 
 	return pspDataSourceModel{
 		ID:                         resourceState.ID,
@@ -397,6 +405,7 @@ func pspDataSourceState(ctx context.Context, statusPage *client.PSP) (pspDataSou
 		CustomDomain:               resourceState.CustomDomain,
 		IsPasswordSet:              resourceState.IsPasswordSet,
 		MonitorIDs:                 monitorIDs,
+		TagIDs:                     tagIDs,
 		MonitorSort:                resourceState.MonitorSort,
 		MonitorsCount:              resourceState.MonitorsCount,
 		Status:                     resourceState.Status,

--- a/internal/provider/psp/data_source_test.go
+++ b/internal/provider/psp/data_source_test.go
@@ -81,6 +81,7 @@ func TestPSPDataSourceStateMapsFields(t *testing.T) {
 		CustomDomain:               &customDomain,
 		IsPasswordSet:              true,
 		MonitorIDs:                 []int64{11, 22},
+		TagIDs:                     []int64{33, 44},
 		MonitorsCount:              &monitorsCount,
 		Status:                     "ENABLED",
 		URLKey:                     "abc123",
@@ -139,6 +140,14 @@ func TestPSPDataSourceStateMapsFields(t *testing.T) {
 	}
 	if len(monitorIDs) != 2 || monitorIDs[0] != 11 || monitorIDs[1] != 22 {
 		t.Fatalf("unexpected monitor IDs %#v", monitorIDs)
+	}
+	var tagIDs []int64
+	diags = state.TagIDs.ElementsAs(context.Background(), &tagIDs, false)
+	if diags.HasError() {
+		t.Fatalf("unexpected tag ID diagnostics: %v", diags)
+	}
+	if len(tagIDs) != 2 || tagIDs[0] != 33 || tagIDs[1] != 44 {
+		t.Fatalf("unexpected tag IDs %#v", tagIDs)
 	}
 	if state.CustomSettings == nil || state.CustomSettings.Colors == nil || state.CustomSettings.Colors.Main.ValueString() != mainColor {
 		t.Fatalf("unexpected custom settings %#v", state.CustomSettings)

--- a/internal/provider/psp/monitor_sort_test.go
+++ b/internal/provider/psp/monitor_sort_test.go
@@ -80,6 +80,30 @@ func TestPSPToResourceDataMonitorSortOmitted(t *testing.T) {
 	}
 }
 
+func TestPSPToResourceDataTagIDs(t *testing.T) {
+	t.Parallel()
+
+	model := pspResourceModel{}
+	pspToResourceData(context.Background(), &client.PSP{
+		ID:                         123,
+		Name:                       "psp",
+		Status:                     "ENABLED",
+		URLKey:                     "abc123",
+		ShareAnalyticsConsent:      true,
+		UseSmallCookieConsentModal: false,
+		TagIDs:                     []int64{33, 44},
+	}, &model)
+
+	var tagIDs []int64
+	diags := model.TagIDs.ElementsAs(context.Background(), &tagIDs, false)
+	if diags.HasError() {
+		t.Fatalf("unexpected tag ID diagnostics: %v", diags)
+	}
+	if len(tagIDs) != 2 || tagIDs[0] != 33 || tagIDs[1] != 44 {
+		t.Fatalf("tag_ids = %#v, want [33 44]", tagIDs)
+	}
+}
+
 func TestPSPMonitorSortPtrMatchesTreatsMissingAPIAsUnverified(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/psp/resource.go
+++ b/internal/provider/psp/resource.go
@@ -50,6 +50,7 @@ type pspResourceModel struct {
 	Password                   types.String         `tfsdk:"password"`
 	IsPasswordSet              types.Bool           `tfsdk:"is_password_set"`
 	MonitorIDs                 types.Set            `tfsdk:"monitor_ids"`
+	TagIDs                     types.Set            `tfsdk:"tag_ids"`
 	MonitorSort                types.String         `tfsdk:"monitor_sort"`
 	MonitorsCount              types.Int64          `tfsdk:"monitors_count"`
 	Status                     types.String         `tfsdk:"status"`
@@ -579,6 +580,12 @@ func (r *pspResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				Computed:    true,
 				ElementType: types.Int64Type,
 			},
+			"tag_ids": schema.SetAttribute{
+				Description: "Set of monitor tag IDs. PSP monitors are resolved server-side from the configured tags and are additive with monitor_ids.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.Int64Type,
+			},
 			"monitor_sort": schema.StringAttribute{
 				Description: "Sort order for monitors displayed on the PSP",
 				MarkdownDescription: "Sort order for monitors displayed on the PSP. Supported values are " +
@@ -911,6 +918,16 @@ func (r *pspResource) Create(ctx context.Context, req resource.CreateRequest, re
 			return
 		}
 	}
+	hasTagPlan := !plan.TagIDs.IsNull() && !plan.TagIDs.IsUnknown()
+	var requestedTagIDs []int64
+	if hasTagPlan {
+		requestedTagIDs = []int64{}
+		diags := plan.TagIDs.ElementsAs(ctx, &requestedTagIDs, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
 	var expectedHomepageLink *string
 	if hasConfiguredString(plan.HomepageLink) {
 		value := plan.HomepageLink.ValueString()
@@ -951,6 +968,9 @@ func (r *pspResource) Create(ctx context.Context, req resource.CreateRequest, re
 
 	if hasMonitorPlan {
 		psp.MonitorIDs = &requestedMonitorIDs
+	}
+	if hasTagPlan {
+		psp.TagIDs = &requestedTagIDs
 	}
 
 	if !plan.Status.IsNull() && !plan.Status.IsUnknown() {
@@ -1176,6 +1196,7 @@ func (r *pspResource) Create(ctx context.Context, req resource.CreateRequest, re
 		newPSP.ID,
 		plan.Name.ValueString(),
 		requestedMonitorIDs,
+		requestedTagIDs,
 		expectedHomepageLink,
 		expectedSubscription,
 		expectedMonitorSort,
@@ -1204,6 +1225,24 @@ func (r *pspResource) Create(ctx context.Context, req resource.CreateRequest, re
 			return // do NOT write a broken PSP to state with a mismatching value
 		}
 	}
+	if hasTagPlan {
+		title, detail, mismatch := r.buildTagIDMismatchError(ctx, requestedTagIDs, pspForState.TagIDs)
+		if mismatch {
+			if delErr := r.client.DeletePSP(ctx, pspForState.ID); delErr != nil && !client.IsNotFound(delErr) {
+				resp.Diagnostics.AddWarning(
+					"Failed to clean up PSP after tag_ids mismatch",
+					fmt.Sprintf(
+						"Attempted to delete PSP ID %d after tag_ids mismatch but got error: %v. "+
+							"You may need to delete it manually in the UptimeRobot UI.",
+						pspForState.ID, delErr,
+					),
+				)
+			}
+
+			resp.Diagnostics.AddError(title, detail)
+			return
+		}
+	}
 
 	// Map response body to schema and populate Computed attribute values
 	var updatedPlan = plan
@@ -1223,6 +1262,9 @@ func (r *pspResource) Create(ctx context.Context, req resource.CreateRequest, re
 		} else {
 			updatedPlan.MonitorIDs = types.SetValueMust(types.Int64Type, []attr.Value{})
 		}
+	}
+	if hasTagPlan {
+		updatedPlan.TagIDs = plan.TagIDs
 	}
 
 	if !managedColors && updatedPlan.CustomSettings != nil {
@@ -1299,6 +1341,14 @@ func (r *pspResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 			return
 		}
 	}
+	var expectedTagIDs []int64
+	if !state.TagIDs.IsNull() && !state.TagIDs.IsUnknown() {
+		diags := state.TagIDs.ElementsAs(ctx, &expectedTagIDs, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
 	var expectedHomepageLink *string
 	if !state.HomepageLink.IsNull() && !state.HomepageLink.IsUnknown() {
 		value := state.HomepageLink.ValueString()
@@ -1323,19 +1373,25 @@ func (r *pspResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		missing, extra := diffMonitorIDs(expectedMonitorIDs, psp.MonitorIDs)
 		monitorsMismatch = len(missing) > 0 || len(extra) > 0
 	}
+	tagsMismatch := false
+	if expectedTagIDs != nil {
+		missing, extra := diffTagIDs(expectedTagIDs, psp.TagIDs)
+		tagsMismatch = len(missing) > 0 || len(extra) > 0
+	}
 	homepageLinkMismatch := expectedHomepageLink != nil && !pspStringPtrMatches(psp.HomepageLink, expectedHomepageLink)
 	subscriptionMismatch := expectedSubscription != nil && psp.Subscription != *expectedSubscription
 	monitorSortMismatch := expectedMonitorSort != nil && psp.Sort != nil && *psp.Sort != *expectedMonitorSort
 
 	// PSP reads can be eventually consistent right after updates.
 	// If the API returns transient old values, re-poll briefly before accepting drift.
-	if !isImport && (nameMismatch || monitorsMismatch || homepageLinkMismatch || subscriptionMismatch || monitorSortMismatch) {
+	if !isImport && (nameMismatch || monitorsMismatch || tagsMismatch || homepageLinkMismatch || subscriptionMismatch || monitorSortMismatch) {
 		if settled, err := waitPSPSettled(
 			ctx,
 			r.client,
 			id,
 			expectedName,
 			expectedMonitorIDs,
+			expectedTagIDs,
 			expectedHomepageLink,
 			expectedSubscription,
 			expectedMonitorSort,
@@ -1420,6 +1476,16 @@ func (r *pspResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	var requestedMonitorIDs []int64
 	if hasMonitorPlan {
 		diags := plan.MonitorIDs.ElementsAs(ctx, &requestedMonitorIDs, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+	hasTagPlan := !plan.TagIDs.IsNull() && !plan.TagIDs.IsUnknown()
+	var requestedTagIDs []int64
+	if hasTagPlan {
+		requestedTagIDs = []int64{}
+		diags := plan.TagIDs.ElementsAs(ctx, &requestedTagIDs, false)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -1514,6 +1580,9 @@ func (r *pspResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 	if hasMonitorPlan {
 		psp.MonitorIDs = &requestedMonitorIDs
+	}
+	if hasTagPlan {
+		psp.TagIDs = &requestedTagIDs
 	}
 
 	if !plan.PinnedAnnouncementID.IsNull() && !plan.PinnedAnnouncementID.IsUnknown() &&
@@ -1689,6 +1758,7 @@ func (r *pspResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		id,
 		plan.Name.ValueString(),
 		requestedMonitorIDs,
+		requestedTagIDs,
 		expectedHomepageLink,
 		expectedSubscription,
 		expectedMonitorSort,
@@ -1701,6 +1771,13 @@ func (r *pspResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 	if hasMonitorPlan {
 		title, detail, mismatch := r.buildMonitorIDMismatchError(ctx, requestedMonitorIDs, pspForState.MonitorIDs)
+		if mismatch {
+			resp.Diagnostics.AddError(title, detail)
+			return
+		}
+	}
+	if hasTagPlan {
+		title, detail, mismatch := r.buildTagIDMismatchError(ctx, requestedTagIDs, pspForState.TagIDs)
 		if mismatch {
 			resp.Diagnostics.AddError(title, detail)
 			return
@@ -1721,6 +1798,11 @@ func (r *pspResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		newState.MonitorIDs = plan.MonitorIDs
 	} else {
 		newState.MonitorIDs = state.MonitorIDs
+	}
+	if hasTagPlan {
+		newState.TagIDs = plan.TagIDs
+	} else {
+		newState.TagIDs = state.TagIDs
 	}
 
 	maskCustomSettingsFromPlan(&plan, &newState)
@@ -1776,6 +1858,7 @@ func waitPSPSettled(
 	id int64,
 	expectedName string,
 	expectedMonitorIDs []int64, // nil means omitted and should not be checked
+	expectedTagIDs []int64, // nil means omitted and should not be checked
 	expectedHomepageLink *string,
 	expectedSubscription *bool,
 	expectedMonitorSort *int,
@@ -1808,17 +1891,22 @@ func waitPSPSettled(
 
 			nameOK := (expectedName == "" || psp.Name == expectedName)
 			monitorsOK := true
+			tagsOK := true
 
 			if expectedMonitorIDs != nil {
 				missing, extra := diffMonitorIDs(expectedMonitorIDs, psp.MonitorIDs)
 				monitorsOK = (len(missing) == 0 && len(extra) == 0)
+			}
+			if expectedTagIDs != nil {
+				missing, extra := diffTagIDs(expectedTagIDs, psp.TagIDs)
+				tagsOK = (len(missing) == 0 && len(extra) == 0)
 			}
 
 			homepageLinkOK := pspStringPtrMatches(psp.HomepageLink, expectedHomepageLink)
 			subscriptionOK := expectedSubscription == nil || psp.Subscription == *expectedSubscription
 			monitorSortOK := pspMonitorSortPtrMatches(psp.Sort, expectedMonitorSort)
 
-			if nameOK && monitorsOK && homepageLinkOK && subscriptionOK && monitorSortOK {
+			if nameOK && monitorsOK && tagsOK && homepageLinkOK && subscriptionOK && monitorSortOK {
 				consecutiveMatches++
 				if consecutiveMatches >= requiredConsecutiveMatches {
 					return psp, nil
@@ -1868,6 +1956,17 @@ func pspMonitorSortPtrMatches(got *int, want *int) bool {
 	return *got == *want
 }
 
+func pspInt64SetValue(_ context.Context, ids []int64) types.Set {
+	if len(ids) == 0 {
+		return types.SetValueMust(types.Int64Type, []attr.Value{})
+	}
+	values := make([]attr.Value, 0, len(ids))
+	for _, id := range ids {
+		values = append(values, types.Int64Value(id))
+	}
+	return types.SetValueMust(types.Int64Type, values)
+}
+
 func AllPSPMonitorSorts() []string {
 	return []string{
 		"friendly_name_asc",
@@ -1910,12 +2009,13 @@ func terraformPSPMonitorSort(value *int) (string, bool) {
 	}
 }
 
-func pspToResourceData(_ context.Context, psp *client.PSP, plan *pspResourceModel) {
+func pspToResourceData(ctx context.Context, psp *client.PSP, plan *pspResourceModel) {
 	plan.ID = types.StringValue(strconv.FormatInt(psp.ID, 10))
 	plan.Name = types.StringValue(psp.Name)
 	plan.Status = types.StringValue(psp.Status)
 	plan.URLKey = types.StringValue(psp.URLKey)
 	plan.IsPasswordSet = types.BoolValue(psp.IsPasswordSet)
+	plan.TagIDs = pspInt64SetValue(ctx, psp.TagIDs)
 
 	// Always set computed values, even if they're defaults from the API
 	plan.ShareAnalyticsConsent = types.BoolValue(psp.ShareAnalyticsConsent)
@@ -2198,6 +2298,14 @@ func (r *pspResource) UpgradeState(_ context.Context) map[int64]resource.StateUp
 
 // diffMonitorIDs returns which IDs are missing from the applied list and which are extra.
 func diffMonitorIDs(requested, applied []int64) (missing, extra []int64) {
+	return diffInt64IDs(requested, applied)
+}
+
+func diffTagIDs(requested, applied []int64) (missing, extra []int64) {
+	return diffInt64IDs(requested, applied)
+}
+
+func diffInt64IDs(requested, applied []int64) (missing, extra []int64) {
 	req := make(map[int64]struct{}, len(requested))
 	app := make(map[int64]struct{}, len(applied))
 
@@ -2269,4 +2377,61 @@ func (r *pspResource) buildMonitorIDMismatchError(
 	fmt.Fprintf(&b, "Please fix monitor_ids (for example, remove invalid IDs or create the missing monitors) and run apply again.")
 
 	return "PSP monitor_ids do not match configuration", b.String(), true
+}
+
+// buildTagIDMismatchError compares requested vs applied tag_ids. If possible,
+// it lists missing IDs that are not visible through the tags API.
+func (r *pspResource) buildTagIDMismatchError(
+	ctx context.Context,
+	requested, applied []int64,
+) (title, detail string, mismatch bool) {
+	missing, extra := diffTagIDs(requested, applied)
+	if len(missing) == 0 && len(extra) == 0 {
+		return "", "", false
+	}
+
+	var notFound []int64
+	var existsButNotAttached []int64
+	var validationErrors []string
+
+	if len(missing) > 0 {
+		tags, err := r.client.ListAllTags(ctx)
+		if err != nil {
+			validationErrors = append(validationErrors, fmt.Sprintf("list tags: %v", err))
+		} else {
+			visibleTags := make(map[int64]struct{}, len(tags))
+			for _, tag := range tags {
+				visibleTags[tag.ID] = struct{}{}
+			}
+			for _, id := range missing {
+				if _, ok := visibleTags[id]; ok {
+					existsButNotAttached = append(existsButNotAttached, id)
+				} else {
+					notFound = append(notFound, id)
+				}
+			}
+		}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Requested tag_ids: %v\nApplied tag_ids:   %v\n", requested, applied)
+	if len(missing) > 0 {
+		fmt.Fprintf(&b, "Missing on PSP after apply: %v\n", missing)
+	}
+	if len(extra) > 0 {
+		fmt.Fprintf(&b, "Unexpected tag_ids reported by PSP API: %v\n", extra)
+	}
+	if len(notFound) > 0 {
+		fmt.Fprintf(&b, "\nThe following tag IDs are not visible through the UptimeRobot tags API: %v\n", notFound)
+	}
+	if len(existsButNotAttached) > 0 {
+		fmt.Fprintf(&b, "\nThe following tags exist but were not attached to the PSP: %v\n", existsButNotAttached)
+	}
+	if len(validationErrors) > 0 {
+		fmt.Fprintf(&b, "\nAdditional errors while validating tag_ids: %s\n", strings.Join(validationErrors, "; "))
+	}
+	fmt.Fprintf(&b, "\nThis mismatch would cause Terraform/state drift, so the provider is treating it as an error.\n")
+	fmt.Fprintf(&b, "Please fix tag_ids (for example, remove invalid IDs or create the missing tags) and run apply again.")
+
+	return "PSP tag_ids do not match configuration", b.String(), true
 }

--- a/templates/resources/psp.md.tmpl
+++ b/templates/resources/psp.md.tmpl
@@ -19,6 +19,10 @@ description: |-
 
 {{tffile "examples/resources/uptimerobot_psp/custom_domain.tf"}}
 
+### Status Page with Tag-Based Monitor Selection
+
+{{tffile "examples/resources/uptimerobot_psp/tag_ids.tf"}}
+
 ### Password Protected Status Page
 
 {{tffile "examples/resources/uptimerobot_psp/password_protected.tf"}}
@@ -46,6 +50,8 @@ You can include specific monitors in your status page by providing their IDs in 
 - Show only public-facing services
 - Create different status pages for different audiences
 - Group related services together
+
+You can also include monitors by tag with `tag_ids`. The UptimeRobot API resolves matching monitors server-side, and `tag_ids` are additive with `monitor_ids`.
 
 Use `monitor_sort` to control how monitors are ordered on the public status page. Supported values are:
 - `friendly_name_asc`


### PR DESCRIPTION
Closes #236.

Summary:
- Adds `tag_ids` support to `uptimerobot_psp` and the PSP data source.
- Sends `tagIds` on create/update, including an empty array when tags are intentionally cleared.
- Verifies applied tag IDs after create/update/read to avoid hidden Terraform drift.
- Adds generated docs, examples, changelog entry, and unit coverage.

Checks run:
- `go generate ./...`
- `go test ./internal/client ./internal/provider/psp`
- `make lint`
- `go test ./...`

Manual checks:
- Created PSP with tag-based monitor selection and confirmed no diff.
- Added explicit `monitor_ids` alongside `tag_ids` and confirmed no diff.
- Cleared `tag_ids` with `tag_ids = []` and confirmed no diff.
- Destroyed all manual test resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `tag_ids` parameter to the Public Status Page resource, enabling monitors to be selected by tag IDs in addition to explicit monitor IDs.
  * Added new `uptimerobot_alert_contact` resource for managing personal alert contacts.

* **Documentation**
  * Enhanced Public Status Page documentation with `tag_ids` support and practical configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->