### PR TITLE
Add PSP auto_add_monitors support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added `uptimerobot_alert_contact` resource for managing personal email and mobile app push alert contacts through API v3.
 - Added `is_active` support to `uptimerobot_alert_contact` for pausing and reactivating alert contacts.
 - Added `tag_ids` support to `uptimerobot_psp` for tag-based public status page monitor selection.
+- Added `auto_add_monitors` support to `uptimerobot_psp` for automatically including all current and future monitors.
 - Added `monitor_ids` support to `uptimerobot_maintenance_window` for assigning maintenance windows to specific monitors.
 
 ## 1.8.1 — 2026-06-16

--- a/docs/data-sources/psp.md
+++ b/docs/data-sources/psp.md
@@ -44,6 +44,7 @@ output "status_page_url_key" {
 
 ### Read-Only
 
+- `auto_add_monitors` (Boolean) Whether the PSP automatically includes all current and future monitors.
 - `custom_domain` (String) Custom domain configured for the PSP, or null when no custom domain is set.
 - `custom_settings` (Attributes) Custom settings for the PSP. (see [below for nested schema](#nestedatt--custom_settings))
 - `ga_code` (String) Google Analytics code configured for the PSP, or null when unset.

--- a/docs/resources/psp.md
+++ b/docs/resources/psp.md
@@ -83,6 +83,16 @@ resource "uptimerobot_psp" "production_status" {
 }
 ```
 
+### Status Page with Automatic Monitor Selection
+
+```terraform
+resource "uptimerobot_psp" "all_monitors" {
+  name              = "All Services Status"
+  auto_add_monitors = true
+  monitor_sort      = "status_down_up_paused"
+}
+```
+
 ### Password Protected Status Page
 
 ```terraform
@@ -192,6 +202,8 @@ You can include specific monitors in your status page by providing their IDs in 
 
 You can also include monitors by tag with `tag_ids`. The UptimeRobot API resolves matching monitors server-side, and `tag_ids` are additive with `monitor_ids`.
 
+Set `auto_add_monitors = true` to automatically include all current and future monitors in the public status page. This uses the UptimeRobot API auto-add mode and should not be combined with explicit `monitor_ids`. Existing configurations that use `monitor_ids = [0]` for the API sentinel continue to work, but `auto_add_monitors` is preferred for new Terraform configuration.
+
 Use `monitor_sort` to control how monitors are ordered on the public status page. Supported values are:
 - `friendly_name_asc`
 - `friendly_name_desc`
@@ -223,6 +235,7 @@ terraform import uptimerobot_psp.example 123456
 
 ### Optional
 
+- `auto_add_monitors` (Boolean) Whether the PSP automatically includes all current and future monitors. When set to `true`, the provider sends the UptimeRobot API auto-add sentinel and `monitor_ids` must not contain explicit monitor IDs.
 - `custom_domain` (String) Custom domain for the PSP
 - `custom_settings` (Attributes) Custom settings for the PSP (see [below for nested schema](#nestedatt--custom_settings))
 - `ga_code` (String) Google Analytics code
@@ -238,7 +251,7 @@ Set to an empty string (`""`) to clear the existing icon.
 This field accepts only local filesystem paths. If you need a remote file, download it first (for example in CI) and then pass the downloaded file path.
 
 Set to an empty string (`""`) to clear the existing logo.
-- `monitor_ids` (Set of Number) Set of monitor IDs
+- `monitor_ids` (Set of Number) Set of monitor IDs assigned to the PSP. Use `auto_add_monitors = true` to automatically include all current and future monitors. `monitor_ids = [0]` remains supported as the UptimeRobot API auto-add sentinel for backward compatibility.
 - `monitor_sort` (String) Sort order for monitors displayed on the PSP. Supported values are `friendly_name_asc`, `friendly_name_desc`, `status_up_down_paused`, and `status_down_up_paused`.
 - `no_index` (Boolean) Whether to prevent indexing
 - `password` (String, Sensitive) Password for accessing the PSP page.

--- a/examples/resources/uptimerobot_psp/auto_add_monitors.tf
+++ b/examples/resources/uptimerobot_psp/auto_add_monitors.tf
@@ -1,0 +1,5 @@
+resource "uptimerobot_psp" "all_monitors" {
+  name              = "All Services Status"
+  auto_add_monitors = true
+  monitor_sort      = "status_down_up_paused"
+}

--- a/internal/provider/psp/auto_add_monitors_test.go
+++ b/internal/provider/psp/auto_add_monitors_test.go
@@ -1,0 +1,192 @@
+package psp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestResolvePSPMonitorSelectionAutoAddTrue(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	selection, diags := resolvePSPMonitorSelection(ctx, pspResourceModel{
+		AutoAddMonitors: types.BoolValue(true),
+		MonitorIDs:      types.SetUnknown(types.Int64Type),
+	}, pspResourceModel{
+		AutoAddMonitors: types.BoolValue(true),
+		MonitorIDs:      types.SetNull(types.Int64Type),
+	})
+
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !selection.hasPlan {
+		t.Fatal("expected monitor selection to be planned")
+	}
+	if selection.configuredMonitorIDs {
+		t.Fatal("did not expect monitor_ids to be treated as configured")
+	}
+	if !isPSPAutoAddMonitorIDs(selection.monitorIDs) {
+		t.Fatalf("monitorIDs = %#v, want auto-add sentinel", selection.monitorIDs)
+	}
+}
+
+func TestResolvePSPMonitorSelectionAutoAddTrueOverridesPriorMonitorIDs(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	selection, diags := resolvePSPMonitorSelection(ctx, pspResourceModel{
+		AutoAddMonitors: types.BoolValue(true),
+		MonitorIDs:      pspInt64SetValue(ctx, []int64{11, 22}),
+	}, pspResourceModel{
+		AutoAddMonitors: types.BoolValue(true),
+		MonitorIDs:      types.SetNull(types.Int64Type),
+	})
+
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !selection.hasPlan {
+		t.Fatal("expected monitor selection to be planned")
+	}
+	if selection.configuredMonitorIDs {
+		t.Fatal("did not expect monitor_ids to be treated as configured")
+	}
+	if !isPSPAutoAddMonitorIDs(selection.monitorIDs) {
+		t.Fatalf("monitorIDs = %#v, want auto-add sentinel", selection.monitorIDs)
+	}
+}
+
+func TestResolvePSPMonitorSelectionAutoAddFalseClearsSentinel(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	selection, diags := resolvePSPMonitorSelection(ctx, pspResourceModel{
+		AutoAddMonitors: types.BoolValue(false),
+		MonitorIDs:      pspInt64SetValue(ctx, []int64{pspAutoAddMonitorID}),
+	}, pspResourceModel{
+		AutoAddMonitors: types.BoolValue(false),
+		MonitorIDs:      types.SetNull(types.Int64Type),
+	})
+
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !selection.hasPlan {
+		t.Fatal("expected monitor selection to be planned")
+	}
+	if len(selection.monitorIDs) != 0 {
+		t.Fatalf("monitorIDs = %#v, want empty set to disable auto-add", selection.monitorIDs)
+	}
+}
+
+func TestResolvePSPMonitorSelectionAutoAddFalsePreservesExplicitMonitors(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	selection, diags := resolvePSPMonitorSelection(ctx, pspResourceModel{
+		AutoAddMonitors: types.BoolValue(false),
+		MonitorIDs:      pspInt64SetValue(ctx, []int64{11, 22}),
+	}, pspResourceModel{
+		AutoAddMonitors: types.BoolValue(false),
+		MonitorIDs:      types.SetNull(types.Int64Type),
+	})
+
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !selection.hasPlan {
+		t.Fatal("expected monitor selection to be planned")
+	}
+	if len(selection.monitorIDs) != 2 || selection.monitorIDs[0] != 11 || selection.monitorIDs[1] != 22 {
+		t.Fatalf("monitorIDs = %#v, want explicit monitors", selection.monitorIDs)
+	}
+}
+
+func TestResolvePSPMonitorSelectionSentinelMonitorIDs(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	selection, diags := resolvePSPMonitorSelection(ctx, pspResourceModel{
+		AutoAddMonitors: types.BoolNull(),
+		MonitorIDs:      pspInt64SetValue(ctx, []int64{pspAutoAddMonitorID}),
+	}, pspResourceModel{
+		AutoAddMonitors: types.BoolNull(),
+		MonitorIDs:      pspInt64SetValue(ctx, []int64{pspAutoAddMonitorID}),
+	})
+
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !selection.hasPlan || !selection.configuredMonitorIDs {
+		t.Fatalf("unexpected selection flags: %#v", selection)
+	}
+	if !isPSPAutoAddMonitorIDs(selection.monitorIDs) {
+		t.Fatalf("monitorIDs = %#v, want auto-add sentinel", selection.monitorIDs)
+	}
+}
+
+func TestResolvePSPMonitorSelectionRejectsConflicts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		plan   pspResourceModel
+		config pspResourceModel
+		want   string
+	}{
+		{
+			name: "auto add true with explicit monitors",
+			plan: pspResourceModel{
+				AutoAddMonitors: types.BoolValue(true),
+				MonitorIDs:      pspInt64SetValue(context.Background(), []int64{11}),
+			},
+			config: pspResourceModel{
+				AutoAddMonitors: types.BoolValue(true),
+				MonitorIDs:      pspInt64SetValue(context.Background(), []int64{11}),
+			},
+			want: "cannot be combined with explicit `monitor_ids`",
+		},
+		{
+			name: "auto add false with sentinel",
+			plan: pspResourceModel{
+				AutoAddMonitors: types.BoolValue(false),
+				MonitorIDs:      pspInt64SetValue(context.Background(), []int64{pspAutoAddMonitorID}),
+			},
+			config: pspResourceModel{
+				AutoAddMonitors: types.BoolValue(false),
+				MonitorIDs:      pspInt64SetValue(context.Background(), []int64{pspAutoAddMonitorID}),
+			},
+			want: "cannot be combined with `monitor_ids = [0]`",
+		},
+		{
+			name: "sentinel mixed with explicit monitors",
+			plan: pspResourceModel{
+				AutoAddMonitors: types.BoolNull(),
+				MonitorIDs:      pspInt64SetValue(context.Background(), []int64{pspAutoAddMonitorID, 11}),
+			},
+			config: pspResourceModel{
+				AutoAddMonitors: types.BoolNull(),
+				MonitorIDs:      pspInt64SetValue(context.Background(), []int64{pspAutoAddMonitorID, 11}),
+			},
+			want: "can use the UptimeRobot auto-add sentinel `0` only by itself",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, diags := resolvePSPMonitorSelection(context.Background(), tt.plan, tt.config)
+			if !diags.HasError() {
+				t.Fatal("expected diagnostics, got none")
+			}
+			if !strings.Contains(diags.Errors()[0].Detail(), tt.want) {
+				t.Fatalf("diagnostic detail = %q, want to contain %q", diags.Errors()[0].Detail(), tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/psp/auto_add_monitors_test.go
+++ b/internal/provider/psp/auto_add_monitors_test.go
@@ -2,6 +2,7 @@ package psp
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 
@@ -101,7 +102,7 @@ func TestResolvePSPMonitorSelectionAutoAddFalsePreservesExplicitMonitors(t *test
 	if !selection.hasPlan {
 		t.Fatal("expected monitor selection to be planned")
 	}
-	if len(selection.monitorIDs) != 2 || selection.monitorIDs[0] != 11 || selection.monitorIDs[1] != 22 {
+	if len(selection.monitorIDs) != 2 || !slices.Contains(selection.monitorIDs, 11) || !slices.Contains(selection.monitorIDs, 22) {
 		t.Fatalf("monitorIDs = %#v, want explicit monitors", selection.monitorIDs)
 	}
 }

--- a/internal/provider/psp/data_source.go
+++ b/internal/provider/psp/data_source.go
@@ -37,6 +37,7 @@ type pspDataSourceModel struct {
 	Name                       types.String         `tfsdk:"name"`
 	CustomDomain               types.String         `tfsdk:"custom_domain"`
 	IsPasswordSet              types.Bool           `tfsdk:"is_password_set"`
+	AutoAddMonitors            types.Bool           `tfsdk:"auto_add_monitors"`
 	MonitorIDs                 types.Set            `tfsdk:"monitor_ids"`
 	TagIDs                     types.Set            `tfsdk:"tag_ids"`
 	MonitorSort                types.String         `tfsdk:"monitor_sort"`
@@ -95,6 +96,10 @@ func (d *pspDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, re
 			"is_password_set": datasourceschema.BoolAttribute{
 				Computed:            true,
 				MarkdownDescription: "Whether a password is set for the PSP. The password value itself is not returned by the UptimeRobot API.",
+			},
+			"auto_add_monitors": datasourceschema.BoolAttribute{
+				Computed:            true,
+				MarkdownDescription: "Whether the PSP automatically includes all current and future monitors.",
 			},
 			"monitor_ids": datasourceschema.SetAttribute{
 				Computed:            true,
@@ -404,6 +409,7 @@ func pspDataSourceState(ctx context.Context, statusPage *client.PSP) (pspDataSou
 		Name:                       resourceState.Name,
 		CustomDomain:               resourceState.CustomDomain,
 		IsPasswordSet:              resourceState.IsPasswordSet,
+		AutoAddMonitors:            resourceState.AutoAddMonitors,
 		MonitorIDs:                 monitorIDs,
 		TagIDs:                     tagIDs,
 		MonitorSort:                resourceState.MonitorSort,

--- a/internal/provider/psp/data_source_test.go
+++ b/internal/provider/psp/data_source_test.go
@@ -120,6 +120,9 @@ func TestPSPDataSourceStateMapsFields(t *testing.T) {
 	if !state.IsPasswordSet.ValueBool() {
 		t.Fatal("expected is_password_set to be true")
 	}
+	if state.AutoAddMonitors.IsNull() {
+		t.Fatal("expected auto_add_monitors to be non-null")
+	}
 	if state.AutoAddMonitors.ValueBool() {
 		t.Fatal("expected auto_add_monitors to be false")
 	}

--- a/internal/provider/psp/data_source_test.go
+++ b/internal/provider/psp/data_source_test.go
@@ -120,6 +120,9 @@ func TestPSPDataSourceStateMapsFields(t *testing.T) {
 	if !state.IsPasswordSet.ValueBool() {
 		t.Fatal("expected is_password_set to be true")
 	}
+	if state.AutoAddMonitors.ValueBool() {
+		t.Fatal("expected auto_add_monitors to be false")
+	}
 	if state.MonitorSort.ValueString() != "friendly_name_asc" {
 		t.Fatalf("unexpected monitor_sort %q", state.MonitorSort.ValueString())
 	}
@@ -154,5 +157,25 @@ func TestPSPDataSourceStateMapsFields(t *testing.T) {
 	}
 	if state.CustomSettings.Features == nil || !state.CustomSettings.Features.ShowBars.ValueBool() {
 		t.Fatalf("expected show_bars in custom settings, got %#v", state.CustomSettings)
+	}
+}
+
+func TestPSPDataSourceStateMapsAutoAddMonitors(t *testing.T) {
+	t.Parallel()
+
+	state, diags := pspDataSourceState(context.Background(), &client.PSP{
+		ID:                         101,
+		Name:                       "Production Status",
+		MonitorIDs:                 []int64{pspAutoAddMonitorID},
+		Status:                     "ENABLED",
+		URLKey:                     "abc123",
+		ShareAnalyticsConsent:      true,
+		UseSmallCookieConsentModal: true,
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !state.AutoAddMonitors.ValueBool() {
+		t.Fatal("expected auto_add_monitors to be true")
 	}
 }

--- a/internal/provider/psp/monitor_sort_test.go
+++ b/internal/provider/psp/monitor_sort_test.go
@@ -104,6 +104,41 @@ func TestPSPToResourceDataTagIDs(t *testing.T) {
 	}
 }
 
+func TestPSPToResourceDataAutoAddMonitors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		monitorIDs []int64
+		want       bool
+	}{
+		{name: "sentinel", monitorIDs: []int64{pspAutoAddMonitorID}, want: true},
+		{name: "explicit monitors", monitorIDs: []int64{11, 22}, want: false},
+		{name: "empty", monitorIDs: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			model := pspResourceModel{}
+			pspToResourceData(context.Background(), &client.PSP{
+				ID:                         123,
+				Name:                       "psp",
+				Status:                     "ENABLED",
+				URLKey:                     "abc123",
+				ShareAnalyticsConsent:      true,
+				UseSmallCookieConsentModal: false,
+				MonitorIDs:                 tt.monitorIDs,
+			}, &model)
+
+			if model.AutoAddMonitors.IsNull() || model.AutoAddMonitors.ValueBool() != tt.want {
+				t.Fatalf("auto_add_monitors = %#v, want %t", model.AutoAddMonitors, tt.want)
+			}
+		})
+	}
+}
+
 func TestPSPMonitorSortPtrMatchesTreatsMissingAPIAsUnverified(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/psp/resource.go
+++ b/internal/provider/psp/resource.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -49,6 +50,7 @@ type pspResourceModel struct {
 	CustomDomain               types.String         `tfsdk:"custom_domain"`
 	Password                   types.String         `tfsdk:"password"`
 	IsPasswordSet              types.Bool           `tfsdk:"is_password_set"`
+	AutoAddMonitors            types.Bool           `tfsdk:"auto_add_monitors"`
 	MonitorIDs                 types.Set            `tfsdk:"monitor_ids"`
 	TagIDs                     types.Set            `tfsdk:"tag_ids"`
 	MonitorSort                types.String         `tfsdk:"monitor_sort"`
@@ -67,6 +69,14 @@ type pspResourceModel struct {
 	ShowCookieBar              types.Bool           `tfsdk:"show_cookie_bar"`
 	PinnedAnnouncementID       types.Int64          `tfsdk:"pinned_announcement_id"`
 	CustomSettings             *customSettingsModel `tfsdk:"custom_settings"`
+}
+
+const pspAutoAddMonitorID int64 = 0
+
+type pspMonitorSelection struct {
+	hasPlan              bool
+	configuredMonitorIDs bool
+	monitorIDs           []int64
 }
 
 type customSettingsModel struct {
@@ -572,9 +582,16 @@ func (r *pspResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				Description: "Whether a password is set for the PSP",
 				Computed:    true,
 			},
+			"auto_add_monitors": schema.BoolAttribute{
+				MarkdownDescription: "Whether the PSP automatically includes all current and future monitors. " +
+					"When set to `true`, the provider sends the UptimeRobot API auto-add sentinel and `monitor_ids` must not contain explicit monitor IDs.",
+				Optional: true,
+				Computed: true,
+			},
 			"monitor_ids": schema.SetAttribute{
-				Description: "Set of monitor IDs",
-				Optional:    true,
+				MarkdownDescription: "Set of monitor IDs assigned to the PSP. Use `auto_add_monitors = true` to automatically include all current and future monitors. " +
+					"`monitor_ids = [0]` remains supported as the UptimeRobot API auto-add sentinel for backward compatibility.",
+				Optional: true,
 				// Optional+Computed allows monitor IDs to be managed when configured,
 				// and observed from the API (including on import) when omitted.
 				Computed:    true,
@@ -902,22 +919,26 @@ func (r *pspResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 
 func (r *pspResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	// Retrieve values from plan
-	var plan pspResourceModel
+	var plan, config pspResourceModel
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	hasMonitorPlan := !plan.MonitorIDs.IsNull() && !plan.MonitorIDs.IsUnknown()
-	var requestedMonitorIDs []int64
-	if hasMonitorPlan {
-		diags := plan.MonitorIDs.ElementsAs(ctx, &requestedMonitorIDs, false)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
+
+	monitorSelection, diags := resolvePSPMonitorSelection(ctx, plan, config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	hasMonitorPlan := monitorSelection.hasPlan
+	requestedMonitorIDs := monitorSelection.monitorIDs
+
 	hasTagPlan := !plan.TagIDs.IsNull() && !plan.TagIDs.IsUnknown()
 	var requestedTagIDs []int64
 	if hasTagPlan {
@@ -1250,7 +1271,11 @@ func (r *pspResource) Create(ctx context.Context, req resource.CreateRequest, re
 	updatedPlan.Name = plan.Name
 
 	if hasMonitorPlan {
-		updatedPlan.MonitorIDs = plan.MonitorIDs
+		if monitorSelection.configuredMonitorIDs {
+			updatedPlan.MonitorIDs = plan.MonitorIDs
+		} else {
+			updatedPlan.MonitorIDs = pspInt64SetValue(ctx, requestedMonitorIDs)
+		}
 	} else {
 		if len(pspForState.MonitorIDs) > 0 {
 			setVal, d := types.SetValueFrom(ctx, types.Int64Type, pspForState.MonitorIDs)
@@ -1262,6 +1287,10 @@ func (r *pspResource) Create(ctx context.Context, req resource.CreateRequest, re
 		} else {
 			updatedPlan.MonitorIDs = types.SetValueMust(types.Int64Type, []attr.Value{})
 		}
+	}
+	resp.Diagnostics.Append(syncPSPAutoAddMonitorsFromMonitorIDs(ctx, &updatedPlan)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 	if hasTagPlan {
 		updatedPlan.TagIDs = plan.TagIDs
@@ -1431,6 +1460,10 @@ func (r *pspResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		// regular read and API returned nothing preserve prior state to avoid drift
 		updatedState.MonitorIDs = state.MonitorIDs
 	}
+	resp.Diagnostics.Append(syncPSPAutoAddMonitorsFromMonitorIDs(ctx, &updatedState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	if !managedColors && updatedState.CustomSettings != nil {
 		updatedState.CustomSettings.Colors = nil
@@ -1462,7 +1495,7 @@ func (r *pspResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 
 func (r *pspResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	// Retrieve values from plan and state
-	var plan, state pspResourceModel
+	var plan, state, config pspResourceModel
 	if diags := req.Plan.Get(ctx, &plan); diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -1471,16 +1504,19 @@ func (r *pspResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		resp.Diagnostics.Append(diags...)
 		return
 	}
-
-	hasMonitorPlan := !plan.MonitorIDs.IsNull() && !plan.MonitorIDs.IsUnknown()
-	var requestedMonitorIDs []int64
-	if hasMonitorPlan {
-		diags := plan.MonitorIDs.ElementsAs(ctx, &requestedMonitorIDs, false)
+	if diags := req.Config.Get(ctx, &config); diags.HasError() {
 		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
+		return
 	}
+
+	monitorSelection, diags := resolvePSPMonitorSelection(ctx, plan, config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	hasMonitorPlan := monitorSelection.hasPlan
+	requestedMonitorIDs := monitorSelection.monitorIDs
+
 	hasTagPlan := !plan.TagIDs.IsNull() && !plan.TagIDs.IsUnknown()
 	var requestedTagIDs []int64
 	if hasTagPlan {
@@ -1795,9 +1831,17 @@ func (r *pspResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	}
 
 	if hasMonitorPlan {
-		newState.MonitorIDs = plan.MonitorIDs
+		if monitorSelection.configuredMonitorIDs {
+			newState.MonitorIDs = plan.MonitorIDs
+		} else {
+			newState.MonitorIDs = pspInt64SetValue(ctx, requestedMonitorIDs)
+		}
 	} else {
 		newState.MonitorIDs = state.MonitorIDs
+	}
+	resp.Diagnostics.Append(syncPSPAutoAddMonitorsFromMonitorIDs(ctx, &newState)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 	if hasTagPlan {
 		newState.TagIDs = plan.TagIDs
@@ -1967,6 +2011,145 @@ func pspInt64SetValue(_ context.Context, ids []int64) types.Set {
 	return types.SetValueMust(types.Int64Type, values)
 }
 
+func pspInt64SetElements(ctx context.Context, set types.Set) ([]int64, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if set.IsNull() || set.IsUnknown() {
+		return nil, diags
+	}
+
+	var ids []int64
+	diags.Append(set.ElementsAs(ctx, &ids, false)...)
+	return ids, diags
+}
+
+func isPSPAutoAddMonitorIDs(ids []int64) bool {
+	return len(ids) == 1 && ids[0] == pspAutoAddMonitorID
+}
+
+func containsPSPAutoAddMonitorID(ids []int64) bool {
+	for _, id := range ids {
+		if id == pspAutoAddMonitorID {
+			return true
+		}
+	}
+	return false
+}
+
+func pspAutoAddMonitorsValue(ctx context.Context, monitorIDs types.Set) (types.Bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if monitorIDs.IsNull() || monitorIDs.IsUnknown() {
+		return types.BoolNull(), diags
+	}
+
+	ids, diags := pspInt64SetElements(ctx, monitorIDs)
+	if diags.HasError() {
+		return types.BoolNull(), diags
+	}
+
+	return types.BoolValue(isPSPAutoAddMonitorIDs(ids)), diags
+}
+
+func syncPSPAutoAddMonitorsFromMonitorIDs(ctx context.Context, state *pspResourceModel) diag.Diagnostics {
+	value, diags := pspAutoAddMonitorsValue(ctx, state.MonitorIDs)
+	if diags.HasError() {
+		return diags
+	}
+	state.AutoAddMonitors = value
+	return diags
+}
+
+func resolvePSPMonitorSelection(ctx context.Context, plan, config pspResourceModel) (pspMonitorSelection, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	planMonitorIDsKnown := !plan.MonitorIDs.IsNull() && !plan.MonitorIDs.IsUnknown()
+	configuredMonitorIDs := !config.MonitorIDs.IsNull()
+
+	var planMonitorIDs []int64
+	if planMonitorIDsKnown {
+		monitorIDs, setDiags := pspInt64SetElements(ctx, plan.MonitorIDs)
+		diags.Append(setDiags...)
+		if diags.HasError() {
+			return pspMonitorSelection{}, diags
+		}
+		planMonitorIDs = monitorIDs
+
+		if containsPSPAutoAddMonitorID(planMonitorIDs) && !isPSPAutoAddMonitorIDs(planMonitorIDs) {
+			diags.AddError(
+				"Invalid PSP monitor_ids",
+				"`monitor_ids` can use the UptimeRobot auto-add sentinel `0` only by itself as `monitor_ids = [0]`. "+
+					"Use `auto_add_monitors = true` for automatic monitor selection, or remove `0` and provide explicit monitor IDs.",
+			)
+			return pspMonitorSelection{}, diags
+		}
+	}
+
+	configuredAutoAddMonitors := !config.AutoAddMonitors.IsNull()
+	if configuredAutoAddMonitors && !plan.AutoAddMonitors.IsNull() && !plan.AutoAddMonitors.IsUnknown() {
+		if plan.AutoAddMonitors.ValueBool() {
+			if configuredMonitorIDs && planMonitorIDsKnown && !isPSPAutoAddMonitorIDs(planMonitorIDs) {
+				diags.AddError(
+					"Conflicting PSP monitor selection",
+					"`auto_add_monitors = true` cannot be combined with explicit `monitor_ids`. "+
+						"Remove `monitor_ids`, or use `monitor_ids = [0]` only for backward compatibility.",
+				)
+				return pspMonitorSelection{}, diags
+			}
+
+			return pspMonitorSelection{
+				hasPlan:              true,
+				configuredMonitorIDs: configuredMonitorIDs,
+				monitorIDs:           []int64{pspAutoAddMonitorID},
+			}, diags
+		}
+
+		if configuredMonitorIDs && planMonitorIDsKnown {
+			if isPSPAutoAddMonitorIDs(planMonitorIDs) {
+				diags.AddError(
+					"Conflicting PSP monitor selection",
+					"`auto_add_monitors = false` cannot be combined with `monitor_ids = [0]`. "+
+						"Remove the auto-add sentinel or set `auto_add_monitors = true`.",
+				)
+				return pspMonitorSelection{}, diags
+			}
+
+			return pspMonitorSelection{
+				hasPlan:              true,
+				configuredMonitorIDs: true,
+				monitorIDs:           planMonitorIDs,
+			}, diags
+		}
+
+		if planMonitorIDsKnown && !isPSPAutoAddMonitorIDs(planMonitorIDs) {
+			return pspMonitorSelection{
+				hasPlan:    true,
+				monitorIDs: planMonitorIDs,
+			}, diags
+		}
+
+		return pspMonitorSelection{
+			hasPlan:    true,
+			monitorIDs: []int64{},
+		}, diags
+	}
+
+	if configuredMonitorIDs && planMonitorIDsKnown {
+		return pspMonitorSelection{
+			hasPlan:              true,
+			configuredMonitorIDs: true,
+			monitorIDs:           planMonitorIDs,
+		}, diags
+	}
+
+	if planMonitorIDsKnown {
+		return pspMonitorSelection{
+			hasPlan:    true,
+			monitorIDs: planMonitorIDs,
+		}, diags
+	}
+
+	return pspMonitorSelection{}, diags
+}
+
 func AllPSPMonitorSorts() []string {
 	return []string{
 		"friendly_name_asc",
@@ -2015,6 +2198,7 @@ func pspToResourceData(ctx context.Context, psp *client.PSP, plan *pspResourceMo
 	plan.Status = types.StringValue(psp.Status)
 	plan.URLKey = types.StringValue(psp.URLKey)
 	plan.IsPasswordSet = types.BoolValue(psp.IsPasswordSet)
+	plan.AutoAddMonitors = types.BoolValue(isPSPAutoAddMonitorIDs(psp.MonitorIDs))
 	plan.TagIDs = pspInt64SetValue(ctx, psp.TagIDs)
 
 	// Always set computed values, even if they're defaults from the API

--- a/internal/provider/psp/upgrader.go
+++ b/internal/provider/psp/upgrader.go
@@ -113,6 +113,9 @@ func upgradePSPFromV0(ctx context.Context, prior pspV0Model) (pspResourceModel, 
 	setIDs, d := tfconv.Int64ListToSet(ctx, prior.MonitorIDs)
 	diags.Append(d...)
 	up.MonitorIDs = setIDs
+	autoAddMonitors, d := pspAutoAddMonitorsValue(ctx, setIDs)
+	diags.Append(d...)
+	up.AutoAddMonitors = autoAddMonitors
 
 	// custom_settings
 	if prior.CustomSettings != nil {

--- a/internal/provider/psp/upgrader_test.go
+++ b/internal/provider/psp/upgrader_test.go
@@ -73,3 +73,16 @@ func TestUpgradePSPFromV0_MonitorIDs_EmptyListToEmptySet(t *testing.T) {
 	require.False(t, eds.HasError())
 	require.Len(t, got, 0)
 }
+
+func TestUpgradePSPFromV0_AutoAddMonitorsFromSentinel(t *testing.T) {
+	ctx := context.Background()
+	prior := pspV0Model{
+		Name:       types.StringValue("PSP"),
+		MonitorIDs: listInt64(pspAutoAddMonitorID),
+	}
+
+	up, diags := upgradePSPFromV0(ctx, prior)
+	require.False(t, diags.HasError())
+	require.False(t, up.AutoAddMonitors.IsNull())
+	require.True(t, up.AutoAddMonitors.ValueBool())
+}

--- a/templates/resources/psp.md.tmpl
+++ b/templates/resources/psp.md.tmpl
@@ -23,6 +23,10 @@ description: |-
 
 {{tffile "examples/resources/uptimerobot_psp/tag_ids.tf"}}
 
+### Status Page with Automatic Monitor Selection
+
+{{tffile "examples/resources/uptimerobot_psp/auto_add_monitors.tf"}}
+
 ### Password Protected Status Page
 
 {{tffile "examples/resources/uptimerobot_psp/password_protected.tf"}}
@@ -52,6 +56,8 @@ You can include specific monitors in your status page by providing their IDs in 
 - Group related services together
 
 You can also include monitors by tag with `tag_ids`. The UptimeRobot API resolves matching monitors server-side, and `tag_ids` are additive with `monitor_ids`.
+
+Set `auto_add_monitors = true` to automatically include all current and future monitors in the public status page. This uses the UptimeRobot API auto-add mode and should not be combined with explicit `monitor_ids`. Existing configurations that use `monitor_ids = [0]` for the API sentinel continue to work, but `auto_add_monitors` is preferred for new Terraform configuration.
 
 Use `monitor_sort` to control how monitors are ordered on the public status page. Supported values are:
 - `friendly_name_asc`


### PR DESCRIPTION
## Summary
- add auto_add_monitors to the uptimerobot_psp resource and data source
- map the field to the API [0] auto-add sentinel while keeping monitor_ids = [0] backward-compatible
- document the usage, example, and changelog entry

## Tests
- go test ./internal/provider/psp
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `auto_add_monitors` attribute for PSP resources to automatically include all current and future monitors
  * Added comprehensive documentation, examples, and usage guidance for the new automatic selection feature
  * Maintained backward compatibility with legacy `monitor_ids = [0]` sentinel configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->