### PR TITLE
docs: refresh provider documentation for 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,22 @@
 ## Unreleased
 
+## 1.9.1 — 2026-07-01
+
+### Changed
+
+- Updated the Go toolchain directive to 1.26.4.
+
 ### Fixed
 
 - Fixed MS Teams integration creation by correcting the `type` API payload from `"MS Teams"` to `"MSTeams"`.
 - Fixed Google Chat integration create/update requests to use the API v3 enum key expected by UptimeRobot.
 - Fixed `uptimerobot_maintenance_window.monitor_ids` validation when IDs reference monitors created in the same Terraform run.
 - Fixed PING and PORT monitor URL state consistency when UptimeRobot returns host-only targets.
+
+### Documentation
+
+- Updated README and provider examples to use the 1.9.1 provider version constraint.
+- Aligned contributor documentation and manual Terraform examples with the current Go toolchain, acceptance-test commands, and provider schema.
 
 ## 1.9.0 — 2026-06-19
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thanks for helping improve the provider! This doc shows how to build, test, and propose changes.
 
 ## Prerequisites
-- Go **1.24.x**
+- Go version from `go.mod` (currently **1.26.4**)
 - Terraform **≥ 1.5** or OpenTofu **≥ 1.7**
 - UptimeRobot **v3** API key (for acceptance tests)
 
@@ -53,6 +53,9 @@ Example:
 ## Running tests
 
 ### Unit tests
+`make test`
+
+For a race-enabled run:
 `go test ./... -race`
 
 ### Acceptance tests with real API interaction
@@ -67,10 +70,10 @@ Use `make testacc` to run whole test suite
 
 They can be slow and sometimes flaky due to network and API interactions and connections.
 Or use
-`go test ./internal/provider -run 'Acc' -v -timeout 45m -parallel=1`
+`go test ./internal/provider/... -tags=acceptance -run '^TestAcc' -v -timeout 60m -p=1 -parallel=1`
 
 ### Single test execution
-`go test ./internal/provider -run '^TestAcc_Monitor_Name_HTMLNormalization$' -v -timeout 45m -parallel=1`
+`go test ./internal/provider/monitor -tags=acceptance -run '^TestAcc_Monitor_NameURL_HTMLNormalization$' -v -timeout 60m -p=1 -parallel=1`
 
 ## Debugging
 - Terraform/OpenTofu logs:

--- a/PRE_COMMIT_SETUP.md
+++ b/PRE_COMMIT_SETUP.md
@@ -2,9 +2,9 @@
 
 This project has pre-commit hooks configured to automatically run linting and code generation before each commit. There are two ways to use pre-commit hooks:
 
-## Option 1: Simple Git Hook (Already Active)
+## Option 1: Makefile Checks
 
-The simple git hook is already installed and active at `.git/hooks/pre-commit`. It will automatically run before each commit and includes:
+Run the same checks CI expects before opening a PR:
 
 - `go generate ./...` - Runs code generation
 - `go mod tidy` - Tidies Go modules
@@ -12,9 +12,7 @@ The simple git hook is already installed and active at `.git/hooks/pre-commit`. 
 - `golangci-lint run` - Runs comprehensive linting
 - `go test ./... -short` - Runs unit tests
 
-### Manual Commands
-
-You can also run the same checks manually using the Makefile:
+Use the Makefile:
 
 ```bash
 # Run all pre-commit checks

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     uptimerobot = {
       source  = "uptimerobot/uptimerobot"
-      version = "~> 1.3.0"
+      version = "~> 1.9.1"
     }
   }
 }
@@ -56,7 +56,7 @@ terraform {
   required_providers {
     uptimerobot = {
       source  = "uptimerobot/uptimerobot"
-      version = "~> 1.3.0"
+      version = "~> 1.9.1"
     }
   }
 }
@@ -122,7 +122,7 @@ Detailed documentation for the data sources supported by this provider can be fo
 
 ## Developing the Provider
 
-If you wish to work on the provider, you'll first need [Go](https://golang.org/doc/install) installed on your machine (version 1.24 or higher is recommended).
+If you wish to work on the provider, you'll first need [Go](https://golang.org/doc/install) installed on your machine. Use the version declared in `go.mod` (currently 1.26.4), which is also what CI uses.
 
 ### Building The Provider
 
@@ -156,11 +156,13 @@ provider_installation {
 
 ### Generating Documentation
 
-If you have `tfplugindocs` installed, you can generate or update documentation by running:
+Generate or update registry documentation by running:
 
 ```shell
