### PR TITLE
docs: remove internal Go update changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 ## Unreleased
 
-### Changed
-
-- Updated the Go toolchain directive to 1.26.5 and refreshed Go module dependencies.
-
 ## 1.9.1 — 2026-07-01
 
 ### Changed


### PR DESCRIPTION
## Summary
- Remove the Unreleased changelog entry for the Go 1.26.5/dependency refresh.
- Keep the changelog header in place for future user-facing release notes.

## Validation
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed an outdated unreleased changelog entry about Go toolchain and dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->