### PR TITLE
Add maintenance window monitor_ids support

### DIFF
--- a/docs/data-sources/maintenance_window.md
+++ b/docs/data-sources/maintenance_window.md
@@ -45,5 +45,6 @@ resource "uptimerobot_monitor" "website" {
 - `days` (Set of Number) Days assigned to weekly or monthly maintenance windows. Weekly: 1=Mon..7=Sun. Monthly: 1..31, or -1 for the last day of the month.
 - `duration` (Number) Duration of the maintenance window in minutes.
 - `interval` (String) The maintenance window interval returned by the API (`once`, `daily`, `weekly`, or `monthly`).
+- `monitor_ids` (Set of Number) Monitor IDs assigned to the maintenance window. A value of `0` means all monitors are automatically added.
 - `status` (String) Status of the maintenance window returned by the API.
 - `time` (String) The maintenance window start time in `HH:mm:ss` format.

--- a/docs/resources/maintenance_window.md
+++ b/docs/resources/maintenance_window.md
@@ -33,6 +33,7 @@ resource "uptimerobot_maintenance_window" "business_hours_maintenance" {
   days     = [2, 4] # Tuesday and Thursday
 
   auto_add_monitors = false
+  monitor_ids       = [uptimerobot_monitor.website.id]
 }
 ```
 
@@ -132,6 +133,7 @@ terraform import uptimerobot_maintenance_window.example 123456
 - `auto_add_monitors` (Boolean) Automatically add new monitors to maintenance window
 - `date` (String) Date of the maintenance window (format: YYYY-MM-DD)
 - `days` (Set of Number) Only for interval = "weekly" or "monthly". Weekly: 1=Mon..7=Sun. Monthly: 1..31, or -1 (last day of month).Invalid values are silently ignored by the API.
+- `monitor_ids` (Set of Number) Set of monitor IDs assigned to the maintenance window. Use [0] to auto-add all monitors.
 
 ### Read-Only
 

--- a/examples/resources/uptimerobot_maintenance_window/weekly.tf
+++ b/examples/resources/uptimerobot_maintenance_window/weekly.tf
@@ -17,4 +17,5 @@ resource "uptimerobot_maintenance_window" "business_hours_maintenance" {
   days     = [2, 4] # Tuesday and Thursday
 
   auto_add_monitors = false
+  monitor_ids       = [uptimerobot_monitor.website.id]
 }

--- a/internal/client/maintenance_window.go
+++ b/internal/client/maintenance_window.go
@@ -20,6 +20,7 @@ type MaintenanceWindow struct {
 	Time            string  `json:"time"`
 	Duration        int     `json:"duration"`
 	AutoAddMonitors bool    `json:"autoAddMonitors"`
+	MonitorIDs      []int64 `json:"monitorIds"`
 	Days            []int64 `json:"days"`
 	Status          string  `json:"status"`
 	Created         string  `json:"created"`
@@ -35,24 +36,26 @@ type MaintenanceWindowListResponse struct {
 
 // CreateMaintenanceWindowRequest represents the request to create a new maintenance window.
 type CreateMaintenanceWindowRequest struct {
-	Name            string  `json:"name"`
-	Interval        string  `json:"interval"`
-	Date            *string `json:"date,omitempty"`
-	Time            string  `json:"time"`
-	Duration        int     `json:"duration"`
-	AutoAddMonitors *bool   `json:"autoAddMonitors,omitempty"`
-	Days            []int64 `json:"days,omitempty"`
+	Name            string   `json:"name"`
+	Interval        string   `json:"interval"`
+	Date            *string  `json:"date,omitempty"`
+	Time            string   `json:"time"`
+	Duration        int      `json:"duration"`
+	AutoAddMonitors *bool    `json:"autoAddMonitors,omitempty"`
+	MonitorIDs      *[]int64 `json:"monitorIds,omitempty"`
+	Days            []int64  `json:"days,omitempty"`
 }
 
 // UpdateMaintenanceWindowRequest represents the request to update an existing maintenance window.
 type UpdateMaintenanceWindowRequest struct {
-	Name            string  `json:"name,omitempty"`
-	Interval        string  `json:"interval,omitempty"`
-	Date            *string `json:"date,omitempty"`
-	Time            string  `json:"time,omitempty"`
-	Duration        int     `json:"duration,omitempty"`
-	AutoAddMonitors *bool   `json:"autoAddMonitors,omitempty"`
-	Days            []int64 `json:"days,omitempty"`
+	Name            string   `json:"name,omitempty"`
+	Interval        string   `json:"interval,omitempty"`
+	Date            *string  `json:"date,omitempty"`
+	Time            string   `json:"time,omitempty"`
+	Duration        int      `json:"duration,omitempty"`
+	AutoAddMonitors *bool    `json:"autoAddMonitors,omitempty"`
+	MonitorIDs      *[]int64 `json:"monitorIds,omitempty"`
+	Days            []int64  `json:"days,omitempty"`
 }
 
 // CreateMaintenanceWindow creates a new maintenance window.

--- a/internal/client/maintenance_window_test.go
+++ b/internal/client/maintenance_window_test.go
@@ -16,7 +16,7 @@ func TestClient_ListMaintenanceWindows_WithCursor(t *testing.T) {
 			if got := req.Method + " " + req.URL.RequestURI(); got != "GET /maintenance-windows?cursor=55" {
 				t.Fatalf("unexpected request %s", got)
 			}
-			return jsonResponse(http.StatusOK, `{"data":[{"id":56,"name":"Next","interval":"weekly","time":"02:00:00","duration":60,"autoAddMonitors":false,"days":[2],"status":"active"}]}`), nil
+			return jsonResponse(http.StatusOK, `{"data":[{"id":56,"name":"Next","interval":"weekly","time":"02:00:00","duration":60,"autoAddMonitors":false,"monitorIds":[11,22],"days":[2],"status":"active"}]}`), nil
 		}),
 	}
 	c.SetBaseURL("https://example.test")
@@ -28,6 +28,9 @@ func TestClient_ListMaintenanceWindows_WithCursor(t *testing.T) {
 	}
 	if len(windows.Data) != 1 || windows.Data[0].ID != 56 || windows.Data[0].Name != "Next" {
 		t.Fatalf("unexpected list response: %#v", windows)
+	}
+	if len(windows.Data[0].MonitorIDs) != 2 || windows.Data[0].MonitorIDs[0] != 11 || windows.Data[0].MonitorIDs[1] != 22 {
+		t.Fatalf("unexpected monitor IDs: %#v", windows.Data[0].MonitorIDs)
 	}
 	if windows.NextLink != nil {
 		t.Fatalf("expected nil next link, got %q", *windows.NextLink)

--- a/internal/client/request_marshal_test.go
+++ b/internal/client/request_marshal_test.go
@@ -470,9 +470,14 @@ func TestMaintenanceWindowRequest_AutoAddMonitors_JSON(t *testing.T) {
 	if _, ok := createMap["autoAddMonitors"]; ok {
 		t.Fatalf("autoAddMonitors should be omitted when nil, got %s", raw)
 	}
+	if _, ok := createMap["monitorIds"]; ok {
+		t.Fatalf("monitorIds should be omitted when nil, got %s", raw)
+	}
 
 	f := false
 	createReq.AutoAddMonitors = &f
+	createMonitorIDs := []int64{123, 456}
+	createReq.MonitorIDs = &createMonitorIDs
 	raw, err = json.Marshal(createReq)
 	if err != nil {
 		t.Fatal(err)
@@ -483,6 +488,9 @@ func TestMaintenanceWindowRequest_AutoAddMonitors_JSON(t *testing.T) {
 	}
 	if v, ok := createMap["autoAddMonitors"].(bool); !ok || v {
 		t.Fatalf("expected autoAddMonitors=false in create request, got %#v", createMap["autoAddMonitors"])
+	}
+	if ids, ok := createMap["monitorIds"].([]any); !ok || len(ids) != 2 || ids[0].(float64) != 123 || ids[1].(float64) != 456 {
+		t.Fatalf("expected monitorIds in create request, got %#v", createMap["monitorIds"])
 	}
 
 	updateReq := UpdateMaintenanceWindowRequest{
@@ -499,9 +507,14 @@ func TestMaintenanceWindowRequest_AutoAddMonitors_JSON(t *testing.T) {
 	if _, ok := updateMap["autoAddMonitors"]; ok {
 		t.Fatalf("autoAddMonitors should be omitted in update when nil, got %s", raw)
 	}
+	if _, ok := updateMap["monitorIds"]; ok {
+		t.Fatalf("monitorIds should be omitted in update when nil, got %s", raw)
+	}
 
 	tVal := true
 	updateReq.AutoAddMonitors = &tVal
+	updateMonitorIDs := []int64{}
+	updateReq.MonitorIDs = &updateMonitorIDs
 	raw, err = json.Marshal(updateReq)
 	if err != nil {
 		t.Fatal(err)
@@ -512,6 +525,9 @@ func TestMaintenanceWindowRequest_AutoAddMonitors_JSON(t *testing.T) {
 	}
 	if v, ok := updateMap["autoAddMonitors"].(bool); !ok || !v {
 		t.Fatalf("expected autoAddMonitors=true in update request, got %#v", updateMap["autoAddMonitors"])
+	}
+	if ids, ok := updateMap["monitorIds"].([]any); !ok || len(ids) != 0 {
+		t.Fatalf("expected empty monitorIds in update request, got %#v", updateMap["monitorIds"])
 	}
 }
 

--- a/internal/client/request_marshal_test.go
+++ b/internal/client/request_marshal_test.go
@@ -489,7 +489,13 @@ func TestMaintenanceWindowRequest_AutoAddMonitors_JSON(t *testing.T) {
 	if v, ok := createMap["autoAddMonitors"].(bool); !ok || v {
 		t.Fatalf("expected autoAddMonitors=false in create request, got %#v", createMap["autoAddMonitors"])
 	}
-	if ids, ok := createMap["monitorIds"].([]any); !ok || len(ids) != 2 || ids[0].(float64) != 123 || ids[1].(float64) != 456 {
+	ids, ok := createMap["monitorIds"].([]any)
+	if !ok || len(ids) != 2 {
+		t.Fatalf("expected monitorIds in create request, got %#v", createMap["monitorIds"])
+	}
+	firstID, firstOK := ids[0].(float64)
+	secondID, secondOK := ids[1].(float64)
+	if !firstOK || !secondOK || firstID != 123 || secondID != 456 {
 		t.Fatalf("expected monitorIds in create request, got %#v", createMap["monitorIds"])
 	}
 

--- a/internal/provider/maintenancewindow/data_source.go
+++ b/internal/provider/maintenancewindow/data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/uptimerobot/terraform-provider-uptimerobot/internal/client"
@@ -48,6 +49,7 @@ type maintenanceWindowDataSourceModel struct {
 	Time            types.String `tfsdk:"time"`
 	Duration        types.Int64  `tfsdk:"duration"`
 	AutoAddMonitors types.Bool   `tfsdk:"auto_add_monitors"`
+	MonitorIDs      types.Set    `tfsdk:"monitor_ids"`
 	Days            types.Set    `tfsdk:"days"`
 	Status          types.String `tfsdk:"status"`
 }
@@ -105,6 +107,11 @@ func (d *maintenanceWindowDataSource) Schema(_ context.Context, _ datasource.Sch
 				Computed:            true,
 				MarkdownDescription: "Whether new monitors are automatically added to the maintenance window.",
 			},
+			"monitor_ids": datasourceschema.SetAttribute{
+				Computed:            true,
+				ElementType:         types.Int64Type,
+				MarkdownDescription: "Monitor IDs assigned to the maintenance window. A value of `0` means all monitors are automatically added.",
+			},
 			"days": datasourceschema.SetAttribute{
 				Computed:            true,
 				ElementType:         types.Int64Type,
@@ -141,7 +148,11 @@ func (d *maintenanceWindowDataSource) Read(ctx context.Context, req datasource.R
 		return
 	}
 
-	state := maintenanceWindowState(maintenanceWindow)
+	state, diags := maintenanceWindowState(ctx, maintenanceWindow)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -259,11 +270,15 @@ func maintenanceWindowIDs(maintenanceWindows []client.MaintenanceWindow) string 
 	return strings.Join(formattedIDs, ", ")
 }
 
-func maintenanceWindowState(maintenanceWindow *client.MaintenanceWindow) maintenanceWindowDataSourceModel {
+func maintenanceWindowState(ctx context.Context, maintenanceWindow *client.MaintenanceWindow) (maintenanceWindowDataSourceModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
 	date := types.StringNull()
 	if maintenanceWindow.Date != nil {
 		date = types.StringValue(*maintenanceWindow.Date)
 	}
+	monitorIDs, setDiags := maintenanceWindowMonitorIDsSet(ctx, maintenanceWindow.MonitorIDs)
+	diags.Append(setDiags...)
 
 	return maintenanceWindowDataSourceModel{
 		ID:              types.StringValue(strconv.FormatInt(maintenanceWindow.ID, 10)),
@@ -273,9 +288,10 @@ func maintenanceWindowState(maintenanceWindow *client.MaintenanceWindow) mainten
 		Time:            types.StringValue(maintenanceWindow.Time),
 		Duration:        types.Int64Value(int64(maintenanceWindow.Duration)),
 		AutoAddMonitors: types.BoolValue(maintenanceWindow.AutoAddMonitors),
+		MonitorIDs:      monitorIDs,
 		Days:            maintenanceWindowDaysSet(maintenanceWindow.Days),
 		Status:          types.StringValue(maintenanceWindow.Status),
-	}
+	}, diags
 }
 
 func maintenanceWindowDaysSet(days []int64) types.Set {

--- a/internal/provider/maintenancewindow/data_source_test.go
+++ b/internal/provider/maintenancewindow/data_source_test.go
@@ -111,7 +111,7 @@ func TestMaintenanceWindowDataSourceStateMapsFields(t *testing.T) {
 	t.Parallel()
 
 	date := "2026-06-15"
-	state := maintenanceWindowState(&client.MaintenanceWindow{
+	state, stateDiags := maintenanceWindowState(t.Context(), &client.MaintenanceWindow{
 		ID:              101,
 		Name:            "Deploy Window",
 		Interval:        "monthly",
@@ -119,9 +119,13 @@ func TestMaintenanceWindowDataSourceStateMapsFields(t *testing.T) {
 		Time:            "02:30:00",
 		Duration:        90,
 		AutoAddMonitors: true,
+		MonitorIDs:      []int64{22, 11},
 		Days:            []int64{7, 2, 4},
 		Status:          "active",
 	})
+	if stateDiags.HasError() {
+		t.Fatalf("unexpected state diagnostics: %v", stateDiags.Errors())
+	}
 
 	if state.ID.ValueString() != "101" {
 		t.Fatalf("unexpected ID %q", state.ID.ValueString())
@@ -144,11 +148,28 @@ func TestMaintenanceWindowDataSourceStateMapsFields(t *testing.T) {
 	if !state.AutoAddMonitors.ValueBool() {
 		t.Fatal("expected auto_add_monitors to be true")
 	}
+	var monitorIDs []int64
+	diags := state.MonitorIDs.ElementsAs(t.Context(), &monitorIDs, false)
+	if diags.HasError() {
+		t.Fatalf("unexpected monitor ID diagnostics: %v", diags.Errors())
+	}
+	gotMonitorIDs := make(map[int64]struct{}, len(monitorIDs))
+	for _, id := range monitorIDs {
+		gotMonitorIDs[id] = struct{}{}
+	}
+	for _, want := range []int64{11, 22} {
+		if _, ok := gotMonitorIDs[want]; !ok {
+			t.Fatalf("expected monitor ID %d in %#v", want, monitorIDs)
+		}
+	}
+	if len(gotMonitorIDs) != 2 {
+		t.Fatalf("unexpected monitor IDs %#v", monitorIDs)
+	}
 	if state.Status.ValueString() != "active" {
 		t.Fatalf("unexpected status %q", state.Status.ValueString())
 	}
 	var days []int64
-	diags := state.Days.ElementsAs(t.Context(), &days, false)
+	diags = state.Days.ElementsAs(t.Context(), &days, false)
 	if diags.HasError() {
 		t.Fatalf("unexpected day diagnostics: %v", diags.Errors())
 	}
@@ -169,7 +190,7 @@ func TestMaintenanceWindowDataSourceStateMapsFields(t *testing.T) {
 func TestMaintenanceWindowDataSourceStateNullDateAndDays(t *testing.T) {
 	t.Parallel()
 
-	state := maintenanceWindowState(&client.MaintenanceWindow{
+	state, stateDiags := maintenanceWindowState(t.Context(), &client.MaintenanceWindow{
 		ID:       101,
 		Name:     "Daily",
 		Interval: "daily",
@@ -177,11 +198,20 @@ func TestMaintenanceWindowDataSourceStateNullDateAndDays(t *testing.T) {
 		Duration: 30,
 		Status:   "active",
 	})
+	if stateDiags.HasError() {
+		t.Fatalf("unexpected state diagnostics: %v", stateDiags.Errors())
+	}
 
 	if !state.Date.IsNull() {
 		t.Fatalf("expected null date, got %#v", state.Date)
 	}
 	if !state.Days.IsNull() {
 		t.Fatalf("expected null days, got %#v", state.Days)
+	}
+	if state.MonitorIDs.IsNull() {
+		t.Fatal("expected empty monitor_ids set, got null")
+	}
+	if len(state.MonitorIDs.Elements()) != 0 {
+		t.Fatalf("expected empty monitor_ids set, got %#v", state.MonitorIDs.Elements())
 	}
 }

--- a/internal/provider/maintenancewindow/resource.go
+++ b/internal/provider/maintenancewindow/resource.go
@@ -612,6 +612,13 @@ func (r *maintenanceWindowResource) Update(ctx context.Context, req resource.Upd
 		return
 	}
 
+	var config maintenanceWindowResourceModel
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	id, err := strconv.ParseInt(plan.ID.ValueString(), 10, 64)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -641,25 +648,17 @@ func (r *maintenanceWindowResource) Update(ctx context.Context, req resource.Upd
 		shouldWait = true
 	}
 
-	if !plan.MonitorIDs.IsNull() && !plan.MonitorIDs.IsUnknown() {
-		monitorIDs, d := maintenanceWindowMonitorIDsFromSet(ctx, plan.MonitorIDs)
-		resp.Diagnostics.Append(d...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		updateReq.MonitorIDs = &monitorIDs
-		expectedMonitorIDs = append([]int64{}, monitorIDs...)
+	monitorIDsExpected, monitorIDsAutoAdd, monitorIDsWait, d := applyMaintenanceWindowMonitorIDsUpdate(ctx, plan, config, updateReq)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if monitorIDsWait {
+		expectedMonitorIDs = monitorIDsExpected
 		shouldWait = true
-
-		if maintenanceWindowMonitorIDsAutoAdd(monitorIDs) {
-			v := true
-			updateReq.AutoAddMonitors = &v
-			expectedAutoAddMonitors = &v
-		} else if plan.AutoAddMonitors.IsNull() || plan.AutoAddMonitors.IsUnknown() {
-			v := false
-			updateReq.AutoAddMonitors = &v
-			expectedAutoAddMonitors = &v
-		}
+	}
+	if monitorIDsAutoAdd != nil {
+		expectedAutoAddMonitors = monitorIDsAutoAdd
 	}
 
 	// Add date if it's set
@@ -914,6 +913,47 @@ func normalizeMonitorIDs(monitorIDs []int64) []int64 {
 		return []int64{}
 	}
 	return cp
+}
+
+func applyMaintenanceWindowMonitorIDsUpdate(
+	ctx context.Context,
+	plan maintenanceWindowResourceModel,
+	config maintenanceWindowResourceModel,
+	updateReq *client.UpdateMaintenanceWindowRequest,
+) ([]int64, *bool, bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if config.MonitorIDs.IsNull() || config.MonitorIDs.IsUnknown() {
+		return nil, nil, false, diags
+	}
+
+	if plan.MonitorIDs.IsNull() || plan.MonitorIDs.IsUnknown() {
+		diags.AddError(
+			"Invalid monitor_ids plan",
+			"Expected monitor_ids to be known because it is present in configuration. Please report this issue to the provider developers.",
+		)
+		return nil, nil, false, diags
+	}
+
+	monitorIDs, d := maintenanceWindowMonitorIDsFromSet(ctx, plan.MonitorIDs)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, nil, false, diags
+	}
+
+	updateReq.MonitorIDs = &monitorIDs
+	expectedMonitorIDs := append([]int64{}, monitorIDs...)
+	var expectedAutoAddMonitors *bool
+	if maintenanceWindowMonitorIDsAutoAdd(monitorIDs) {
+		v := true
+		updateReq.AutoAddMonitors = &v
+		expectedAutoAddMonitors = &v
+	} else if plan.AutoAddMonitors.IsNull() || plan.AutoAddMonitors.IsUnknown() {
+		v := false
+		updateReq.AutoAddMonitors = &v
+		expectedAutoAddMonitors = &v
+	}
+
+	return expectedMonitorIDs, expectedAutoAddMonitors, true, diags
 }
 
 func maintenanceWindowMonitorIDsFromSet(ctx context.Context, value types.Set) ([]int64, diag.Diagnostics) {

--- a/internal/provider/maintenancewindow/resource.go
+++ b/internal/provider/maintenancewindow/resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -38,6 +39,7 @@ var (
 	_ resource.Resource                   = &maintenanceWindowResource{}
 	_ resource.ResourceWithConfigure      = &maintenanceWindowResource{}
 	_ resource.ResourceWithImportState    = &maintenanceWindowResource{}
+	_ resource.ResourceWithModifyPlan     = &maintenanceWindowResource{}
 	_ resource.ResourceWithValidateConfig = &maintenanceWindowResource{}
 	_ resource.ResourceWithUpgradeState   = &maintenanceWindowResource{}
 )
@@ -61,6 +63,7 @@ type maintenanceWindowResourceModel struct {
 	Time            types.String `tfsdk:"time"`
 	Duration        types.Int64  `tfsdk:"duration"`
 	AutoAddMonitors types.Bool   `tfsdk:"auto_add_monitors"`
+	MonitorIDs      types.Set    `tfsdk:"monitor_ids"`
 	Days            types.Set    `tfsdk:"days"`
 	Status          types.String `tfsdk:"status"`
 }
@@ -131,6 +134,15 @@ func (r *maintenanceWindowResource) Schema(_ context.Context, _ resource.SchemaR
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
+			"monitor_ids": schema.SetAttribute{
+				Description: "Set of monitor IDs assigned to the maintenance window. Use [0] to auto-add all monitors.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.Int64Type,
+				Validators: []validator.Set{
+					setvalidator.ValueInt64sAre(int64validator.AtLeast(0)),
+				},
+			},
 			"days": schema.SetAttribute{
 				Description: "Only for interval = \"weekly\" or \"monthly\". " +
 					"Weekly: 1=Mon..7=Sun. Monthly: 1..31, or -1 (last day of month)." +
@@ -173,7 +185,7 @@ func (r *maintenanceWindowResource) ValidateConfig(
 
 	validateRuleDaysRequiredForWeeklyMonthly(ctx, cfg, resp)
 	validateRuleDaysNotAllowedForOnceDaily(ctx, cfg, resp)
-
+	validateRuleMonitorIDsAutoAddConflict(ctx, cfg, resp)
 }
 
 func validateRuleDaysRequiredForWeeklyMonthly(
@@ -252,6 +264,55 @@ func validateRuleDaysNotAllowedForOnceDaily(
 	}
 }
 
+func validateRuleMonitorIDsAutoAddConflict(
+	ctx context.Context,
+	cfg maintenanceWindowResourceModel,
+	resp *resource.ValidateConfigResponse,
+) {
+	if cfg.MonitorIDs.IsNull() || cfg.MonitorIDs.IsUnknown() {
+		return
+	}
+
+	monitorIDs, diags := maintenanceWindowMonitorIDsFromSet(ctx, cfg.MonitorIDs)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if maintenanceWindowMonitorIDsContainAutoAdd(monitorIDs) && len(monitorIDs) > 1 {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("monitor_ids"),
+			"Invalid monitor_ids",
+			`"monitor_ids" can contain either specific monitor IDs or [0] to auto-add all monitors, but not both.`,
+		)
+		return
+	}
+
+	if cfg.AutoAddMonitors.IsNull() || cfg.AutoAddMonitors.IsUnknown() {
+		return
+	}
+
+	autoAddMonitors := cfg.AutoAddMonitors.ValueBool()
+	if autoAddMonitors {
+		if len(monitorIDs) == 0 || !maintenanceWindowMonitorIDsAutoAdd(monitorIDs) {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("monitor_ids"),
+				"monitor_ids conflicts with auto_add_monitors",
+				`When "auto_add_monitors" is true, omit "monitor_ids" or set it to [0].`,
+			)
+		}
+		return
+	}
+
+	if maintenanceWindowMonitorIDsAutoAdd(monitorIDs) {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("auto_add_monitors"),
+			"auto_add_monitors conflicts with monitor_ids",
+			`When "monitor_ids" is [0], omit "auto_add_monitors" or set it to true.`,
+		)
+	}
+}
+
 func (r *maintenanceWindowResource) ModifyPlan(
 	ctx context.Context,
 	req resource.ModifyPlanRequest,
@@ -267,14 +328,31 @@ func (r *maintenanceWindowResource) ModifyPlan(
 		return
 	}
 
-	// Put in a separate function Interval segment to not exit earlier when modify plan increase in functionality
-	if plan.Interval.IsUnknown() || plan.Interval.IsNull() {
+	var config maintenanceWindowResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	switch strings.ToLower(plan.Interval.ValueString()) {
-	case intervalDaily, intervalOnce:
-		resp.Plan.SetAttribute(ctx, path.Root("days"), types.SetNull(types.Int64Type))
+	if !config.MonitorIDs.IsNull() && !config.MonitorIDs.IsUnknown() {
+		monitorIDs, diags := maintenanceWindowMonitorIDsFromSet(ctx, config.MonitorIDs)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		autoAddMonitors := maintenanceWindowMonitorIDsAutoAdd(monitorIDs)
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("auto_add_monitors"), types.BoolValue(autoAddMonitors))...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	if !plan.Interval.IsUnknown() && !plan.Interval.IsNull() {
+		switch strings.ToLower(plan.Interval.ValueString()) {
+		case intervalDaily, intervalOnce:
+			resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("days"), types.SetNull(types.Int64Type))...)
+		}
 	}
 }
 
@@ -306,6 +384,22 @@ func (r *maintenanceWindowResource) Create(ctx context.Context, req resource.Cre
 	if !plan.AutoAddMonitors.IsNull() && !plan.AutoAddMonitors.IsUnknown() {
 		v := plan.AutoAddMonitors.ValueBool()
 		mw.AutoAddMonitors = &v
+	}
+
+	if !plan.MonitorIDs.IsNull() && !plan.MonitorIDs.IsUnknown() {
+		monitorIDs, d := maintenanceWindowMonitorIDsFromSet(ctx, plan.MonitorIDs)
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		mw.MonitorIDs = &monitorIDs
+		if maintenanceWindowMonitorIDsAutoAdd(monitorIDs) {
+			v := true
+			mw.AutoAddMonitors = &v
+		} else if plan.AutoAddMonitors.IsNull() || plan.AutoAddMonitors.IsUnknown() {
+			v := false
+			mw.AutoAddMonitors = &v
+		}
 	}
 
 	// Add date if it's set
@@ -374,6 +468,12 @@ func (r *maintenanceWindowResource) Create(ctx context.Context, req resource.Cre
 	}
 
 	plan.AutoAddMonitors = types.BoolValue(newMW.AutoAddMonitors)
+	monitorIDs, d := maintenanceWindowMonitorIDsSet(ctx, newMW.MonitorIDs)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.MonitorIDs = monitorIDs
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, plan)
@@ -464,6 +564,12 @@ func (r *maintenanceWindowResource) Read(ctx context.Context, req resource.ReadR
 	state.Duration = types.Int64Value(int64(mw.Duration))
 
 	state.AutoAddMonitors = types.BoolValue(mw.AutoAddMonitors)
+	monitorIDs, d := maintenanceWindowMonitorIDsSet(ctx, mw.MonitorIDs)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.MonitorIDs = monitorIDs
 
 	// Set additional computed values if available
 	if mw.Status != "" {
@@ -523,6 +629,7 @@ func (r *maintenanceWindowResource) Update(ctx context.Context, req resource.Upd
 		Duration: int(plan.Duration.ValueInt64()),
 	}
 	var expectedDays []int64
+	var expectedMonitorIDs []int64
 	var expectedAutoAddMonitors *bool
 	shouldWait := false
 
@@ -532,6 +639,27 @@ func (r *maintenanceWindowResource) Update(ctx context.Context, req resource.Upd
 		updateReq.AutoAddMonitors = &v
 		expectedAutoAddMonitors = &v
 		shouldWait = true
+	}
+
+	if !plan.MonitorIDs.IsNull() && !plan.MonitorIDs.IsUnknown() {
+		monitorIDs, d := maintenanceWindowMonitorIDsFromSet(ctx, plan.MonitorIDs)
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		updateReq.MonitorIDs = &monitorIDs
+		expectedMonitorIDs = append([]int64{}, monitorIDs...)
+		shouldWait = true
+
+		if maintenanceWindowMonitorIDsAutoAdd(monitorIDs) {
+			v := true
+			updateReq.AutoAddMonitors = &v
+			expectedAutoAddMonitors = &v
+		} else if plan.AutoAddMonitors.IsNull() || plan.AutoAddMonitors.IsUnknown() {
+			v := false
+			updateReq.AutoAddMonitors = &v
+			expectedAutoAddMonitors = &v
+		}
 	}
 
 	// Add date if it's set
@@ -575,7 +703,7 @@ func (r *maintenanceWindowResource) Update(ctx context.Context, req resource.Upd
 
 	var settled *client.MaintenanceWindow
 	if shouldWait {
-		settled, err = waitMaintenanceWindowSettled(ctx, r.client, id, iv, expectedDays, expectedAutoAddMonitors)
+		settled, err = waitMaintenanceWindowSettled(ctx, r.client, id, iv, expectedDays, expectedMonitorIDs, expectedAutoAddMonitors)
 		if err != nil {
 			resp.Diagnostics.AddError("Maintenance window did not settle", err.Error())
 			return
@@ -600,6 +728,12 @@ func (r *maintenanceWindowResource) Update(ctx context.Context, req resource.Upd
 	plan.Time = types.StringValue(latest.Time)
 	plan.Duration = types.Int64Value(int64(latest.Duration))
 	plan.AutoAddMonitors = types.BoolValue(latest.AutoAddMonitors)
+	monitorIDs, d := maintenanceWindowMonitorIDsSet(ctx, latest.MonitorIDs)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.MonitorIDs = monitorIDs
 
 	if latest.Status != "" {
 		plan.Status = types.StringValue(latest.Status)
@@ -640,11 +774,14 @@ func waitMaintenanceWindowSettled(
 	id int64,
 	expectedInterval string,
 	expectedDays []int64,
+	expectedMonitorIDs []int64,
 	expectedAutoAddMonitors *bool,
 ) (*client.MaintenanceWindow, error) {
 	want := normalizeDays(expectedDays)
+	wantMonitorIDs := normalizeMonitorIDs(expectedMonitorIDs)
 	wantInterval := strings.ToLower(expectedInterval)
 	var lastGot []int64
+	var lastMonitorIDs []int64
 	var lastInterval string
 	var lastAutoAddMonitors bool
 	var lastMW *client.MaintenanceWindow
@@ -659,10 +796,12 @@ func waitMaintenanceWindowSettled(
 		lastMW = mw
 		lastInterval = strings.ToLower(mw.Interval)
 		lastGot = normalizeDays(mw.Days)
+		lastMonitorIDs = normalizeMonitorIDs(mw.MonitorIDs)
 		lastAutoAddMonitors = mw.AutoAddMonitors
 
 		autoAddMatches := expectedAutoAddMonitors == nil || mw.AutoAddMonitors == *expectedAutoAddMonitors
-		if lastInterval == wantInterval && equalInt64Sets(want, lastGot) && autoAddMatches {
+		monitorIDsMatch := expectedMonitorIDs == nil || equalInt64Sets(wantMonitorIDs, lastMonitorIDs)
+		if lastInterval == wantInterval && equalInt64Sets(want, lastGot) && monitorIDsMatch && autoAddMatches {
 			consecutiveMatches++
 			if consecutiveMatches >= requiredConsecutiveMatches {
 				return mw, nil
@@ -680,13 +819,19 @@ func waitMaintenanceWindowSettled(
 	if expectedAutoAddMonitors != nil {
 		wantAutoAdd = strconv.FormatBool(*expectedAutoAddMonitors)
 	}
+	wantMonitorIDsText := "<ignored>"
+	if expectedMonitorIDs != nil {
+		wantMonitorIDsText = fmt.Sprint(wantMonitorIDs)
+	}
 	return lastMW, fmt.Errorf(
-		"maintenance window did not settle: want interval=%s days=%v auto_add_monitors=%s got interval=%s days=%v auto_add_monitors=%t",
+		"maintenance window did not settle: want interval=%s days=%v monitor_ids=%s auto_add_monitors=%s got interval=%s days=%v monitor_ids=%v auto_add_monitors=%t",
 		wantInterval,
 		want,
+		wantMonitorIDsText,
 		wantAutoAdd,
 		lastInterval,
 		lastGot,
+		lastMonitorIDs,
 		lastAutoAddMonitors,
 	)
 }
@@ -723,13 +868,23 @@ func (r *maintenanceWindowResource) stabilizeMaintenanceWindowReadSnapshot(
 		wantDays = nil
 	}
 
+	var wantMonitorIDs []int64
+	if !state.MonitorIDs.IsNull() && !state.MonitorIDs.IsUnknown() {
+		var monitorIDs []int64
+		if diags := state.MonitorIDs.ElementsAs(ctx, &monitorIDs, false); !diags.HasError() {
+			wantMonitorIDs = normalizeMonitorIDs(monitorIDs)
+		}
+	}
+
 	gotInterval := strings.ToLower(strings.TrimSpace(got.Interval))
 	gotDays := normalizeDays(got.Days)
-	if gotInterval == wantInterval && equalInt64Sets(wantDays, gotDays) {
+	gotMonitorIDs := normalizeMonitorIDs(got.MonitorIDs)
+	monitorIDsMatch := wantMonitorIDs == nil || equalInt64Sets(wantMonitorIDs, gotMonitorIDs)
+	if gotInterval == wantInterval && equalInt64Sets(wantDays, gotDays) && monitorIDsMatch {
 		return got
 	}
 
-	settled, err := waitMaintenanceWindowSettled(ctx, r.client, id, wantInterval, wantDays, nil)
+	settled, err := waitMaintenanceWindowSettled(ctx, r.client, id, wantInterval, wantDays, wantMonitorIDs, nil)
 	if err == nil && settled != nil {
 		return settled
 	}
@@ -746,6 +901,41 @@ func normalizeDays(days []int64) []int64 {
 	cp := append([]int64(nil), days...)
 	slices.Sort(cp)
 	return cp
+}
+
+func normalizeMonitorIDs(monitorIDs []int64) []int64 {
+	cp := append([]int64(nil), monitorIDs...)
+	slices.Sort(cp)
+	return slices.Compact(cp)
+}
+
+func maintenanceWindowMonitorIDsFromSet(ctx context.Context, value types.Set) ([]int64, diag.Diagnostics) {
+	var monitorIDs []int64
+	diags := value.ElementsAs(ctx, &monitorIDs, false)
+	if diags.HasError() {
+		return nil, diags
+	}
+	normalized := normalizeMonitorIDs(monitorIDs)
+	if normalized == nil {
+		normalized = []int64{}
+	}
+	return normalized, diags
+}
+
+func maintenanceWindowMonitorIDsSet(ctx context.Context, monitorIDs []int64) (types.Set, diag.Diagnostics) {
+	normalized := normalizeMonitorIDs(monitorIDs)
+	if normalized == nil {
+		normalized = []int64{}
+	}
+	return types.SetValueFrom(ctx, types.Int64Type, normalized)
+}
+
+func maintenanceWindowMonitorIDsContainAutoAdd(monitorIDs []int64) bool {
+	return slices.Contains(monitorIDs, int64(0))
+}
+
+func maintenanceWindowMonitorIDsAutoAdd(monitorIDs []int64) bool {
+	return len(monitorIDs) == 1 && monitorIDs[0] == 0
 }
 
 func equalInt64Sets(a, b []int64) bool {

--- a/internal/provider/maintenancewindow/resource.go
+++ b/internal/provider/maintenancewindow/resource.go
@@ -904,9 +904,16 @@ func normalizeDays(days []int64) []int64 {
 }
 
 func normalizeMonitorIDs(monitorIDs []int64) []int64 {
-	cp := append([]int64(nil), monitorIDs...)
+	if monitorIDs == nil {
+		return nil
+	}
+	cp := append([]int64{}, monitorIDs...)
 	slices.Sort(cp)
-	return slices.Compact(cp)
+	cp = slices.Compact(cp)
+	if len(cp) == 0 {
+		return []int64{}
+	}
+	return cp
 }
 
 func maintenanceWindowMonitorIDsFromSet(ctx context.Context, value types.Set) ([]int64, diag.Diagnostics) {

--- a/internal/provider/maintenancewindow/resource_test.go
+++ b/internal/provider/maintenancewindow/resource_test.go
@@ -64,6 +64,14 @@ func TestNormalizeMonitorIDs(t *testing.T) {
 	if got := normalizeMonitorIDs(nil); got != nil {
 		t.Fatalf("normalizeMonitorIDs(nil) should be nil, got=%v", got)
 	}
+
+	empty := normalizeMonitorIDs([]int64{})
+	if empty == nil {
+		t.Fatal("normalizeMonitorIDs should preserve explicit empty slices")
+	}
+	if len(empty) != 0 {
+		t.Fatalf("expected empty monitor IDs, got=%v", empty)
+	}
 }
 
 func TestValidateRuleDaysRequiredForWeeklyMonthly(t *testing.T) {
@@ -186,6 +194,13 @@ func TestValidateRuleMonitorIDsAutoAddConflict(t *testing.T) {
 		cfg     maintenanceWindowResourceModel
 		wantErr bool
 	}{
+		{
+			name: "auto_add_true_with_null_monitor_ids_ok",
+			cfg: maintenanceWindowResourceModel{
+				AutoAddMonitors: types.BoolValue(true),
+				MonitorIDs:      types.SetNull(types.Int64Type),
+			},
+		},
 		{
 			name: "auto_marker_with_specific_ids_errors",
 			cfg: maintenanceWindowResourceModel{

--- a/internal/provider/maintenancewindow/resource_test.go
+++ b/internal/provider/maintenancewindow/resource_test.go
@@ -292,6 +292,159 @@ func TestMaintenanceWindowMonitorIDsFromSetEmptyReturnsEmptySlice(t *testing.T) 
 	}
 }
 
+func TestApplyMaintenanceWindowMonitorIDsUpdate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("skips_omitted_config_with_stale_plan_values", func(t *testing.T) {
+		t.Parallel()
+
+		autoAdd := false
+		updateReq := &client.UpdateMaintenanceWindowRequest{
+			AutoAddMonitors: &autoAdd,
+		}
+		monitorIDs, expectedAutoAdd, shouldWait, diags := applyMaintenanceWindowMonitorIDsUpdate(
+			ctx,
+			maintenanceWindowResourceModel{
+				AutoAddMonitors: types.BoolValue(false),
+				MonitorIDs:      setInt64(0),
+			},
+			maintenanceWindowResourceModel{
+				MonitorIDs: types.SetNull(types.Int64Type),
+			},
+			updateReq,
+		)
+
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags.Errors())
+		}
+		if shouldWait {
+			t.Fatal("expected omitted monitor_ids config to skip waiting for monitor IDs")
+		}
+		if monitorIDs != nil {
+			t.Fatalf("expected no expected monitor IDs, got=%v", monitorIDs)
+		}
+		if updateReq.MonitorIDs != nil {
+			t.Fatalf("expected monitorIds payload to be omitted, got=%v", *updateReq.MonitorIDs)
+		}
+		if updateReq.AutoAddMonitors == nil || *updateReq.AutoAddMonitors {
+			t.Fatalf("expected existing auto_add_monitors=false to be preserved, got=%v", updateReq.AutoAddMonitors)
+		}
+		if expectedAutoAdd != nil {
+			t.Fatalf("expected monitor_ids helper not to override expected auto_add_monitors, got=%v", *expectedAutoAdd)
+		}
+	})
+
+	t.Run("sends_auto_add_marker_when_configured", func(t *testing.T) {
+		t.Parallel()
+
+		updateReq := &client.UpdateMaintenanceWindowRequest{}
+		monitorIDs, expectedAutoAdd, shouldWait, diags := applyMaintenanceWindowMonitorIDsUpdate(
+			ctx,
+			maintenanceWindowResourceModel{
+				AutoAddMonitors: types.BoolNull(),
+				MonitorIDs:      setInt64(0),
+			},
+			maintenanceWindowResourceModel{
+				MonitorIDs: setInt64(0),
+			},
+			updateReq,
+		)
+
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags.Errors())
+		}
+		if !shouldWait {
+			t.Fatal("expected configured monitor_ids to require settle wait")
+		}
+		if !slices.Equal(monitorIDs, []int64{0}) {
+			t.Fatalf("expected monitor IDs [0], got=%v", monitorIDs)
+		}
+		if updateReq.MonitorIDs == nil || !slices.Equal(*updateReq.MonitorIDs, []int64{0}) {
+			t.Fatalf("expected monitorIds payload [0], got=%v", updateReq.MonitorIDs)
+		}
+		if updateReq.AutoAddMonitors == nil || !*updateReq.AutoAddMonitors {
+			t.Fatalf("expected auto_add_monitors=true payload, got=%v", updateReq.AutoAddMonitors)
+		}
+		if expectedAutoAdd == nil || !*expectedAutoAdd {
+			t.Fatalf("expected auto_add_monitors=true settle target, got=%v", expectedAutoAdd)
+		}
+	})
+
+	t.Run("sends_specific_monitor_ids_when_configured", func(t *testing.T) {
+		t.Parallel()
+
+		updateReq := &client.UpdateMaintenanceWindowRequest{}
+		monitorIDs, expectedAutoAdd, shouldWait, diags := applyMaintenanceWindowMonitorIDsUpdate(
+			ctx,
+			maintenanceWindowResourceModel{
+				AutoAddMonitors: types.BoolNull(),
+				MonitorIDs:      setInt64(456, 123),
+			},
+			maintenanceWindowResourceModel{
+				MonitorIDs: setInt64(456, 123),
+			},
+			updateReq,
+		)
+
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags.Errors())
+		}
+		if !shouldWait {
+			t.Fatal("expected configured monitor_ids to require settle wait")
+		}
+		if !slices.Equal(monitorIDs, []int64{123, 456}) {
+			t.Fatalf("expected sorted monitor IDs, got=%v", monitorIDs)
+		}
+		if updateReq.MonitorIDs == nil || !slices.Equal(*updateReq.MonitorIDs, []int64{123, 456}) {
+			t.Fatalf("expected sorted monitorIds payload, got=%v", updateReq.MonitorIDs)
+		}
+		if updateReq.AutoAddMonitors == nil || *updateReq.AutoAddMonitors {
+			t.Fatalf("expected auto_add_monitors=false payload, got=%v", updateReq.AutoAddMonitors)
+		}
+		if expectedAutoAdd == nil || *expectedAutoAdd {
+			t.Fatalf("expected auto_add_monitors=false settle target, got=%v", expectedAutoAdd)
+		}
+	})
+
+	t.Run("preserves_explicit_empty_monitor_ids", func(t *testing.T) {
+		t.Parallel()
+
+		updateReq := &client.UpdateMaintenanceWindowRequest{}
+		monitorIDs, expectedAutoAdd, shouldWait, diags := applyMaintenanceWindowMonitorIDsUpdate(
+			ctx,
+			maintenanceWindowResourceModel{
+				AutoAddMonitors: types.BoolNull(),
+				MonitorIDs:      setInt64(),
+			},
+			maintenanceWindowResourceModel{
+				MonitorIDs: setInt64(),
+			},
+			updateReq,
+		)
+
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags.Errors())
+		}
+		if !shouldWait {
+			t.Fatal("expected configured monitor_ids to require settle wait")
+		}
+		if monitorIDs == nil || len(monitorIDs) != 0 {
+			t.Fatalf("expected non-nil empty monitor IDs, got=%#v", monitorIDs)
+		}
+		if updateReq.MonitorIDs == nil || len(*updateReq.MonitorIDs) != 0 {
+			t.Fatalf("expected empty monitorIds payload, got=%v", updateReq.MonitorIDs)
+		}
+		if updateReq.AutoAddMonitors == nil || *updateReq.AutoAddMonitors {
+			t.Fatalf("expected auto_add_monitors=false payload, got=%v", updateReq.AutoAddMonitors)
+		}
+		if expectedAutoAdd == nil || *expectedAutoAdd {
+			t.Fatalf("expected auto_add_monitors=false settle target, got=%v", expectedAutoAdd)
+		}
+	})
+}
+
 func setInt64(values ...int64) types.Set {
 	elements := make([]attr.Value, 0, len(values))
 	for _, value := range values {

--- a/internal/provider/maintenancewindow/resource_test.go
+++ b/internal/provider/maintenancewindow/resource_test.go
@@ -47,6 +47,25 @@ func TestEqualInt64Sets(t *testing.T) {
 	}
 }
 
+func TestNormalizeMonitorIDs(t *testing.T) {
+	t.Parallel()
+
+	in := []int64{3, 1, 3, 2}
+	got := normalizeMonitorIDs(in)
+	if !slices.Equal(got, []int64{1, 2, 3}) {
+		t.Fatalf("normalizeMonitorIDs mismatch: got=%v", got)
+	}
+
+	in[0] = 99
+	if !slices.Equal(got, []int64{1, 2, 3}) {
+		t.Fatalf("normalizeMonitorIDs should return a copy, got=%v", got)
+	}
+
+	if got := normalizeMonitorIDs(nil); got != nil {
+		t.Fatalf("normalizeMonitorIDs(nil) should be nil, got=%v", got)
+	}
+}
+
 func TestValidateRuleDaysRequiredForWeeklyMonthly(t *testing.T) {
 	t.Parallel()
 
@@ -156,6 +175,114 @@ func TestValidateRuleDaysNotAllowedForOnceDaily(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateRuleMonitorIDsAutoAddConflict(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tests := []struct {
+		name    string
+		cfg     maintenanceWindowResourceModel
+		wantErr bool
+	}{
+		{
+			name: "auto_marker_with_specific_ids_errors",
+			cfg: maintenanceWindowResourceModel{
+				AutoAddMonitors: types.BoolNull(),
+				MonitorIDs:      setInt64(0, 123),
+			},
+			wantErr: true,
+		},
+		{
+			name: "auto_add_true_with_specific_ids_errors",
+			cfg: maintenanceWindowResourceModel{
+				AutoAddMonitors: types.BoolValue(true),
+				MonitorIDs:      setInt64(123),
+			},
+			wantErr: true,
+		},
+		{
+			name: "auto_add_true_with_empty_monitor_ids_errors",
+			cfg: maintenanceWindowResourceModel{
+				AutoAddMonitors: types.BoolValue(true),
+				MonitorIDs:      setInt64(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "auto_add_false_with_auto_marker_errors",
+			cfg: maintenanceWindowResourceModel{
+				AutoAddMonitors: types.BoolValue(false),
+				MonitorIDs:      setInt64(0),
+			},
+			wantErr: true,
+		},
+		{
+			name: "auto_add_true_with_auto_marker_ok",
+			cfg: maintenanceWindowResourceModel{
+				AutoAddMonitors: types.BoolValue(true),
+				MonitorIDs:      setInt64(0),
+			},
+		},
+		{
+			name: "auto_add_omitted_with_auto_marker_ok",
+			cfg: maintenanceWindowResourceModel{
+				AutoAddMonitors: types.BoolNull(),
+				MonitorIDs:      setInt64(0),
+			},
+		},
+		{
+			name: "auto_add_false_with_empty_monitor_ids_ok",
+			cfg: maintenanceWindowResourceModel{
+				AutoAddMonitors: types.BoolValue(false),
+				MonitorIDs:      setInt64(),
+			},
+		},
+		{
+			name: "auto_add_omitted_with_specific_ids_ok",
+			cfg: maintenanceWindowResourceModel{
+				AutoAddMonitors: types.BoolNull(),
+				MonitorIDs:      setInt64(123, 456),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := &resource.ValidateConfigResponse{}
+			validateRuleMonitorIDsAutoAddConflict(ctx, tt.cfg, resp)
+			if resp.Diagnostics.HasError() != tt.wantErr {
+				t.Fatalf("unexpected error state: wantErr=%v diags=%v", tt.wantErr, resp.Diagnostics)
+			}
+		})
+	}
+}
+
+func TestMaintenanceWindowMonitorIDsFromSetEmptyReturnsEmptySlice(t *testing.T) {
+	t.Parallel()
+
+	monitorIDs, diags := maintenanceWindowMonitorIDsFromSet(context.Background(), setInt64())
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags.Errors())
+	}
+	if monitorIDs == nil {
+		t.Fatal("expected non-nil empty slice")
+	}
+	if len(monitorIDs) != 0 {
+		t.Fatalf("expected empty slice, got %#v", monitorIDs)
+	}
+}
+
+func setInt64(values ...int64) types.Set {
+	elements := make([]attr.Value, 0, len(values))
+	for _, value := range values {
+		elements = append(elements, types.Int64Value(value))
+	}
+	return types.SetValueMust(types.Int64Type, elements)
 }
 
 func TestShouldRetryCreateMaintenanceWindow(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `monitor_ids` to `uptimerobot_maintenance_window` and its data source
- support explicit monitor selection, clearing with `[]`, and `[0]` for auto-add/all monitors
- validate conflicting `[0]`/specific-ID and `auto_add_monitors` combinations
- document the new attribute and example usage

Fixes #245.

## Tests
- `go test ./internal/client ./internal/provider/maintenancewindow`
- `go test ./...` (rerun outside sandbox because `httptest` listeners cannot bind inside it)
- `go vet ./...`
- Manual Docker-backed Terraform flow against local api-internal: create `[1,2]`, no-op plan, update `[2]`, clear `[]`, auto-add `[0]`, transition back to `[1,2]`, reject invalid `[0,1]`, destroy, and verify DB cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `monitor_ids` attribute to maintenance windows, enabling explicit monitor assignment and a special `[0]` option to auto-add all monitors.
  * Implemented validation rules to prevent conflicting `monitor_ids` and `auto_add_monitors` configurations.
  * Added `monitor_ids` to the maintenance window data source (computed).
* **Documentation**
  * Updated maintenance window schema and examples to show `monitor_ids` usage.
* **Tests**
  * Expanded unit tests for request/response `monitor_ids` handling, normalization, validation, and settle-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->