### PR TITLE
feat: accept QUERY as http_method_type

### DIFF
--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -741,7 +741,7 @@ terraform import 'uptimerobot_monitor.monitors["www_production"]' 800123456
 - `follow_redirections` (Boolean) Whether to follow redirections
 - `grace_period` (Number) The grace period (in seconds). Only for HEARTBEAT monitors
 - `group_id` (Number) Monitor group ID to assign monitor to. Use 0 for default group.
-- `http_method_type` (String) The HTTP method type (HEAD, GET, POST, PUT, PATCH, DELETE, OPTIONS). HEAD is not supported for API monitors; use HTTP monitors for status/header-only HEAD checks.
+- `http_method_type` (String) The HTTP method type (HEAD, GET, POST, PUT, PATCH, DELETE, OPTIONS, QUERY). HEAD is not supported for API monitors; use HTTP monitors for status/header-only HEAD checks.
 - `http_password` (String, Sensitive) The password for HTTP authentication
 - `http_username` (String) The username for HTTP authentication
 - `is_paused` (Boolean) Controls monitor run state. Set true to pause, false to start. Omit to preserve remote state (unmanaged).

--- a/internal/provider/monitor/monitor_http_method_schema_test.go
+++ b/internal/provider/monitor/monitor_http_method_schema_test.go
@@ -1,0 +1,60 @@
+package monitor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func httpMethodTypeValidators(t *testing.T) []validator.String {
+	t.Helper()
+
+	resp := &resource.SchemaResponse{}
+	(&monitorResource{}).Schema(context.Background(), resource.SchemaRequest{}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected schema diagnostics: %+v", resp.Diagnostics)
+	}
+
+	attr, ok := resp.Schema.Attributes["http_method_type"].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("http_method_type is not a StringAttribute")
+	}
+	return attr.Validators
+}
+
+func validateHTTPMethodValue(t *testing.T, value string) bool {
+	t.Helper()
+
+	req := validator.StringRequest{
+		Path:        path.Root("http_method_type"),
+		ConfigValue: types.StringValue(value),
+	}
+	resp := &validator.StringResponse{}
+	for _, v := range httpMethodTypeValidators(t) {
+		v.ValidateString(context.Background(), req, resp)
+	}
+	return !resp.Diagnostics.HasError()
+}
+
+func TestHTTPMethodTypeSchemaAcceptsAllSupportedMethods(t *testing.T) {
+	t.Parallel()
+
+	for _, method := range []string{"HEAD", "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "QUERY"} {
+		if !validateHTTPMethodValue(t, method) {
+			t.Errorf("expected %s to pass http_method_type validation", method)
+		}
+	}
+}
+
+func TestHTTPMethodTypeSchemaRejectsUnknownMethod(t *testing.T) {
+	t.Parallel()
+
+	if validateHTTPMethodValue(t, "TRACE") {
+		t.Errorf("expected TRACE to fail http_method_type validation")
+	}
+}

--- a/internal/provider/monitor/monitor_schema.go
+++ b/internal/provider/monitor/monitor_schema.go
@@ -198,11 +198,11 @@ func monitorSchema(version int64, includeApplicationErrorRetries bool) schema.Sc
 				},
 			},
 			"http_method_type": schema.StringAttribute{
-				Description: "The HTTP method type (HEAD, GET, POST, PUT, PATCH, DELETE, OPTIONS). HEAD is not supported for API monitors; use HTTP monitors for status/header-only HEAD checks.",
+				Description: "The HTTP method type (HEAD, GET, POST, PUT, PATCH, DELETE, OPTIONS, QUERY). HEAD is not supported for API monitors; use HTTP monitors for status/header-only HEAD checks.",
 				Optional:    true,
 				Computed:    true,
 				Validators: []validator.String{
-					stringvalidator.OneOf("HEAD", "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"),
+					stringvalidator.OneOf("HEAD", "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "QUERY"),
 				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),


### PR DESCRIPTION
## Summary
- Add `"QUERY"` to the `http_method_type` OneOf validator and attribute description in the monitor resource schema
- `docs/resources/monitor.md` regenerated via tfplugindocs
- Deliberate skip: the four historical OneOf copies in `monitor_upgrade.go` prior schemas — no pre-upgrade state can contain QUERY before this release
- Request-body semantics: QUERY falls into the existing non-GET/HEAD branches like POST; the provider's own API-monitor rule (HEAD rejected, `validateAPIHTTPMethodType`) leaves QUERY permitted

## Tests (RED → GREEN)
New `monitor_http_method_schema_test.go` exercises the real schema's validators: acceptance table for all 8 methods (QUERY failed pre-change) + TRACE rejection guard.

## Deploy order
Release only after platform-side API support for the QUERY method is live in production.

## Quality gate
- `go test ./...` green (acceptance tests skip without `TF_ACC`, as designed); `go vet` clean
- `go generate` note: the `terraform fmt` directive can't run locally (no terraform binary) — examples untouched by this change; tfplugindocs ran directly
- Mutation pass (manual): removing `"QUERY"` from OneOf is killed by the acceptance-table test; widening beyond the set is killed by the TRACE guard; description drift is caught by tfplugindocs regeneration in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `QUERY` HTTP method in monitor configuration.
  * Updated the documentation for supported HTTP methods to reflect the new option.

* **Bug Fixes**
  * Improved validation so supported HTTP methods are accepted correctly, while unsupported methods continue to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
