### PR TITLE
Add alert contact active state management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Added `uptimerobot_alert_contact` resource for managing personal email and mobile app push alert contacts through API v3.
+- Added `is_active` support to `uptimerobot_alert_contact` for pausing and reactivating alert contacts.
 - Added `tag_ids` support to `uptimerobot_psp` for tag-based public status page monitor selection.
 - Added `monitor_ids` support to `uptimerobot_maintenance_window` for assigning maintenance windows to specific monitors.
 

--- a/docs/resources/alert_contact.md
+++ b/docs/resources/alert_contact.md
@@ -15,6 +15,7 @@ Manages a personal UptimeRobot alert contact. Email and mobile app push contacts
 - `mobile_app_old` corresponds to iOS push contacts and `mobile_app` corresponds to Android push contacts.
 - `pro_sms` and `voice` contacts can be discovered with alert-contact data sources, but they require dashboard phone verification and cannot be created through this resource.
 - Mobile push identity fields are required when creating mobile contacts. The public API does not return `one_signal_user_id` or `device_fingerprint` after creation, so imported mobile contacts leave those fields unset until configured.
+- Use `is_active = false` to pause an alert contact without deleting it.
 - Delay and repeat settings are monitor assignment settings. Configure them with `threshold` and `recurrence` inside `uptimerobot_monitor.assigned_alert_contacts`.
 
 ## Example Usage
