### PR TITLE
docs: show monitor list reuse in maintenance windows

### DIFF
--- a/docs/data-sources/monitors.md
+++ b/docs/data-sources/monitors.md
@@ -25,9 +25,26 @@ data "uptimerobot_monitors" "production_api" {
   }
 }
 
+locals {
+  production_api_monitor_ids = toset([
+    for id in data.uptimerobot_monitors.production_api.ids : tonumber(id)
+  ])
+}
+
 resource "uptimerobot_psp" "production" {
   name        = "Production Status"
-  monitor_ids = data.uptimerobot_monitors.production_api.ids
+  monitor_ids = local.production_api_monitor_ids
+}
+
+resource "uptimerobot_maintenance_window" "production_api" {
+  name     = "Production API Maintenance"
+  interval = "weekly"
+  duration = 60
+  time     = "02:00:00"
+  days     = [7]
+
+  auto_add_monitors = false
+  monitor_ids       = local.production_api_monitor_ids
 }
 
 output "production_api_monitors" {

--- a/examples/data-sources/uptimerobot_monitors/data-source.tf
+++ b/examples/data-sources/uptimerobot_monitors/data-source.tf
@@ -7,9 +7,26 @@ data "uptimerobot_monitors" "production_api" {
   }
 }
 
+locals {
+  production_api_monitor_ids = toset([
+    for id in data.uptimerobot_monitors.production_api.ids : tonumber(id)
+  ])
+}
+
 resource "uptimerobot_psp" "production" {
   name        = "Production Status"
-  monitor_ids = data.uptimerobot_monitors.production_api.ids
+  monitor_ids = local.production_api_monitor_ids
+}
+
+resource "uptimerobot_maintenance_window" "production_api" {
+  name     = "Production API Maintenance"
+  interval = "weekly"
+  duration = 60
+  time     = "02:00:00"
+  days     = [7]
+
+  auto_add_monitors = false
+  monitor_ids       = local.production_api_monitor_ids
 }
 
 output "production_api_monitors" {


### PR DESCRIPTION
Adds an `uptimerobot_monitors` example that converts the returned IDs once and reuses them for both a public status page and a maintenance window.