### PR TITLE
fix: correct MS Teams integration type string format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Fixed
+- Fixed MS Teams integration creation by correcting the `type` API payload from `"MS Teams"` to `"MSTeams"`.
+
 ## 1.9.0 — 2026-06-19
 
 ### Added

--- a/internal/provider/integration/data_source_test.go
+++ b/internal/provider/integration/data_source_test.go
@@ -15,7 +15,7 @@ func TestFilterIntegrationsExactNameAndCanonicalType(t *testing.T) {
 		{ID: 101, Name: "Ops", Type: "Slack"},
 		{ID: 102, Name: "Ops", Type: "Webhook"},
 		{ID: 103, Name: "ops", Type: "Slack"},
-		{ID: 104, Name: "Ops", Type: "MS Teams"},
+		{ID: 104, Name: "Ops", Type: "MSTeams"},
 	}
 
 	matches := filterIntegrations(integrations, "Ops", "msteams")

--- a/internal/provider/integration/types.go
+++ b/internal/provider/integration/types.go
@@ -72,7 +72,7 @@ func TransformIntegrationTypeToAPI(terraformType string) string {
 	case "pushbullet":
 		return "Pushbullet"
 	case "msteams", "ms teams", "microsoft teams":
-		return "MS Teams"
+		return "MSTeams"
 	case "zapier":
 		return "Zapier"
 	case "pagerduty", "pager duty":
@@ -103,7 +103,7 @@ func TransformIntegrationTypeFromAPI(apiType string) string {
 		return "pushover"
 	case "Pushbullet":
 		return "pushbullet"
-	case "MS Teams":
+	case "MSTeams", "MS Teams":
 		return "msteams"
 	case "Zapier":
 		return "zapier"


### PR DESCRIPTION
### Description
This PR fixes a bug where creating a Microsoft Teams integration via the provider results in a `404 No integration found. (code 021-005)` error from the UptimeRobot API. 

The UptimeRobot API strictly expects the type payload for Microsoft Teams to be `"MSTeams"` (without a space). The provider was previously formatting this as `"MS Teams"`, which caused the API to reject the creation request.

### Scope
- **`internal/provider/integration/types.go`**: Updated `TransformIntegrationTypeToAPI` to return `"MSTeams"`, and updated `TransformIntegrationTypeFromAPI` to safely handle both `"MSTeams"` and `"MS Teams"` for robust backward compatibility.
- **`internal/provider/integration/data_source_test.go`**: Updated integration test fixtures.
- **`CHANGELOG.md`**: Added an entry under `Unreleased`.

### User Impact
Users will now be able to successfully create, read, and manage `uptimerobot_integration` resources of `type = "msteams"` without encountering API rejection errors.

### Edge Cases
The API might return either `"MSTeams"` or `"MS Teams"` in different contexts or legacy states. The `TransformIntegrationTypeFromAPI` function has been updated to accept both variants to prevent perpetual diffs for existing users.

### Testing
- [x] Unit tests (`go test ./... -race`) pass locally.
- [x] Tested locally against the live UptimeRobot API to verify that the `msteams` integration creates successfully.