@@ -28,6 +29,7 @@ resource "uptimerobot_alert_contact" "team_email" {
   value                   = var.team_alert_email
   notification_events     = "down"
   ssl_expiration_reminder = true
+  is_active               = true
 }
 
 variable "team_alert_email" {
@@ -143,6 +145,7 @@ terraform import uptimerobot_alert_contact.team_email 123456
 - `android_push_down_channel` (String) Android push channel used for down notifications. Only valid for `mobile_app` contacts.
 - `android_push_up_channel` (String) Android push channel used for up notifications. Only valid for `mobile_app` contacts.
 - `device_fingerprint` (String, Sensitive) Device fingerprint. Required when creating `mobile_app_old` or `mobile_app` contacts. The public API does not return this value after creation, so imported resources leave it unset.
+- `is_active` (Boolean) Whether the alert contact is active. Set to `false` to pause notifications for this contact without deleting it.
 - `notification_events` (String) Notification event setting: `up_and_down`, `down`, `up`, or `none`.
 - `one_signal_subscription_id` (String, Sensitive) OneSignal subscription ID. Required when creating `mobile_app_old` or `mobile_app` contacts.
 - `one_signal_user_id` (String, Sensitive) OneSignal user ID. Required when creating `mobile_app_old` or `mobile_app` contacts. The public API does not return this value after creation, so imported resources leave it unset.

--- a/examples/resources/uptimerobot_alert_contact/email.tf
+++ b/examples/resources/uptimerobot_alert_contact/email.tf
@@ -4,6 +4,7 @@ resource "uptimerobot_alert_contact" "team_email" {
   value                   = var.team_alert_email
   notification_events     = "down"
   ssl_expiration_reminder = true
+  is_active               = true
 }
 
 variable "team_alert_email" {

--- a/internal/provider/alertcontact/resource.go
+++ b/internal/provider/alertcontact/resource.go
@@ -125,9 +125,6 @@ func (r *alertContactResource) Schema(_ context.Context, _ resource.SchemaReques
 			"status": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The normalized alert contact status.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"mobile_provider_id": schema.Int64Attribute{
 				Computed:            true,
@@ -218,7 +215,7 @@ func (r *alertContactResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	updateReq := buildUpdateAlertContactRequest(plan)
+	updateReq := buildUpdateAlertContactRequest(plan, plan)
 	contact, err = r.client.UpdateAlertContact(ctx, contact.ID, updateReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating alert contact after create", "The alert contact was created but common settings could not be applied: "+err.Error())
@@ -261,8 +258,12 @@ func (r *alertContactResource) Read(ctx context.Context, req resource.ReadReques
 }
 
 func (r *alertContactResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan alertContactResourceModel
+	var plan, config alertContactResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -277,7 +278,7 @@ func (r *alertContactResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	contact, err := r.client.UpdateAlertContact(ctx, id, buildUpdateAlertContactRequest(plan))
+	contact, err := r.client.UpdateAlertContact(ctx, id, buildUpdateAlertContactRequest(plan, config))
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating alert contact", "Could not update alert contact, unexpected error: "+err.Error())
 		return
@@ -385,7 +386,7 @@ func buildCreateAlertContactRequest(plan alertContactResourceModel) *client.Crea
 	return req
 }
 
-func buildUpdateAlertContactRequest(plan alertContactResourceModel) *client.UpdateAlertContactRequest {
+func buildUpdateAlertContactRequest(plan alertContactResourceModel, config alertContactResourceModel) *client.UpdateAlertContactRequest {
 	name := valueString(plan.Name)
 	events := alertContactNotificationEventsToAPI(valueString(plan.NotificationEvents))
 	ssl := plan.SSLExpirationReminder.ValueBool()
@@ -394,8 +395,8 @@ func buildUpdateAlertContactRequest(plan alertContactResourceModel) *client.Upda
 		EnableNotificationsFor: &events,
 		SSLExpirationReminder:  &ssl,
 	}
-	if !plan.IsActive.IsNull() && !plan.IsActive.IsUnknown() {
-		isActive := plan.IsActive.ValueBool()
+	if !config.IsActive.IsNull() && !config.IsActive.IsUnknown() {
+		isActive := config.IsActive.ValueBool()
 		req.IsActive = &isActive
 	}
 	return req

--- a/internal/provider/alertcontact/resource.go
+++ b/internal/provider/alertcontact/resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -43,6 +44,7 @@ type alertContactResourceModel struct {
 	Value                   types.String `tfsdk:"value"`
 	NotificationEvents      types.String `tfsdk:"notification_events"`
 	SSLExpirationReminder   types.Bool   `tfsdk:"ssl_expiration_reminder"`
+	IsActive                types.Bool   `tfsdk:"is_active"`
 	Status                  types.String `tfsdk:"status"`
 	MobileProviderID        types.Int64  `tfsdk:"mobile_provider_id"`
 	OrgAlertContactID       types.Int64  `tfsdk:"org_alert_contact_id"`
@@ -111,6 +113,14 @@ func (r *alertContactResource) Schema(_ context.Context, _ resource.SchemaReques
 				Computed:            true,
 				MarkdownDescription: "Whether SSL expiration reminders are enabled for this alert contact.",
 				Default:             booldefault.StaticBool(false),
+			},
+			"is_active": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Whether the alert contact is active. Set to `false` to pause notifications for this contact without deleting it.",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"status": schema.StringAttribute{
 				Computed:            true,
@@ -379,10 +389,29 @@ func buildUpdateAlertContactRequest(plan alertContactResourceModel) *client.Upda
 	name := valueString(plan.Name)
 	events := alertContactNotificationEventsToAPI(valueString(plan.NotificationEvents))
 	ssl := plan.SSLExpirationReminder.ValueBool()
-	return &client.UpdateAlertContactRequest{
+	req := &client.UpdateAlertContactRequest{
 		FriendlyName:           &name,
 		EnableNotificationsFor: &events,
 		SSLExpirationReminder:  &ssl,
+	}
+	if !plan.IsActive.IsNull() && !plan.IsActive.IsUnknown() {
+		isActive := plan.IsActive.ValueBool()
+		req.IsActive = &isActive
+	}
+	return req
+}
+
+func alertContactIsActiveState(status string, prev types.Bool) types.Bool {
+	switch normalizeAlertContactStatus(status) {
+	case "active":
+		return types.BoolValue(true)
+	case "paused", "not_activated", "to_migrate":
+		return types.BoolValue(false)
+	default:
+		if !prev.IsNull() && !prev.IsUnknown() {
+			return prev
+		}
+		return types.BoolNull()
 	}
 }
 
@@ -394,6 +423,7 @@ func alertContactResourceState(contact client.UserAlertContact, prev alertContac
 		Type:                    types.StringValue(alertType),
 		NotificationEvents:      notificationEventsState(contact.EnableNotificationsFor, prev.NotificationEvents),
 		SSLExpirationReminder:   types.BoolValue(contact.SSLExpirationReminder),
+		IsActive:                alertContactIsActiveState(contact.Status, prev.IsActive),
 		Status:                  stringState(normalizeAlertContactStatus(contact.Status)),
 		MobileProviderID:        int64PtrState(contact.MobileProviderID),
 		OrgAlertContactID:       int64PtrState(contact.OrgAlertContactID),

--- a/internal/provider/alertcontact/resource_test.go
+++ b/internal/provider/alertcontact/resource_test.go
@@ -37,6 +37,7 @@ func TestAlertContactResource_Schema(t *testing.T) {
 		"value",
 		"notification_events",
 		"ssl_expiration_reminder",
+		"is_active",
 		"status",
 		"mobile_provider_id",
 		"org_alert_contact_id",
@@ -130,6 +131,39 @@ func TestBuildCreateAlertContactRequestMobileOld(t *testing.T) {
 	}
 }
 
+func TestBuildUpdateAlertContactRequestIsActive(t *testing.T) {
+	t.Parallel()
+
+	base := alertContactResourceModel{
+		Name:                  types.StringValue("Work email"),
+		NotificationEvents:    types.StringValue("down"),
+		SSLExpirationReminder: types.BoolValue(true),
+	}
+
+	inactivePlan := base
+	inactivePlan.IsActive = types.BoolValue(false)
+	inactiveReq := buildUpdateAlertContactRequest(inactivePlan)
+	if inactiveReq.IsActive == nil || *inactiveReq.IsActive {
+		t.Fatalf("expected inactive update request, got %#v", inactiveReq.IsActive)
+	}
+
+	activePlan := base
+	activePlan.IsActive = types.BoolValue(true)
+	activeReq := buildUpdateAlertContactRequest(activePlan)
+	if activeReq.IsActive == nil || !*activeReq.IsActive {
+		t.Fatalf("expected active update request, got %#v", activeReq.IsActive)
+	}
+
+	for _, isActive := range []types.Bool{types.BoolNull(), types.BoolUnknown()} {
+		plan := base
+		plan.IsActive = isActive
+		req := buildUpdateAlertContactRequest(plan)
+		if req.IsActive != nil {
+			t.Fatalf("expected omitted active state for %#v, got %#v", isActive, req.IsActive)
+		}
+	}
+}
+
 func TestValidateAlertContactResourceCreate(t *testing.T) {
 	t.Parallel()
 
@@ -204,6 +238,45 @@ func TestAlertContactResourceStateMobilePreservesHiddenIdentity(t *testing.T) {
 	}
 	if state.AndroidPushDownChannel.ValueString() != "down" {
 		t.Fatalf("unexpected down channel %q", state.AndroidPushDownChannel.ValueString())
+	}
+	if !state.IsActive.ValueBool() {
+		t.Fatalf("expected active contact state, got %#v", state.IsActive)
+	}
+}
+
+func TestAlertContactIsActiveState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		status   string
+		prev     types.Bool
+		want     bool
+		wantNull bool
+	}{
+		{name: "active", status: "Active", want: true},
+		{name: "paused", status: "Paused", want: false},
+		{name: "not activated", status: "NotActivated", want: false},
+		{name: "to migrate", status: "ToMigrate", want: false},
+		{name: "unknown preserves previous", status: "Unexpected", prev: types.BoolValue(true), want: true},
+		{name: "unknown without previous", status: "Unexpected", wantNull: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := alertContactIsActiveState(tt.status, tt.prev)
+			if tt.wantNull {
+				if !got.IsNull() {
+					t.Fatalf("expected null active state, got %#v", got)
+				}
+				return
+			}
+			if got.IsNull() || got.IsUnknown() || got.ValueBool() != tt.want {
+				t.Fatalf("expected active state %v, got %#v", tt.want, got)
+			}
+		})
 	}
 }
 

--- a/internal/provider/alertcontact/resource_test.go
+++ b/internal/provider/alertcontact/resource_test.go
@@ -141,23 +141,29 @@ func TestBuildUpdateAlertContactRequestIsActive(t *testing.T) {
 	}
 
 	inactivePlan := base
+	inactiveConfig := base
 	inactivePlan.IsActive = types.BoolValue(false)
-	inactiveReq := buildUpdateAlertContactRequest(inactivePlan)
+	inactiveConfig.IsActive = types.BoolValue(false)
+	inactiveReq := buildUpdateAlertContactRequest(inactivePlan, inactiveConfig)
 	if inactiveReq.IsActive == nil || *inactiveReq.IsActive {
 		t.Fatalf("expected inactive update request, got %#v", inactiveReq.IsActive)
 	}
 
 	activePlan := base
+	activeConfig := base
 	activePlan.IsActive = types.BoolValue(true)
-	activeReq := buildUpdateAlertContactRequest(activePlan)
+	activeConfig.IsActive = types.BoolValue(true)
+	activeReq := buildUpdateAlertContactRequest(activePlan, activeConfig)
 	if activeReq.IsActive == nil || !*activeReq.IsActive {
 		t.Fatalf("expected active update request, got %#v", activeReq.IsActive)
 	}
 
 	for _, isActive := range []types.Bool{types.BoolNull(), types.BoolUnknown()} {
 		plan := base
-		plan.IsActive = isActive
-		req := buildUpdateAlertContactRequest(plan)
+		config := base
+		plan.IsActive = types.BoolValue(true)
+		config.IsActive = isActive
+		req := buildUpdateAlertContactRequest(plan, config)
 		if req.IsActive != nil {
 			t.Fatalf("expected omitted active state for %#v, got %#v", isActive, req.IsActive)
 		}

--- a/templates/resources/alert_contact.md.tmpl
+++ b/templates/resources/alert_contact.md.tmpl
@@ -15,6 +15,7 @@ description: |-
 - `mobile_app_old` corresponds to iOS push contacts and `mobile_app` corresponds to Android push contacts.
 - `pro_sms` and `voice` contacts can be discovered with alert-contact data sources, but they require dashboard phone verification and cannot be created through this resource.
 - Mobile push identity fields are required when creating mobile contacts. The public API does not return `one_signal_user_id` or `device_fingerprint` after creation, so imported mobile contacts leave those fields unset until configured.
+- Use `is_active = false` to pause an alert contact without deleting it.
 - Delay and repeat settings are monitor assignment settings. Configure them with `threshold` and `recurrence` inside `uptimerobot_monitor.assigned_alert_contacts`.
 
 ## Example Usage


### PR DESCRIPTION
Summary:
- Add is_active to uptimerobot_alert_contact for pausing and reactivating alert contacts.
- Derive is_active from API status on read and send isActive only when Terraform has a concrete bool.
- Update generated docs, example, changelog, and unit coverage.

Tests:
- go generate ./...
- go test ./internal/provider/alertcontact ./internal/client
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `is_active` attribute to alert contacts, enabling users to pause and reactivate alerts without deletion.

* **Documentation**
  * Updated documentation and examples to reflect the new `is_active` functionality for managing alert contact status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->