### PR TITLE
docs: changelog entry for QUERY http_method_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Added
+
+- `http_method_type` now accepts `QUERY` on monitor resources.
+
 ## 1.9.1 — 2026-07-01
 
 ### Changed


### PR DESCRIPTION
## Summary
Documentation-update phase for QUERY `http_method_type` support. The resource documentation was already regenerated via tfplugindocs in #267; the only remaining gap in this repository was the changelog entry under `## Unreleased`, added here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `http_method_type` now supports `QUERY` for monitor resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
