### PR TITLE
Preserve omitted maintenance windows on monitor updates

### DIFF
--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -749,8 +749,8 @@ terraform import 'uptimerobot_monitor.monitors["www_production"]' 800123456
 - `keyword_case_type` (String) Case sensitivity for keyword. One of: CaseSensitive, CaseInsensitive. Omit to leave server as-is.
 - `keyword_type` (String) The type of keyword check (ALERT_EXISTS, ALERT_NOT_EXISTS)
 - `keyword_value` (String) The keyword to search for
-- `maintenance_window_ids` (Set of Number) Today API v3 behavior on update, if maintenance_window_ids is omitted or set to [] they both clear maintenance windows.
-					Recommended: To clear, set maintenance_window_ids = []. To manage them, set the exact IDs.
+- `maintenance_window_ids` (Set of Number) Omit maintenance_window_ids or set it to null to preserve existing maintenance windows on update.
+					To clear maintenance windows, set maintenance_window_ids = []. To manage them, set the exact IDs.
 - `port` (Number) The port to monitor
 - `post_value_data` (String) JSON body (use jsonencode). Mutually exclusive with post_value_kv.
 - `post_value_kv` (Map of String) Key/Value body for application/x-www-form-urlencoded. Mutually exclusive with post_value_data.

--- a/internal/provider/monitor/monitor_crud_update.go
+++ b/internal/provider/monitor/monitor_crud_update.go
@@ -549,8 +549,7 @@ func setMaintenanceWindowsOnUpdate(ctx context.Context, plan monitorResourceMode
 	case plan.MaintenanceWindowIDs.IsUnknown():
 		req.MaintenanceWindowIDs = nil
 	case plan.MaintenanceWindowIDs.IsNull():
-		empty := []int64{}
-		req.MaintenanceWindowIDs = &empty
+		req.MaintenanceWindowIDs = nil
 	default:
 		var ids []int64
 		resp.Diagnostics.Append(plan.MaintenanceWindowIDs.ElementsAs(ctx, &ids, false)...)

--- a/internal/provider/monitor/monitor_schema.go
+++ b/internal/provider/monitor/monitor_schema.go
@@ -286,15 +286,11 @@ func monitorSchema(version int64, includeApplicationErrorRetries bool) schema.Sc
 			"maintenance_window_ids": schema.SetAttribute{
 				Description: "The maintenance window IDs",
 				MarkdownDescription: `
-					Today API v3 behavior on update, if maintenance_window_ids is omitted or set to [] they both clear maintenance windows.
-					Recommended: To clear, set maintenance_window_ids = []. To manage them, set the exact IDs.
+					Omit maintenance_window_ids or set it to null to preserve existing maintenance windows on update.
+					To clear maintenance windows, set maintenance_window_ids = []. To manage them, set the exact IDs.
 				`,
-				//	When the API changes to preserve omits, leaving the attribute out will preserve remote values automatically and no provider change will be needed.
 				Optional:    true,
 				ElementType: types.Int64Type,
-				// PlanModifiers: []planmodifier.Set{ // Check if omit delets and fix
-				// 	setplanmodifier.UseStateForUnknown(),
-				// },
 			},
 			"id": schema.StringAttribute{
 				Description: "Monitor ID",

--- a/internal/provider/monitor/monitor_transform_test.go
+++ b/internal/provider/monitor/monitor_transform_test.go
@@ -437,6 +437,73 @@ func TestPlanAlertContactsComparable_SkipsComparisonForIncompleteContact(t *test
 	}
 }
 
+func TestSetMaintenanceWindowsOnUpdatePreserveOrClear(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tests := []struct {
+		name     string
+		plan     types.Set
+		wantSent bool
+		want     []int64
+	}{
+		{
+			name:     "null omits and preserves remote",
+			plan:     types.SetNull(types.Int64Type),
+			wantSent: false,
+		},
+		{
+			name:     "unknown omits and preserves remote",
+			plan:     types.SetUnknown(types.Int64Type),
+			wantSent: false,
+		},
+		{
+			name:     "empty set sends clear payload",
+			plan:     types.SetValueMust(types.Int64Type, []attr.Value{}),
+			wantSent: true,
+			want:     []int64{},
+		},
+		{
+			name: "configured set sends normalized ids",
+			plan: types.SetValueMust(types.Int64Type, []attr.Value{
+				types.Int64Value(2),
+				types.Int64Value(1),
+			}),
+			wantSent: true,
+			want:     []int64{1, 2},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := &client.UpdateMonitorRequest{}
+			resp := &resource.UpdateResponse{}
+			setMaintenanceWindowsOnUpdate(ctx, monitorResourceModel{
+				MaintenanceWindowIDs: tt.plan,
+			}, req, resp)
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
+			}
+
+			if !tt.wantSent {
+				if req.MaintenanceWindowIDs != nil {
+					t.Fatalf("expected maintenanceWindowsIds to be omitted, got %#v", *req.MaintenanceWindowIDs)
+				}
+				return
+			}
+			if req.MaintenanceWindowIDs == nil {
+				t.Fatal("expected maintenanceWindowsIds payload to be sent")
+			}
+			if !equalInt64Set(tt.want, *req.MaintenanceWindowIDs) {
+				t.Fatalf("expected maintenanceWindowsIds %#v, got %#v", tt.want, *req.MaintenanceWindowIDs)
+			}
+		})
+	}
+}
+
 func TestBuildUpdateRequest_HeartbeatOmitsServerGeneratedURL(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Preserve existing monitor maintenance windows when `maintenance_window_ids` is omitted or null during update.
- Keep explicit `maintenance_window_ids = []` as the clear operation.
- Update generated monitor resource docs and add focused unit coverage.

## Testing
- `go test ./internal/provider/monitor`
- `go test ./...`
- `npm test -- apps/api-internal/src/monitors/commands/handlers/update-monitor.handler.spec.ts --runInBand`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated maintenance window update behavior so leaving the field unset or setting it to `null` now preserves existing windows instead of clearing them.
  * Setting the field to an empty list now explicitly clears maintenance windows, while providing IDs updates the selected windows.
* **Documentation**
  * Clarified the expected update behavior for maintenance windows in the resource documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->