### PR TITLE
fix: correct Google Chat integration type string format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## Unreleased
 
 ### Fixed
+
 - Fixed MS Teams integration creation by correcting the `type` API payload from `"MS Teams"` to `"MSTeams"`.
+- Fixed Google Chat integration create/update requests to use the API v3 enum key expected by UptimeRobot.
 
 ## 1.9.0 — 2026-06-19
 

--- a/internal/provider/integration/data_source_test.go
+++ b/internal/provider/integration/data_source_test.go
@@ -27,6 +27,22 @@ func TestFilterIntegrationsExactNameAndCanonicalType(t *testing.T) {
 	}
 }
 
+func TestTransformIntegrationTypeGoogleChatUsesAPIEnumKey(t *testing.T) {
+	t.Parallel()
+
+	for _, input := range []string{"googlechat", "google chat"} {
+		if got := TransformIntegrationTypeToAPI(input); got != "GoogleChat" {
+			t.Fatalf("TransformIntegrationTypeToAPI(%q) = %q, want GoogleChat", input, got)
+		}
+	}
+
+	for _, input := range []string{"GoogleChat", "Google Chat"} {
+		if got := TransformIntegrationTypeFromAPI(input); got != "googlechat" {
+			t.Fatalf("TransformIntegrationTypeFromAPI(%q) = %q, want googlechat", input, got)
+		}
+	}
+}
+
 func TestIntegrationLookupSelectorsRequireSelectorAndValidateID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/integration/types.go
+++ b/internal/provider/integration/types.go
@@ -78,7 +78,7 @@ func TransformIntegrationTypeToAPI(terraformType string) string {
 	case "pagerduty", "pager duty":
 		return "PagerDuty"
 	case "googlechat", "google chat":
-		return "Google Chat"
+		return "GoogleChat"
 	case "splunk":
 		return "Splunk"
 	case "mattermost":
@@ -109,7 +109,7 @@ func TransformIntegrationTypeFromAPI(apiType string) string {
 		return "zapier"
 	case "PagerDuty":
 		return "pagerduty"
-	case "Google Chat":
+	case "GoogleChat", "Google Chat":
 		return "googlechat"
 	case "Splunk":
 		return "splunk"


### PR DESCRIPTION
## Summary
- Send Google Chat integration create/update requests with the API v3 enum key `GoogleChat` instead of the display label `Google Chat`.
- Keep read-side normalization accepting both `GoogleChat` and `Google Chat`.
- Add regression coverage and a changelog entry.

## Validation
- `go test ./internal/provider/integration`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Google Chat integration create/update requests to use the API’s expected enum value.
  * Corrected MS Teams integration create payload `type` to match the API’s required format.
  * Improved normalization so both common Google Chat spellings are handled consistently.
* **Tests**
  * Added unit coverage to verify Google Chat integration type conversions in both directions.
* **Documentation**
  * Updated the release notes under Unreleased to reflect the Google Chat and MS Teams fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->