-go generate
+go generate ./...
 ```
+
+This formats Terraform examples and regenerates the files in `docs/` from the provider schema and templates.
 
 ### Running Acceptance Tests
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     uptimerobot = {
       source  = "uptimerobot/uptimerobot"
-      version = "~> 0.1.0"
+      version = "~> 1.9.1"
     }
   }
 }

--- a/docs/resources/maintenance_window.md
+++ b/docs/resources/maintenance_window.md
@@ -73,7 +73,7 @@ resource "uptimerobot_maintenance_window" "server_migration" {
   name     = "Server Migration"
   interval = "once"
   duration = 240 # 4 hours
-  date     = "2024-12-15"
+  date     = "2030-12-15"
   time     = "01:00:00"
 
   auto_add_monitors = false
@@ -83,7 +83,7 @@ resource "uptimerobot_maintenance_window" "emergency_patch" {
   name     = "Emergency Security Patch"
   interval = "once"
   duration = 60
-  date     = "2024-08-20"
+  date     = "2030-08-20"
   time     = "23:00:00"
 
   auto_add_monitors = true

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -65,7 +65,7 @@ resource "uptimerobot_monitor" "api_health" {
   interval = 60
 
   # Look for "healthy" in the response
-  keyword_type  = "exists"
+  keyword_type  = "ALERT_EXISTS"
   keyword_value = "healthy"
 
   # Case insensitive search (default)
@@ -112,7 +112,6 @@ resource "uptimerobot_monitor" "protected_api" {
   http_method_type = "POST"
 
   # POST data
-  post_value_type = "JSON"
   post_value_data = jsonencode({
     action = "health_check"
     source = "uptime_monitor"

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,8 +2,8 @@
 
 This directory contains examples that are mostly used for documentation, but can also be run/tested manually via the Terraform CLI.
 
-The document generation tool looks for files in the following locations by default. All other *.tf files besides the ones mentioned below are ignored by the documentation tool. This is useful for creating examples that can run and/or ar testable even if some parts are not relevant for the documentation.
+The document generation tool looks for files in the following locations by default. All other `*.tf` files besides the ones mentioned below are ignored by the documentation tool. This is useful for creating examples that can run and/or are testable even if some parts are not relevant for the documentation.
 
 * **provider/provider.tf** example file for the provider index page
 * **data-sources/`full data source name`/data-source.tf** example file for the named data source page
-* **resources/`full resource name`/resource.tf** example file for the named data source page
+* **resources/`full resource name`/resource.tf** example file for the named resource page

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     uptimerobot = {
       source  = "uptimerobot/uptimerobot"
-      version = "~> 0.1.0"
+      version = "~> 1.9.1"
     }
   }
 }

--- a/examples/resources/uptimerobot_maintenance_window/onetime.tf
+++ b/examples/resources/uptimerobot_maintenance_window/onetime.tf
@@ -2,7 +2,7 @@ resource "uptimerobot_maintenance_window" "server_migration" {
   name     = "Server Migration"
   interval = "once"
   duration = 240 # 4 hours
-  date     = "2024-12-15"
+  date     = "2030-12-15"
   time     = "01:00:00"
 
   auto_add_monitors = false
@@ -12,7 +12,7 @@ resource "uptimerobot_maintenance_window" "emergency_patch" {
   name     = "Emergency Security Patch"
   interval = "once"
   duration = 60
-  date     = "2024-08-20"
+  date     = "2030-08-20"
   time     = "23:00:00"
 
   auto_add_monitors = true

--- a/examples/resources/uptimerobot_monitor/auth.tf
+++ b/examples/resources/uptimerobot_monitor/auth.tf
@@ -14,7 +14,6 @@ resource "uptimerobot_monitor" "protected_api" {
   http_method_type = "POST"
 
   # POST data
-  post_value_type = "JSON"
   post_value_data = jsonencode({
     action = "health_check"
     source = "uptime_monitor"

--- a/examples/resources/uptimerobot_monitor/keyword.tf
+++ b/examples/resources/uptimerobot_monitor/keyword.tf
@@ -5,7 +5,7 @@ resource "uptimerobot_monitor" "api_health" {
   interval = 60
 
   # Look for "healthy" in the response
-  keyword_type  = "exists"
+  keyword_type  = "ALERT_EXISTS"
   keyword_value = "healthy"
 
   # Case insensitive search (default)

--- a/examples/test/main.tf
+++ b/examples/test/main.tf
@@ -1,14 +1,20 @@
 terraform {
   required_providers {
     uptimerobot = {
-      source  = "local/providers/uptimerobot"
-      version = "1.0.0"
+      source  = "uptimerobot/uptimerobot"
+      version = "~> 1.9.1"
     }
   }
 }
 
 provider "uptimerobot" {
-  api_key = "your-api-key" # Replace with your actual API key
+  api_key = var.uptimerobot_api_key
+}
+
+variable "uptimerobot_api_key" {
+  description = "UptimeRobot API key"
+  type        = string
+  sensitive   = true
 }
 
 # Test Monitor Resource
@@ -32,10 +38,9 @@ resource "uptimerobot_monitor" "heartbeat" {
 
 # Test PSP Resource
 resource "uptimerobot_psp" "test" {
-  name     = "Test PSP"
-  type     = "public"
-  sort     = "name-asc"
-  monitors = [uptimerobot_monitor.test.id]
+  name         = "Test PSP"
+  monitor_sort = "friendly_name_asc"
+  monitor_ids  = [uptimerobot_monitor.test.id]
 }
 
 output "heartbeat_url" {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/uptimerobot/terraform-provider-uptimerobot
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.25.0

--- a/test-uptimerobot/main.tf
+++ b/test-uptimerobot/main.tf
@@ -1,13 +1,25 @@
 terraform {
   required_providers {
     uptimerobot = {
-      source = "uptimerobot/uptimerobot"
-      version = "1.0.0"
+      source  = "uptimerobot/uptimerobot"
+      version = "~> 1.9.1"
     }
   }
 }
 
 provider "uptimerobot" {
-  api_key  = "524ce7d7fe8f647ddbbc419f"
-  api_url = "http://localhost:3000"
+  api_key = var.uptimerobot_api_key
+  api_url = var.uptimerobot_api_url
+}
+
+variable "uptimerobot_api_key" {
+  description = "UptimeRobot API key"
+  type        = string
+  sensitive   = true
+}
+
+variable "uptimerobot_api_url" {
+  description = "UptimeRobot API URL. Override this for local API testing."
+  type        = string
+  default     = "https://api.uptimerobot.com/v3"
 }

--- a/test-uptimerobot/test.tf
+++ b/test-uptimerobot/test.tf
@@ -1,10 +1,10 @@
 # Example HTTP monitor with extended configuration
 resource "uptimerobot_monitor" "http_test" {
-  name                     = "HTTP Monitor Test"
-  type                     = "HTTP"
-  url                      = "https://google.com"
-  interval                 = 300
-  timeout                  = 30
+  name                    = "HTTP Monitor Test"
+  type                    = "HTTP"
+  url                     = "https://google.com"
+  interval                = 300
+  timeout                 = 30
   http_method_type        = "GET"
   follow_redirections     = true
   ssl_expiration_reminder = true
@@ -12,15 +12,15 @@ resource "uptimerobot_monitor" "http_test" {
 
 # Example Keyword monitor
 resource "uptimerobot_monitor" "keyword_test" {
-  name             = "Keyword Monitor Test"
-  type             = "KEYWORD"
-  url              = "https://example.com"
-  interval         = 300
-  keyword_type     = "ALERT_EXISTS"
-  keyword_value    = "Example Domain"
+  name              = "Keyword Monitor Test"
+  type              = "KEYWORD"
+  url               = "https://example.com"
+  interval          = 300
+  keyword_type      = "ALERT_EXISTS"
+  keyword_value     = "Example Domain"
   keyword_case_type = "CaseInsensitive"
-  http_method_type = "GET"
-  timeout          = 30
+  http_method_type  = "GET"
+  timeout           = 30
 }
 
 # Example Port monitor
@@ -35,8 +35,8 @@ resource "uptimerobot_monitor" "port_test" {
 
 # Example PSP (Public Status Page)
 resource "uptimerobot_psp" "test_page" {
-  name           = "Test Status Page"
-  monitor_ids    = [
+  name = "Test Status Page"
+  monitor_ids = [
     uptimerobot_monitor.http_test.id,
     uptimerobot_monitor.keyword_test.id,
     uptimerobot_monitor.port_test.id
@@ -49,18 +49,18 @@ resource "uptimerobot_psp" "test_page" {
 resource "uptimerobot_maintenance_window" "weekly_maintenance" {
   name              = "Weekly Maintenance"
   interval          = "weekly"
-  time              = "22:00:00"    # 10 PM
-  duration          = 120           # 2 hours
+  time              = "22:00:00" # 10 PM
+  duration          = 120        # 2 hours
   auto_add_monitors = true
-  days              = [1]          # Monday
+  days              = [1] # Monday
 }
 
 # Example Maintenance Window (Once)
 resource "uptimerobot_maintenance_window" "one_time_maintenance" {
   name              = "One-time Maintenance"
   interval          = "once"
-  date              = "2025-03-01"
-  time              = "03:00:00"    # Including seconds as required
-  duration          = 180          # 3 hours
+  date              = "2030-03-01"
+  time              = "03:00:00" # Including seconds as required
+  duration          = 180        # 3 hours
   auto_add_monitors = false
 }


### PR DESCRIPTION
## Summary

- Prepare changelog and documentation for the 1.9.1 release.
- Update README, generated provider docs, and examples to use the 1.9.1 provider constraint.
- Align Go toolchain references and go.mod with Go 1.26.4.
- Refresh generated docs and clean up stale manual examples.