### PR TITLE
Guard API monitor HTTP method handling

### DIFF
--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -742,7 +742,7 @@ terraform import 'uptimerobot_monitor.monitors["www_production"]' 800123456
 - `follow_redirections` (Boolean) Whether to follow redirections
 - `grace_period` (Number) The grace period (in seconds). Only for HEARTBEAT monitors
 - `group_id` (Number) Monitor group ID to assign monitor to. Use 0 for default group.
-- `http_method_type` (String) The HTTP method type (HEAD, GET, POST, PUT, PATCH, DELETE, OPTIONS)
+- `http_method_type` (String) The HTTP method type (HEAD, GET, POST, PUT, PATCH, DELETE, OPTIONS). HEAD is not supported for API monitors; use HTTP monitors for status/header-only HEAD checks.
 - `http_password` (String, Sensitive) The password for HTTP authentication
 - `http_username` (String) The username for HTTP authentication
 - `is_paused` (Boolean) Controls monitor run state. Set true to pause, false to start. Omit to preserve remote state (unmanaged).

--- a/internal/provider/monitor/monitor_crud_create.go
+++ b/internal/provider/monitor/monitor_crud_create.go
@@ -86,6 +86,11 @@ func (r *monitorResource) Create(ctx context.Context, req resource.CreateRequest
 func validateCreateHighLevel(ctx context.Context, plan monitorResourceModel, resp *resource.CreateResponse) bool {
 	t := strings.ToUpper(plan.Type.ValueString())
 
+	validateAPIHTTPMethodType(t, plan.HTTPMethodType, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return false
+	}
+
 	if (t == MonitorTypePORT || t == MonitorTypeUDP) && (plan.Port.IsNull() || plan.Port.IsUnknown()) {
 		resp.Diagnostics.AddError(
 			"Port required for PORT/UDP monitor",

--- a/internal/provider/monitor/monitor_crud_update.go
+++ b/internal/provider/monitor/monitor_crud_update.go
@@ -302,8 +302,9 @@ func buildUpdateRequest(
 	hasJSON := !plan.PostValueData.IsUnknown() && !plan.PostValueData.IsNull()
 	hasKV := !plan.PostValueKV.IsUnknown() && !plan.PostValueKV.IsNull()
 	effMethod := inferEffectiveMethod(plan.HTTPMethodType, plan.Type, hasJSON, hasKV)
+	stateMethod := stateHTTPMethodTypeOnUpdate(plan.Type, plan.HTTPMethodType, effMethod, httpMethodTypeOmitted, hasJSON, hasKV)
 	if isMethodHTTPLike(plan.Type) {
-		if shouldSendHTTPMethodTypeOnUpdate(plan.Type, effMethod, httpMethodTypeOmitted) {
+		if shouldSendHTTPMethodTypeOnUpdate(plan.Type, effMethod, httpMethodTypeOmitted, hasJSON, hasKV) {
 			req.HTTPMethodType = effMethod
 		}
 		setBodyOnUpdate(ctx, plan, effMethod, req, resp)
@@ -411,16 +412,32 @@ func buildUpdateRequest(
 	// Config
 	expandOrClearConfigOnUpdate(ctx, plan, state.Config, configOmitted, applicationErrorRetriesOmitted, req, resp)
 
-	return req, effMethod
+	return req, stateMethod
 }
 
-func shouldSendHTTPMethodTypeOnUpdate(monType types.String, effMethod string, httpMethodTypeOmitted bool) bool {
-	if strings.ToUpper(stringOrEmpty(monType)) == MonitorTypeAPI &&
-		httpMethodTypeOmitted &&
-		strings.EqualFold(strings.TrimSpace(effMethod), "HEAD") {
+func shouldSendHTTPMethodTypeOnUpdate(monType types.String, effMethod string, httpMethodTypeOmitted bool, hasJSON, hasKV bool) bool {
+	if strings.ToUpper(stringOrEmpty(monType)) == MonitorTypeAPI && httpMethodTypeOmitted && !hasJSON && !hasKV {
 		return false
 	}
 	return effMethod != ""
+}
+
+func stateHTTPMethodTypeOnUpdate(
+	monType types.String,
+	method types.String,
+	effMethod string,
+	httpMethodTypeOmitted bool,
+	hasJSON bool,
+	hasKV bool,
+) string {
+	if strings.ToUpper(stringOrEmpty(monType)) == MonitorTypeAPI &&
+		httpMethodTypeOmitted &&
+		!hasJSON &&
+		!hasKV &&
+		strings.TrimSpace(stringOrEmpty(method)) == "" {
+		return ""
+	}
+	return effMethod
 }
 
 func configAttributeOmitted(config basetypes.ObjectValue, name string) bool {

--- a/internal/provider/monitor/monitor_crud_update.go
+++ b/internal/provider/monitor/monitor_crud_update.go
@@ -38,17 +38,24 @@ func (r *monitorResource) Update(ctx context.Context, req resource.UpdateRequest
 	configOmitted := configVal.IsNull() || configVal.IsUnknown()
 	applicationErrorRetriesOmitted := configAttributeOmitted(configVal, "application_error_retries")
 
+	var configHTTPMethodType types.String
+	if diags := req.Config.GetAttribute(ctx, path.Root("http_method_type"), &configHTTPMethodType); diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	httpMethodTypeOmitted := configHTTPMethodType.IsNull() || configHTTPMethodType.IsUnknown()
+
 	id, err := strconv.ParseInt(plan.ID.ValueString(), 10, 64)
 	if err != nil {
 		resp.Diagnostics.AddError("Error parsing monitor ID", "Could not parse monitor ID: "+err.Error())
 		return
 	}
 
-	if !validateUpdateHighLevel(plan, resp) {
+	if !validateUpdateHighLevel(plan, httpMethodTypeOmitted, resp) {
 		return
 	}
 
-	updateReq, effMethod := buildUpdateRequest(ctx, plan, state, configOmitted, applicationErrorRetriesOmitted, resp)
+	updateReq, effMethod := buildUpdateRequest(ctx, plan, state, configOmitted, applicationErrorRetriesOmitted, httpMethodTypeOmitted, resp)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -228,8 +235,15 @@ func applyTrustedMonitorUpdateEcho(
 	return &out
 }
 
-func validateUpdateHighLevel(plan monitorResourceModel, resp *resource.UpdateResponse) bool {
+func validateUpdateHighLevel(plan monitorResourceModel, httpMethodTypeOmitted bool, resp *resource.UpdateResponse) bool {
 	t := plan.Type.ValueString()
+
+	if !httpMethodTypeOmitted {
+		validateAPIHTTPMethodType(t, plan.HTTPMethodType, &resp.Diagnostics)
+		if resp.Diagnostics.HasError() {
+			return false
+		}
+	}
 
 	// PORT/UDP requires port to be set
 	if (t == MonitorTypePORT || t == MonitorTypeUDP) && (plan.Port.IsNull() || plan.Port.IsUnknown()) {
@@ -267,6 +281,7 @@ func buildUpdateRequest(
 	state monitorResourceModel,
 	configOmitted bool,
 	applicationErrorRetriesOmitted bool,
+	httpMethodTypeOmitted bool,
 	resp *resource.UpdateResponse,
 ) (*client.UpdateMonitorRequest, string) {
 	req := &client.UpdateMonitorRequest{
@@ -288,7 +303,9 @@ func buildUpdateRequest(
 	hasKV := !plan.PostValueKV.IsUnknown() && !plan.PostValueKV.IsNull()
 	effMethod := inferEffectiveMethod(plan.HTTPMethodType, plan.Type, hasJSON, hasKV)
 	if isMethodHTTPLike(plan.Type) {
-		req.HTTPMethodType = effMethod
+		if shouldSendHTTPMethodTypeOnUpdate(plan.Type, effMethod, httpMethodTypeOmitted) {
+			req.HTTPMethodType = effMethod
+		}
 		setBodyOnUpdate(ctx, plan, effMethod, req, resp)
 	}
 
@@ -395,6 +412,15 @@ func buildUpdateRequest(
 	expandOrClearConfigOnUpdate(ctx, plan, state.Config, configOmitted, applicationErrorRetriesOmitted, req, resp)
 
 	return req, effMethod
+}
+
+func shouldSendHTTPMethodTypeOnUpdate(monType types.String, effMethod string, httpMethodTypeOmitted bool) bool {
+	if strings.ToUpper(stringOrEmpty(monType)) == MonitorTypeAPI &&
+		httpMethodTypeOmitted &&
+		strings.EqualFold(strings.TrimSpace(effMethod), "HEAD") {
+		return false
+	}
+	return effMethod != ""
 }
 
 func configAttributeOmitted(config basetypes.ObjectValue, name string) bool {

--- a/internal/provider/monitor/monitor_schema.go
+++ b/internal/provider/monitor/monitor_schema.go
@@ -198,7 +198,7 @@ func monitorSchema(version int64, includeApplicationErrorRetries bool) schema.Sc
 				},
 			},
 			"http_method_type": schema.StringAttribute{
-				Description: "The HTTP method type (HEAD, GET, POST, PUT, PATCH, DELETE, OPTIONS)",
+				Description: "The HTTP method type (HEAD, GET, POST, PUT, PATCH, DELETE, OPTIONS). HEAD is not supported for API monitors; use HTTP monitors for status/header-only HEAD checks.",
 				Optional:    true,
 				Computed:    true,
 				Validators: []validator.String{

--- a/internal/provider/monitor/monitor_transform_test.go
+++ b/internal/provider/monitor/monitor_transform_test.go
@@ -249,7 +249,7 @@ func TestBuildUpdateRequest_CustomFieldsSemantics(t *testing.T) {
 		state := monitorResourceModel{CustomFields: types.MapNull(types.StringType)}
 		resp := &resource.UpdateResponse{}
 
-		req, _ := buildUpdateRequest(ctx, plan, state, true, true, resp)
+		req, _ := buildUpdateRequest(ctx, plan, state, true, true, false, resp)
 		if resp.Diagnostics.HasError() {
 			t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
 		}
@@ -266,7 +266,7 @@ func TestBuildUpdateRequest_CustomFieldsSemantics(t *testing.T) {
 		})}
 		resp := &resource.UpdateResponse{}
 
-		req, _ := buildUpdateRequest(ctx, plan, state, true, true, resp)
+		req, _ := buildUpdateRequest(ctx, plan, state, true, true, false, resp)
 		if resp.Diagnostics.HasError() {
 			t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
 		}
@@ -283,7 +283,7 @@ func TestBuildUpdateRequest_CustomFieldsSemantics(t *testing.T) {
 		})}
 		resp := &resource.UpdateResponse{}
 
-		req, _ := buildUpdateRequest(ctx, plan, state, true, true, resp)
+		req, _ := buildUpdateRequest(ctx, plan, state, true, true, false, resp)
 		if resp.Diagnostics.HasError() {
 			t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
 		}
@@ -377,7 +377,7 @@ func TestBuildUpdateRequest_CustomHTTPHeadersSemantics(t *testing.T) {
 			state := monitorResourceModel{CustomHTTPHeaders: tt.stateHeaders}
 			resp := &resource.UpdateResponse{}
 
-			req, _ := buildUpdateRequest(ctx, plan, state, true, true, resp)
+			req, _ := buildUpdateRequest(ctx, plan, state, true, true, false, resp)
 			if resp.Diagnostics.HasError() {
 				t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
 			}
@@ -450,7 +450,7 @@ func TestBuildUpdateRequest_HeartbeatOmitsServerGeneratedURL(t *testing.T) {
 	}
 	resp := &resource.UpdateResponse{}
 
-	req, _ := buildUpdateRequest(ctx, plan, monitorResourceModel{}, true, true, resp)
+	req, _ := buildUpdateRequest(ctx, plan, monitorResourceModel{}, true, true, false, resp)
 	if resp.Diagnostics.HasError() {
 		t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
 	}
@@ -465,6 +465,36 @@ func TestBuildUpdateRequest_HeartbeatOmitsServerGeneratedURL(t *testing.T) {
 	}
 	if req.Timeout != nil {
 		t.Fatalf("expected timeout to be omitted for heartbeat, got %#v", req.Timeout)
+	}
+}
+
+func TestBuildUpdateRequest_APIMonitorOmitsLegacyHEADMethodWhenConfigOmitted(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	plan := monitorResourceModel{
+		Type:           types.StringValue(MonitorTypeAPI),
+		Name:           types.StringValue("api"),
+		URL:            types.StringValue("https://example.com/api"),
+		Interval:       types.Int64Value(300),
+		HTTPMethodType: types.StringValue("HEAD"),
+		Config:         types.ObjectNull(configObjectType().AttrTypes),
+	}
+	state := monitorResourceModel{
+		HTTPMethodType: types.StringValue("HEAD"),
+		Config:         types.ObjectNull(configObjectType().AttrTypes),
+	}
+	resp := &resource.UpdateResponse{}
+
+	req, effMethod := buildUpdateRequest(ctx, plan, state, true, true, true, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
+	}
+	if effMethod != "HEAD" {
+		t.Fatalf("expected effective method to preserve legacy HEAD state, got %q", effMethod)
+	}
+	if req.HTTPMethodType != "" {
+		t.Fatalf("expected update request to omit legacy HEAD API method, got %q", req.HTTPMethodType)
 	}
 }
 

--- a/internal/provider/monitor/monitor_transform_test.go
+++ b/internal/provider/monitor/monitor_transform_test.go
@@ -498,6 +498,73 @@ func TestBuildUpdateRequest_APIMonitorOmitsLegacyHEADMethodWhenConfigOmitted(t *
 	}
 }
 
+func TestBuildUpdateRequest_APIMonitorOmitsLegacyNullMethodWhenConfigOmitted(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	plan := monitorResourceModel{
+		Type:           types.StringValue(MonitorTypeAPI),
+		Name:           types.StringValue("api"),
+		URL:            types.StringValue("https://example.com/api"),
+		Interval:       types.Int64Value(300),
+		HTTPMethodType: types.StringNull(),
+		PostValueData:  jsontypes.NewNormalizedNull(),
+		PostValueKV:    types.MapNull(types.StringType),
+		Config:         types.ObjectNull(configObjectType().AttrTypes),
+	}
+	state := monitorResourceModel{
+		HTTPMethodType: types.StringNull(),
+		Config:         types.ObjectNull(configObjectType().AttrTypes),
+	}
+	resp := &resource.UpdateResponse{}
+
+	req, stateMethod := buildUpdateRequest(ctx, plan, state, true, true, true, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
+	}
+	if stateMethod != "" {
+		t.Fatalf("expected state method to remain unmanaged, got %q", stateMethod)
+	}
+	if req.HTTPMethodType != "" {
+		t.Fatalf("expected update request to omit legacy null API method, got %q", req.HTTPMethodType)
+	}
+}
+
+func TestBuildUpdateRequest_APIMonitorSendsPOSTWhenBodyConfiguredAndMethodOmitted(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	plan := monitorResourceModel{
+		Type:           types.StringValue(MonitorTypeAPI),
+		Name:           types.StringValue("api"),
+		URL:            types.StringValue("https://example.com/api"),
+		Interval:       types.Int64Value(300),
+		HTTPMethodType: types.StringNull(),
+		PostValueData:  jsontypes.NewNormalizedValue(`{"status":"ok"}`),
+		PostValueKV:    types.MapNull(types.StringType),
+		Config:         types.ObjectNull(configObjectType().AttrTypes),
+	}
+	state := monitorResourceModel{
+		HTTPMethodType: types.StringNull(),
+		Config:         types.ObjectNull(configObjectType().AttrTypes),
+	}
+	resp := &resource.UpdateResponse{}
+
+	req, stateMethod := buildUpdateRequest(ctx, plan, state, true, true, true, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
+	}
+	if stateMethod != "POST" {
+		t.Fatalf("expected state method POST for body update, got %q", stateMethod)
+	}
+	if req.HTTPMethodType != "POST" {
+		t.Fatalf("expected update request to send POST for body update, got %q", req.HTTPMethodType)
+	}
+	if req.PostValueType != PostTypeRawJSON {
+		t.Fatalf("expected RAW_JSON post type, got %q", req.PostValueType)
+	}
+}
+
 func TestFlattenConfigToState_DNSFromAPI_PopulatesSets(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/monitor/monitor_transform_test.go
+++ b/internal/provider/monitor/monitor_transform_test.go
@@ -468,17 +468,25 @@ func TestBuildUpdateRequest_HeartbeatOmitsServerGeneratedURL(t *testing.T) {
 	}
 }
 
-func TestBuildUpdateRequest_APIMonitorOmitsLegacyHEADMethodWhenConfigOmitted(t *testing.T) {
+func TestBuildUpdateRequest_APIMonitorOmitsLegacyHEADMethodWhenHTTPMethodOmitted(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
+	config := types.ObjectValueMust(configObjectType().AttrTypes, map[string]attr.Value{
+		"ssl_expiration_period_days": types.SetNull(types.Int64Type),
+		"dns_records":                types.ObjectNull(dnsRecordsObjectType().AttrTypes),
+		"ip_version":                 types.StringNull(),
+		"api_assertions":             types.ObjectNull(apiAssertionsObjectType().AttrTypes),
+		"udp":                        types.ObjectNull(udpObjectType().AttrTypes),
+		"application_error_retries":  types.Int64Unknown(),
+	})
 	plan := monitorResourceModel{
 		Type:           types.StringValue(MonitorTypeAPI),
 		Name:           types.StringValue("api"),
 		URL:            types.StringValue("https://example.com/api"),
 		Interval:       types.Int64Value(300),
 		HTTPMethodType: types.StringValue("HEAD"),
-		Config:         types.ObjectNull(configObjectType().AttrTypes),
+		Config:         config,
 	}
 	state := monitorResourceModel{
 		HTTPMethodType: types.StringValue("HEAD"),
@@ -486,7 +494,7 @@ func TestBuildUpdateRequest_APIMonitorOmitsLegacyHEADMethodWhenConfigOmitted(t *
 	}
 	resp := &resource.UpdateResponse{}
 
-	req, effMethod := buildUpdateRequest(ctx, plan, state, true, true, true, resp)
+	req, effMethod := buildUpdateRequest(ctx, plan, state, false, true, true, resp)
 	if resp.Diagnostics.HasError() {
 		t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
 	}
@@ -495,6 +503,10 @@ func TestBuildUpdateRequest_APIMonitorOmitsLegacyHEADMethodWhenConfigOmitted(t *
 	}
 	if req.HTTPMethodType != "" {
 		t.Fatalf("expected update request to omit legacy HEAD API method, got %q", req.HTTPMethodType)
+	}
+
+	if !shouldSendHTTPMethodTypeOnUpdate(plan.Type, effMethod, false, false, false) {
+		t.Fatalf("expected explicit HEAD method to be sent when http_method_type is configured")
 	}
 }
 

--- a/internal/provider/monitor/monitor_validate.go
+++ b/internal/provider/monitor/monitor_validate.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -59,6 +60,7 @@ func (r *monitorResource) ValidateConfig(
 	validateURL(ctx, t, &data, resp)
 	validateGracePeriodAndTimeout(ctx, t, &data, resp)
 	validateMethodVsBody(ctx, &data, resp)
+	validateAPIHTTPMethodType(t, data.HTTPMethodType, &resp.Diagnostics)
 	validateAssignedAlertContacts(ctx, &data, resp)
 	validateConfig(ctx, t, &data, resp)
 	validateRegionData(ctx, &data, resp)
@@ -217,6 +219,30 @@ func validateMethodVsBody(
 			)
 		}
 	}
+}
+
+func validateAPIHTTPMethodType(monitorType string, method types.String, diagnostics *diag.Diagnostics) {
+	if !isAPIHeadHTTPMethod(monitorType, method) {
+		return
+	}
+
+	diagnostics.AddAttributeError(
+		path.Root("http_method_type"),
+		"HEAD is not supported for API monitors",
+		"API monitors evaluate response bodies with config.api_assertions. "+
+			"Use GET, POST, PUT, PATCH, DELETE, or OPTIONS for API monitors, "+
+			"or use type = HTTP for status/header-only HEAD checks.",
+	)
+}
+
+func isAPIHeadHTTPMethod(monitorType string, method types.String) bool {
+	if strings.ToUpper(strings.TrimSpace(monitorType)) != MonitorTypeAPI {
+		return false
+	}
+	if method.IsNull() || method.IsUnknown() {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(method.ValueString()), http.MethodHead)
 }
 
 func validateAssignedAlertContacts(

--- a/internal/provider/monitor/monitor_validate_test.go
+++ b/internal/provider/monitor/monitor_validate_test.go
@@ -195,9 +195,25 @@ func TestValidateCreateHighLevel_UDPType_RejectsUnknownPort(t *testing.T) {
 
 func TestValidateCreateHighLevel_APIMonitorRejectsHEADMethod(t *testing.T) {
 	resp := &resource.CreateResponse{}
+	check := types.ObjectValueMust(apiAssertionCheckObjectType().AttrTypes, map[string]attr.Value{
+		"property":   types.StringValue("$.status"),
+		"comparison": types.StringValue("equals"),
+		"target":     jsontypes.NewNormalizedValue(`"ok"`),
+	})
 	plan := monitorResourceModel{
 		Type:           types.StringValue(MonitorTypeAPI),
 		HTTPMethodType: types.StringValue("HEAD"),
+		Config: types.ObjectValueMust(configObjectType().AttrTypes, map[string]attr.Value{
+			"ssl_expiration_period_days": types.SetNull(types.Int64Type),
+			"dns_records":                types.ObjectNull(dnsRecordsObjectType().AttrTypes),
+			"ip_version":                 types.StringNull(),
+			"api_assertions": types.ObjectValueMust(apiAssertionsObjectType().AttrTypes, map[string]attr.Value{
+				"logic":  types.StringValue("AND"),
+				"checks": types.ListValueMust(apiAssertionCheckObjectType(), []attr.Value{check}),
+			}),
+			"udp":                       types.ObjectNull(udpObjectType().AttrTypes),
+			"application_error_retries": types.Int64Unknown(),
+		}),
 	}
 
 	ok := validateCreateHighLevel(context.TODO(), plan, resp)

--- a/internal/provider/monitor/monitor_validate_test.go
+++ b/internal/provider/monitor/monitor_validate_test.go
@@ -42,6 +42,39 @@ func TestValidateNoHTMLEntities_AllowsLiteralAmpersandToken(t *testing.T) {
 	}
 }
 
+func TestValidateAPIHTTPMethodType_RejectsHEADForAPIMonitor(t *testing.T) {
+	t.Parallel()
+
+	resp := &resource.ValidateConfigResponse{}
+	validateAPIHTTPMethodType(MonitorTypeAPI, types.StringValue("HEAD"), &resp.Diagnostics)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected an error for HEAD API monitor method")
+	}
+}
+
+func TestValidateAPIHTTPMethodType_AllowsHEADForHTTPMonitor(t *testing.T) {
+	t.Parallel()
+
+	resp := &resource.ValidateConfigResponse{}
+	validateAPIHTTPMethodType(MonitorTypeHTTP, types.StringValue("HEAD"), &resp.Diagnostics)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected no errors for HEAD HTTP monitor method, got: %v", resp.Diagnostics)
+	}
+}
+
+func TestValidateAPIHTTPMethodType_AllowsOPTIONSForAPIMonitor(t *testing.T) {
+	t.Parallel()
+
+	resp := &resource.ValidateConfigResponse{}
+	validateAPIHTTPMethodType(MonitorTypeAPI, types.StringValue("OPTIONS"), &resp.Diagnostics)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected no errors for OPTIONS API monitor method, got: %v", resp.Diagnostics)
+	}
+}
+
 func TestValidateURL_HeartbeatOmittedURL(t *testing.T) {
 	t.Parallel()
 
@@ -160,6 +193,23 @@ func TestValidateCreateHighLevel_UDPType_RejectsUnknownPort(t *testing.T) {
 	}
 }
 
+func TestValidateCreateHighLevel_APIMonitorRejectsHEADMethod(t *testing.T) {
+	resp := &resource.CreateResponse{}
+	plan := monitorResourceModel{
+		Type:           types.StringValue(MonitorTypeAPI),
+		HTTPMethodType: types.StringValue("HEAD"),
+	}
+
+	ok := validateCreateHighLevel(context.TODO(), plan, resp)
+
+	if ok {
+		t.Fatalf("expected ok=false for HEAD API monitor method")
+	}
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected diagnostics error for HEAD API monitor method")
+	}
+}
+
 func TestValidateUpdateHighLevel_PortType_RejectsUnknownPort(t *testing.T) {
 	resp := &resource.UpdateResponse{}
 	plan := monitorResourceModel{
@@ -167,7 +217,7 @@ func TestValidateUpdateHighLevel_PortType_RejectsUnknownPort(t *testing.T) {
 		Port: types.Int64Unknown(),
 	}
 
-	ok := validateUpdateHighLevel(plan, resp)
+	ok := validateUpdateHighLevel(plan, false, resp)
 
 	if ok {
 		t.Fatalf("expected ok=false for unknown port")
@@ -184,13 +234,47 @@ func TestValidateUpdateHighLevel_UDPType_RejectsUnknownPort(t *testing.T) {
 		Port: types.Int64Unknown(),
 	}
 
-	ok := validateUpdateHighLevel(plan, resp)
+	ok := validateUpdateHighLevel(plan, false, resp)
 
 	if ok {
 		t.Fatalf("expected ok=false for unknown port")
 	}
 	if !resp.Diagnostics.HasError() {
 		t.Fatalf("expected diagnostics error for unknown port")
+	}
+}
+
+func TestValidateUpdateHighLevel_APIMonitorRejectsConfiguredHEADMethod(t *testing.T) {
+	resp := &resource.UpdateResponse{}
+	plan := monitorResourceModel{
+		Type:           types.StringValue(MonitorTypeAPI),
+		HTTPMethodType: types.StringValue("HEAD"),
+	}
+
+	ok := validateUpdateHighLevel(plan, false, resp)
+
+	if ok {
+		t.Fatalf("expected ok=false for configured HEAD API monitor method")
+	}
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected diagnostics error for configured HEAD API monitor method")
+	}
+}
+
+func TestValidateUpdateHighLevel_APIMonitorAllowsOmittedLegacyHEADMethod(t *testing.T) {
+	resp := &resource.UpdateResponse{}
+	plan := monitorResourceModel{
+		Type:           types.StringValue(MonitorTypeAPI),
+		HTTPMethodType: types.StringValue("HEAD"),
+	}
+
+	ok := validateUpdateHighLevel(plan, true, resp)
+
+	if !ok {
+		t.Fatalf("expected ok=true for omitted legacy HEAD API monitor method, got diagnostics: %v", resp.Diagnostics)
+	}
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected no diagnostics for omitted legacy HEAD API monitor method")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reject `http_method_type = "HEAD"` for API monitors during validation and CRUD flows.
- Preserve omitted API monitor methods on update so legacy remote values are not silently changed.
- Keep body-driven API monitor updates on POST when no method is configured.
- Update generated monitor resource documentation and add focused unit coverage.

## Testing
- `go test ./internal/provider/monitor`
- `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified and enforced that `HEAD` is not supported for API monitors.
  * Improved monitor updates so omitted HTTP method settings are handled more accurately, especially for API monitors with no request body.
  * Prevented invalid API monitor configurations from passing create/update validation.
* **Documentation**
  * Updated monitor guidance to explain when to use HTTP monitors for `HEAD` checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->