### PR TITLE
fix: handle unknown maintenance window monitor IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed MS Teams integration creation by correcting the `type` API payload from `"MS Teams"` to `"MSTeams"`.
 - Fixed Google Chat integration create/update requests to use the API v3 enum key expected by UptimeRobot.
 - Fixed `uptimerobot_maintenance_window.monitor_ids` validation when IDs reference monitors created in the same Terraform run.
+- Fixed PING and PORT monitor URL state consistency when UptimeRobot returns host-only targets.
 
 ## 1.9.0 — 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed MS Teams integration creation by correcting the `type` API payload from `"MS Teams"` to `"MSTeams"`.
 - Fixed Google Chat integration create/update requests to use the API v3 enum key expected by UptimeRobot.
+- Fixed `uptimerobot_maintenance_window.monitor_ids` validation when IDs reference monitors created in the same Terraform run.
 
 ## 1.9.0 — 2026-06-19
 

--- a/internal/provider/maintenancewindow/resource.go
+++ b/internal/provider/maintenancewindow/resource.go
@@ -272,6 +272,9 @@ func validateRuleMonitorIDsAutoAddConflict(
 	if cfg.MonitorIDs.IsNull() || cfg.MonitorIDs.IsUnknown() {
 		return
 	}
+	if maintenanceWindowMonitorIDsContainUnknown(cfg.MonitorIDs) {
+		return
+	}
 
 	monitorIDs, diags := maintenanceWindowMonitorIDsFromSet(ctx, cfg.MonitorIDs)
 	resp.Diagnostics.Append(diags...)
@@ -279,38 +282,7 @@ func validateRuleMonitorIDsAutoAddConflict(
 		return
 	}
 
-	if maintenanceWindowMonitorIDsContainAutoAdd(monitorIDs) && len(monitorIDs) > 1 {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("monitor_ids"),
-			"Invalid monitor_ids",
-			`"monitor_ids" can contain either specific monitor IDs or [0] to auto-add all monitors, but not both.`,
-		)
-		return
-	}
-
-	if cfg.AutoAddMonitors.IsNull() || cfg.AutoAddMonitors.IsUnknown() {
-		return
-	}
-
-	autoAddMonitors := cfg.AutoAddMonitors.ValueBool()
-	if autoAddMonitors {
-		if len(monitorIDs) == 0 || !maintenanceWindowMonitorIDsAutoAdd(monitorIDs) {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("monitor_ids"),
-				"monitor_ids conflicts with auto_add_monitors",
-				`When "auto_add_monitors" is true, omit "monitor_ids" or set it to [0].`,
-			)
-		}
-		return
-	}
-
-	if maintenanceWindowMonitorIDsAutoAdd(monitorIDs) {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("auto_add_monitors"),
-			"auto_add_monitors conflicts with monitor_ids",
-			`When "monitor_ids" is [0], omit "auto_add_monitors" or set it to true.`,
-		)
-	}
+	resp.Diagnostics.Append(validateMaintenanceWindowMonitorIDsAutoAdd(monitorIDs, cfg.AutoAddMonitors)...)
 }
 
 func (r *maintenanceWindowResource) ModifyPlan(
@@ -334,7 +306,7 @@ func (r *maintenanceWindowResource) ModifyPlan(
 		return
 	}
 
-	if !config.MonitorIDs.IsNull() && !config.MonitorIDs.IsUnknown() {
+	if !config.MonitorIDs.IsNull() && !config.MonitorIDs.IsUnknown() && !maintenanceWindowMonitorIDsContainUnknown(config.MonitorIDs) {
 		monitorIDs, diags := maintenanceWindowMonitorIDsFromSet(ctx, config.MonitorIDs)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
@@ -387,8 +359,21 @@ func (r *maintenanceWindowResource) Create(ctx context.Context, req resource.Cre
 	}
 
 	if !plan.MonitorIDs.IsNull() && !plan.MonitorIDs.IsUnknown() {
+		if maintenanceWindowMonitorIDsContainUnknown(plan.MonitorIDs) {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("monitor_ids"),
+				"Invalid monitor_ids plan",
+				"Expected monitor_ids values to be known before creating the maintenance window. Please report this issue to the provider developers.",
+			)
+			return
+		}
+
 		monitorIDs, d := maintenanceWindowMonitorIDsFromSet(ctx, plan.MonitorIDs)
 		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		resp.Diagnostics.Append(validateMaintenanceWindowMonitorIDsAutoAdd(monitorIDs, plan.AutoAddMonitors)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
@@ -916,16 +901,20 @@ func applyMaintenanceWindowMonitorIDsUpdate(
 		return nil, nil, false, diags
 	}
 
-	if plan.MonitorIDs.IsNull() || plan.MonitorIDs.IsUnknown() {
+	if plan.MonitorIDs.IsNull() || plan.MonitorIDs.IsUnknown() || maintenanceWindowMonitorIDsContainUnknown(plan.MonitorIDs) {
 		diags.AddError(
 			"Invalid monitor_ids plan",
-			"Expected monitor_ids to be known because it is present in configuration. Please report this issue to the provider developers.",
+			"Expected monitor_ids values to be known because monitor_ids is present in configuration. Please report this issue to the provider developers.",
 		)
 		return nil, nil, false, diags
 	}
 
 	monitorIDs, d := maintenanceWindowMonitorIDsFromSet(ctx, plan.MonitorIDs)
 	diags.Append(d...)
+	if diags.HasError() {
+		return nil, nil, false, diags
+	}
+	diags.Append(validateMaintenanceWindowMonitorIDsAutoAdd(monitorIDs, plan.AutoAddMonitors)...)
 	if diags.HasError() {
 		return nil, nil, false, diags
 	}
@@ -957,6 +946,56 @@ func maintenanceWindowMonitorIDsFromSet(ctx context.Context, value types.Set) ([
 		normalized = []int64{}
 	}
 	return normalized, diags
+}
+
+func maintenanceWindowMonitorIDsContainUnknown(value types.Set) bool {
+	if value.IsUnknown() {
+		return true
+	}
+	for _, element := range value.Elements() {
+		if element.IsUnknown() {
+			return true
+		}
+	}
+	return false
+}
+
+func validateMaintenanceWindowMonitorIDsAutoAdd(monitorIDs []int64, autoAddMonitors types.Bool) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if maintenanceWindowMonitorIDsContainAutoAdd(monitorIDs) && len(monitorIDs) > 1 {
+		diags.AddAttributeError(
+			path.Root("monitor_ids"),
+			"Invalid monitor_ids",
+			`"monitor_ids" can contain either specific monitor IDs or [0] to auto-add all monitors, but not both.`,
+		)
+		return diags
+	}
+
+	if autoAddMonitors.IsNull() || autoAddMonitors.IsUnknown() {
+		return diags
+	}
+
+	if autoAddMonitors.ValueBool() {
+		if len(monitorIDs) == 0 || !maintenanceWindowMonitorIDsAutoAdd(monitorIDs) {
+			diags.AddAttributeError(
+				path.Root("monitor_ids"),
+				"monitor_ids conflicts with auto_add_monitors",
+				`When "auto_add_monitors" is true, omit "monitor_ids" or set it to [0].`,
+			)
+		}
+		return diags
+	}
+
+	if maintenanceWindowMonitorIDsAutoAdd(monitorIDs) {
+		diags.AddAttributeError(
+			path.Root("auto_add_monitors"),
+			"auto_add_monitors conflicts with monitor_ids",
+			`When "monitor_ids" is [0], omit "auto_add_monitors" or set it to true.`,
+		)
+	}
+
+	return diags
 }
 
 func maintenanceWindowMonitorIDsSet(ctx context.Context, monitorIDs []int64) (types.Set, diag.Diagnostics) {

--- a/internal/provider/maintenancewindow/resource_test.go
+++ b/internal/provider/maintenancewindow/resource_test.go
@@ -261,6 +261,13 @@ func TestValidateRuleMonitorIDsAutoAddConflict(t *testing.T) {
 				MonitorIDs:      setInt64(123, 456),
 			},
 		},
+		{
+			name: "unknown_monitor_id_skips_validation",
+			cfg: maintenanceWindowResourceModel{
+				AutoAddMonitors: types.BoolValue(false),
+				MonitorIDs:      setInt64Values(types.Int64Unknown()),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -443,6 +450,72 @@ func TestApplyMaintenanceWindowMonitorIDsUpdate(t *testing.T) {
 			t.Fatalf("expected auto_add_monitors=false settle target, got=%v", expectedAutoAdd)
 		}
 	})
+
+	t.Run("rejects_unknown_plan_values_before_payload", func(t *testing.T) {
+		t.Parallel()
+
+		updateReq := &client.UpdateMaintenanceWindowRequest{}
+		monitorIDs, expectedAutoAdd, shouldWait, diags := applyMaintenanceWindowMonitorIDsUpdate(
+			ctx,
+			maintenanceWindowResourceModel{
+				AutoAddMonitors: types.BoolNull(),
+				MonitorIDs:      setInt64Values(types.Int64Unknown()),
+			},
+			maintenanceWindowResourceModel{
+				MonitorIDs: setInt64Values(types.Int64Unknown()),
+			},
+			updateReq,
+		)
+
+		if !diags.HasError() {
+			t.Fatal("expected diagnostics for unknown plan monitor_ids")
+		}
+		if shouldWait {
+			t.Fatal("did not expect settle wait for invalid monitor_ids plan")
+		}
+		if monitorIDs != nil {
+			t.Fatalf("expected no monitor IDs, got=%v", monitorIDs)
+		}
+		if updateReq.MonitorIDs != nil {
+			t.Fatalf("expected monitorIds payload to be omitted, got=%v", *updateReq.MonitorIDs)
+		}
+		if expectedAutoAdd != nil {
+			t.Fatalf("expected no auto_add_monitors settle target, got=%v", *expectedAutoAdd)
+		}
+	})
+
+	t.Run("rejects_resolved_auto_marker_with_specific_ids", func(t *testing.T) {
+		t.Parallel()
+
+		updateReq := &client.UpdateMaintenanceWindowRequest{}
+		monitorIDs, expectedAutoAdd, shouldWait, diags := applyMaintenanceWindowMonitorIDsUpdate(
+			ctx,
+			maintenanceWindowResourceModel{
+				AutoAddMonitors: types.BoolNull(),
+				MonitorIDs:      setInt64(0, 123),
+			},
+			maintenanceWindowResourceModel{
+				MonitorIDs: setInt64Values(types.Int64Unknown()),
+			},
+			updateReq,
+		)
+
+		if !diags.HasError() {
+			t.Fatal("expected diagnostics for invalid resolved monitor_ids")
+		}
+		if shouldWait {
+			t.Fatal("did not expect settle wait for invalid monitor_ids plan")
+		}
+		if monitorIDs != nil {
+			t.Fatalf("expected no monitor IDs, got=%v", monitorIDs)
+		}
+		if updateReq.MonitorIDs != nil {
+			t.Fatalf("expected monitorIds payload to be omitted, got=%v", *updateReq.MonitorIDs)
+		}
+		if expectedAutoAdd != nil {
+			t.Fatalf("expected no auto_add_monitors settle target, got=%v", *expectedAutoAdd)
+		}
+	})
 }
 
 func setInt64(values ...int64) types.Set {
@@ -450,6 +523,12 @@ func setInt64(values ...int64) types.Set {
 	for _, value := range values {
 		elements = append(elements, types.Int64Value(value))
 	}
+	return setInt64Values(elements...)
+}
+
+func setInt64Values(values ...attr.Value) types.Set {
+	elements := make([]attr.Value, 0, len(values))
+	elements = append(elements, values...)
 	return types.SetValueMust(types.Int64Type, elements)
 }
 

--- a/internal/provider/monitor/monitor_compare.go
+++ b/internal/provider/monitor/monitor_compare.go
@@ -797,7 +797,7 @@ func equalComparable(want, got monComparable) bool {
 	if want.Type != nil && (got.Type == nil || *want.Type != *got.Type) {
 		return false
 	}
-	if want.URL != nil && (got.URL == nil || *want.URL != *got.URL) {
+	if want.URL != nil && !equalComparableURL(want, got) {
 		return false
 	}
 	if want.Name != nil && (got.Name == nil || *want.Name != *got.Name) {
@@ -909,6 +909,14 @@ func equalComparable(want, got monComparable) bool {
 	return true
 }
 
+func equalComparableURL(want, got monComparable) bool {
+	if got.URL == nil {
+		return false
+	}
+	monitorType := comparableMonitorType(want, got)
+	return monitorURLsEquivalentForState(monitorType, *want.URL, *got.URL)
+}
+
 // fieldsStillDifferent shows different of what we wanted and what we got from the API for debugging and logging.
 func fieldsStillDifferent(want, got monComparable) []string {
 	var f []string
@@ -919,7 +927,7 @@ func fieldsStillDifferent(want, got monComparable) []string {
 	if want.Name != nil && (got.Name == nil || *want.Name != *got.Name) {
 		f = append(f, "name")
 	}
-	if want.URL != nil && (got.URL == nil || *want.URL != *got.URL) {
+	if want.URL != nil && !equalComparableURL(want, got) {
 		f = append(f, "url")
 	}
 	if want.Interval != nil && (got.Interval == nil || *want.Interval != *got.Interval) {

--- a/internal/provider/monitor/monitor_compare_test.go
+++ b/internal/provider/monitor/monitor_compare_test.go
@@ -90,6 +90,29 @@ func TestEqualComparable_UsesGroupID(t *testing.T) {
 	}
 }
 
+func TestEqualComparable_TreatsPingPortURLsWithoutSchemeAsEquivalent(t *testing.T) {
+	t.Parallel()
+
+	ping := MonitorTypePING
+	port := MonitorTypePORT
+	httpType := MonitorTypeHTTP
+	configured := "https://example.com/check"
+	apiURL := "example.com/check"
+
+	if !equalComparable(monComparable{Type: &ping, URL: &configured}, monComparable{Type: &ping, URL: &apiURL}) {
+		t.Fatal("expected PING URL with scheme to match API host-only URL")
+	}
+	if !equalComparable(monComparable{Type: &port, URL: &configured}, monComparable{Type: &port, URL: &apiURL}) {
+		t.Fatal("expected PORT URL with scheme to match API host-only URL")
+	}
+	if equalComparable(monComparable{Type: &httpType, URL: &configured}, monComparable{Type: &httpType, URL: &apiURL}) {
+		t.Fatal("did not expect HTTP URL with scheme to match host-only URL")
+	}
+	if diff := fieldsStillDifferent(monComparable{Type: &ping, URL: &configured}, monComparable{Type: &ping, URL: &apiURL}); len(diff) != 0 {
+		t.Fatalf("expected no differing fields for equivalent PING URLs, got %v", diff)
+	}
+}
+
 func TestEqualComparable_UsesCustomFields(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/monitor/monitor_crud_create.go
+++ b/internal/provider/monitor/monitor_crud_create.go
@@ -551,7 +551,7 @@ func (r *monitorResource) buildStateAfterCreate(
 	resp *resource.CreateResponse,
 ) monitorResourceModel {
 	plan.Name = types.StringValue(unescapeHTML(api.Name))
-	plan.URL = types.StringValue(unescapeHTML(api.URL))
+	plan.URL = monitorURLForState(plan.Type.ValueString(), plan.URL, api.URL)
 	plan.Status = types.StringValue(api.Status)
 	if !plan.IsPaused.IsNull() && !plan.IsPaused.IsUnknown() {
 		plan.IsPaused = types.BoolValue(isMonitorPausedStatus(api.Status))

--- a/internal/provider/monitor/monitor_crud_read.go
+++ b/internal/provider/monitor/monitor_crud_read.go
@@ -219,7 +219,7 @@ func readApplyKeywordAndPort(state *monitorResourceModel, m *client.Monitor, isI
 
 func readApplyIdentity(state *monitorResourceModel, m *client.Monitor) {
 	state.Name = types.StringValue(unescapeHTML(m.Name))
-	state.URL = types.StringValue(unescapeHTML(m.URL))
+	state.URL = monitorURLForState(state.Type.ValueString(), state.URL, m.URL)
 	state.ID = types.StringValue(strconv.FormatInt(m.ID, 10))
 	state.Status = types.StringValue(m.Status)
 }

--- a/internal/provider/monitor/monitor_crud_update.go
+++ b/internal/provider/monitor/monitor_crud_update.go
@@ -733,7 +733,7 @@ func applyUpdatedMonitorToState(
 ) monitorResourceModel {
 	out := plan
 	out.Name = types.StringValue(unescapeHTML(m.Name))
-	out.URL = types.StringValue(unescapeHTML(m.URL))
+	out.URL = monitorURLForState(plan.Type.ValueString(), plan.URL, m.URL)
 	out.Status = prev.Status
 	if !plan.IsPaused.IsNull() && !plan.IsPaused.IsUnknown() {
 		out.IsPaused = types.BoolValue(isMonitorPausedStatus(m.Status))

--- a/internal/provider/monitor/monitor_transform.go
+++ b/internal/provider/monitor/monitor_transform.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -706,6 +707,42 @@ func normalizeIPVersionForAPI(in string) (string, bool) {
 	default:
 		return "", false
 	}
+}
+
+func monitorURLForState(monitorType string, configured types.String, apiURL string) types.String {
+	apiURL = unescapeHTML(apiURL)
+	if configured.IsNull() || configured.IsUnknown() {
+		return types.StringValue(apiURL)
+	}
+
+	configuredURL := unescapeHTML(configured.ValueString())
+	if monitorURLsEquivalentForState(monitorType, configuredURL, apiURL) {
+		return types.StringValue(configuredURL)
+	}
+
+	return types.StringValue(apiURL)
+}
+
+func monitorURLsEquivalentForState(monitorType, configuredURL, apiURL string) bool {
+	switch strings.ToUpper(strings.TrimSpace(monitorType)) {
+	case MonitorTypePING, MonitorTypePORT:
+		return monitorURLTargetWithoutScheme(configuredURL) == monitorURLTargetWithoutScheme(apiURL)
+	default:
+		return strings.TrimSpace(configuredURL) == strings.TrimSpace(apiURL)
+	}
+}
+
+func monitorURLTargetWithoutScheme(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(raw)
+	if err == nil && parsed.Scheme != "" && parsed.Host != "" {
+		return parsed.Host + parsed.RequestURI()
+	}
+	return raw
 }
 
 // setStringsRespectingShape keeps empty-set vs null consistent with user's intent.

--- a/internal/provider/monitor/monitor_transform_test.go
+++ b/internal/provider/monitor/monitor_transform_test.go
@@ -203,6 +203,80 @@ func TestBuildCreateRequest_HeartbeatOmitsURL(t *testing.T) {
 	}
 }
 
+func TestBuildStateAfterCreate_PingPreservesEquivalentConfiguredURL(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	plan := monitorResourceModel{
+		Type:     types.StringValue(MonitorTypePING),
+		Name:     types.StringValue("ping"),
+		URL:      types.StringValue("https://example.com/ping"),
+		Interval: types.Int64Value(300),
+	}
+	resp := &resource.CreateResponse{}
+
+	got := (&monitorResource{}).buildStateAfterCreate(ctx, plan, &client.Monitor{
+		Name:    "ping",
+		URL:     "example.com/ping",
+		Type:    MonitorTypePING,
+		Status:  "STARTED",
+		Timeout: 30,
+	}, "", resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
+	}
+	if got.URL.ValueString() != "https://example.com/ping" {
+		t.Fatalf("expected configured URL to be preserved, got %q", got.URL.ValueString())
+	}
+}
+
+func TestApplyUpdatedMonitorToState_PortPreservesEquivalentConfiguredURL(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	plan := monitorResourceModel{
+		Type:     types.StringValue(MonitorTypePORT),
+		Name:     types.StringValue("port"),
+		URL:      types.StringValue("https://example.com/port"),
+		Interval: types.Int64Value(300),
+	}
+	resp := &resource.UpdateResponse{}
+
+	got := applyUpdatedMonitorToState(ctx, plan, monitorResourceModel{}, &client.Monitor{
+		Name:    "port",
+		URL:     "example.com/port",
+		Type:    MonitorTypePORT,
+		Status:  "STARTED",
+		Timeout: 30,
+	}, "", false, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %+v", resp.Diagnostics)
+	}
+	if got.URL.ValueString() != "https://example.com/port" {
+		t.Fatalf("expected configured URL to be preserved, got %q", got.URL.ValueString())
+	}
+}
+
+func TestReadApplyIdentity_PingPreservesEquivalentConfiguredURL(t *testing.T) {
+	t.Parallel()
+
+	state := monitorResourceModel{
+		Type: types.StringValue(MonitorTypePING),
+		URL:  types.StringValue("https://example.com/ping"),
+	}
+
+	readApplyIdentity(&state, &client.Monitor{
+		ID:     123,
+		Name:   "ping",
+		URL:    "example.com/ping",
+		Status: "STARTED",
+	})
+
+	if state.URL.ValueString() != "https://example.com/ping" {
+		t.Fatalf("expected configured URL to be preserved, got %q", state.URL.ValueString())
+	}
+}
+
 func TestBuildCreateRequest_CustomFields(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Fix `uptimerobot_maintenance_window.monitor_ids` validation when IDs reference monitors created in the same Terraform run.
- Skip auto-add sentinel inference while `monitor_ids` contains unknown values, then keep the same conflict checks once values are resolved before create/update payloads are sent.
- Preserve equivalent configured PING and PORT monitor URLs when UptimeRobot returns host-only targets, including the update settle comparison used by acceptance tests.
- Add focused unit coverage for unknown monitor IDs, invalid resolved monitor ID combinations, and PING/PORT URL equivalence.

Resolves #264.