### PR TITLE
fix: adopt monitor into state when create errors but the monitor was created

### DIFF
--- a/internal/client/monitor.go
+++ b/internal/client/monitor.go
@@ -255,7 +255,7 @@ func (c *Client) CreateMonitor(ctx context.Context, req *CreateMonitorRequest) (
 	base := NewBaseCRUDOperations(c, "/monitors")
 	var monitor Monitor
 	if err := base.doCreate(ctx, req, &monitor); err != nil {
-		return nil, fmt.Errorf("failed to create monitor: %v", err)
+		return nil, fmt.Errorf("failed to create monitor: %w", err)
 	}
 	return &monitor, nil
 }

--- a/internal/provider/monitor/monitor_create_recover_test.go
+++ b/internal/provider/monitor/monitor_create_recover_test.go
@@ -47,9 +47,9 @@ func TestRecoverMonitorCreatedDespiteErrorAdopts(t *testing.T) {
 			],"nextCursorId":null}`,
 			wantID: 101,
 		},
-		"5xx on http create with matching url": {
-			createStatus: http.StatusInternalServerError,
-			createBody:   `{"message":"Internal Server Error","statusCode":500}`,
+		"404 on http create with matching url and different code": {
+			createStatus: http.StatusNotFound,
+			createBody:   `{"message":"Monitor not found","code":"000-004"}`,
 			createReq: &client.CreateMonitorRequest{
 				Name:     "api-prod",
 				Type:     client.MonitorType("HTTP"),
@@ -101,6 +101,51 @@ func TestRecoverMonitorCreatedDespiteErrorAdopts(t *testing.T) {
 				t.Fatalf("expected no error diagnostics, got %v", diags)
 			}
 		})
+	}
+}
+
+func TestRecoverMonitorCreatedDespiteErrorDoesNotAdoptGeneric5xx(t *testing.T) {
+	t.Parallel()
+
+	// Reproduces #273: an invalid HEARTBEAT interval (3,888,000s) was
+	// rejected with a 500 but the API persisted it anyway. A generic 500 must
+	// never be auto-adopted, even when exactly one matching monitor is
+	// found, because that monitor's settings can't be trusted.
+	r := newRecoverTestResource(t, func(w http.ResponseWriter, req *http.Request) {
+		switch {
+		case req.Method == http.MethodPost && req.URL.Path == "/monitors":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"Internal Server Error"}`))
+		case req.Method == http.MethodGet && req.URL.Path == "/monitors":
+			_, _ = w.Write([]byte(`{"data":[
+				{"id":301,"friendlyName":"prod-heartbeat","type":"HEARTBEAT","url":"https://heartbeat.uptimerobot.com/token"}
+			],"nextCursorId":null}`))
+		default:
+			t.Errorf("unexpected request %s %s", req.Method, req.URL.RequestURI())
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+
+	createReq := &client.CreateMonitorRequest{
+		Name:     "prod-heartbeat",
+		Type:     client.MonitorType("HEARTBEAT"),
+		Interval: 3888000,
+	}
+
+	_, createErr := r.client.CreateMonitor(context.Background(), createReq)
+	if createErr == nil {
+		t.Fatal("expected create to fail, got nil error")
+	}
+
+	var diags diag.Diagnostics
+	if adopted := r.recoverMonitorCreatedDespiteError(context.Background(), createReq, createErr, &diags); adopted != nil {
+		t.Fatalf("expected no adoption for generic 5xx, got monitor id %d", adopted.ID)
+	}
+	if diags.WarningsCount() != 1 {
+		t.Fatalf("expected 1 hint warning diagnostic, got %d: %v", diags.WarningsCount(), diags)
+	}
+	if diags.HasError() {
+		t.Fatalf("expected no error diagnostics, got %v", diags)
 	}
 }
 

--- a/internal/provider/monitor/monitor_create_recover_test.go
+++ b/internal/provider/monitor/monitor_create_recover_test.go
@@ -1,0 +1,159 @@
+package monitor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/uptimerobot/terraform-provider-uptimerobot/internal/client"
+)
+
+func newRecoverTestResource(t *testing.T, handler http.HandlerFunc) *monitorResource {
+	t.Helper()
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	apiClient := client.NewClient("test-key")
+	apiClient.SetBaseURL(srv.URL)
+	return &monitorResource{client: apiClient}
+}
+
+func TestRecoverMonitorCreatedDespiteError404(t *testing.T) {
+	t.Parallel()
+
+	r := newRecoverTestResource(t, func(w http.ResponseWriter, req *http.Request) {
+		switch {
+		case req.Method == http.MethodPost && req.URL.Path == "/monitors":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"Monitor not found","code":"000-004"}`))
+		case req.Method == http.MethodGet && req.URL.Path == "/monitors":
+			// The API name filter matches substrings, so include a near-match
+			// to prove the recovery only adopts the exact name.
+			_, _ = w.Write([]byte(`{"data":[
+				{"id":102,"friendlyName":"prod-process-sectionals-extra","type":"HEARTBEAT","url":"https://heartbeat.uptimerobot.com/other"},
+				{"id":101,"friendlyName":"prod-process-sectionals","type":"HEARTBEAT","url":"https://heartbeat.uptimerobot.com/token"}
+			],"nextCursorId":null}`))
+		default:
+			t.Errorf("unexpected request %s %s", req.Method, req.URL.RequestURI())
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+
+	createReq := &client.CreateMonitorRequest{
+		Name:     "prod-process-sectionals",
+		Type:     client.MonitorType("HEARTBEAT"),
+		Interval: 3600,
+	}
+
+	_, createErr := r.client.CreateMonitor(context.Background(), createReq)
+	if createErr == nil {
+		t.Fatal("expected create to fail, got nil error")
+	}
+
+	var diags diag.Diagnostics
+	adopted := r.recoverMonitorCreatedDespiteError(context.Background(), createReq, createErr, &diags)
+	if adopted == nil {
+		t.Fatal("expected monitor to be adopted, got nil")
+	}
+	if adopted.ID != 101 {
+		t.Fatalf("expected adopted monitor id 101, got %d", adopted.ID)
+	}
+	if diags.WarningsCount() != 1 {
+		t.Fatalf("expected 1 warning diagnostic, got %d: %v", diags.WarningsCount(), diags)
+	}
+	if diags.HasError() {
+		t.Fatalf("expected no error diagnostics, got %v", diags)
+	}
+}
+
+func TestRecoverMonitorCreatedDespiteErrorSkipsCleanValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	r := newRecoverTestResource(t, func(w http.ResponseWriter, req *http.Request) {
+		switch {
+		case req.Method == http.MethodPost && req.URL.Path == "/monitors":
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"Validation failed"}`))
+		default:
+			// A clean 4xx means the create genuinely failed; recovery must
+			// not even look the monitor up.
+			t.Errorf("unexpected request %s %s", req.Method, req.URL.RequestURI())
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+
+	createReq := &client.CreateMonitorRequest{
+		Name:     "prod-process-sectionals",
+		Type:     client.MonitorType("HEARTBEAT"),
+		Interval: 3600,
+	}
+
+	_, createErr := r.client.CreateMonitor(context.Background(), createReq)
+	if createErr == nil {
+		t.Fatal("expected create to fail, got nil error")
+	}
+
+	var diags diag.Diagnostics
+	if adopted := r.recoverMonitorCreatedDespiteError(context.Background(), createReq, createErr, &diags); adopted != nil {
+		t.Fatalf("expected no adoption for validation error, got monitor id %d", adopted.ID)
+	}
+	if diags.WarningsCount() != 0 {
+		t.Fatalf("expected no warning diagnostics, got %v", diags)
+	}
+}
+
+func TestRecoverMonitorCreatedDespiteErrorRequiresExactlyOneMatch(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"no exact match": `{"data":[
+			{"id":102,"friendlyName":"prod-process-sectionals-extra","type":"HEARTBEAT","url":""}
+		],"nextCursorId":null}`,
+		"multiple exact matches": `{"data":[
+			{"id":101,"friendlyName":"prod-process-sectionals","type":"HEARTBEAT","url":""},
+			{"id":103,"friendlyName":"prod-process-sectionals","type":"HEARTBEAT","url":""}
+		],"nextCursorId":null}`,
+		"exact name but different type": `{"data":[
+			{"id":104,"friendlyName":"prod-process-sectionals","type":"HTTP","url":"https://example.com"}
+		],"nextCursorId":null}`,
+	}
+
+	for name, listBody := range cases {
+		listBody := listBody
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			r := newRecoverTestResource(t, func(w http.ResponseWriter, req *http.Request) {
+				switch {
+				case req.Method == http.MethodPost && req.URL.Path == "/monitors":
+					w.WriteHeader(http.StatusNotFound)
+					_, _ = w.Write([]byte(`{"message":"Monitor not found","code":"000-004"}`))
+				case req.Method == http.MethodGet && req.URL.Path == "/monitors":
+					_, _ = w.Write([]byte(listBody))
+				default:
+					t.Errorf("unexpected request %s %s", req.Method, req.URL.RequestURI())
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			})
+
+			createReq := &client.CreateMonitorRequest{
+				Name:     "prod-process-sectionals",
+				Type:     client.MonitorType("HEARTBEAT"),
+				Interval: 3600,
+			}
+
+			_, createErr := r.client.CreateMonitor(context.Background(), createReq)
+			if createErr == nil {
+				t.Fatal("expected create to fail, got nil error")
+			}
+
+			var diags diag.Diagnostics
+			if adopted := r.recoverMonitorCreatedDespiteError(context.Background(), createReq, createErr, &diags); adopted != nil {
+				t.Fatalf("expected no adoption, got monitor id %d", adopted.ID)
+			}
+		})
+	}
+}

--- a/internal/provider/monitor/monitor_create_recover_test.go
+++ b/internal/provider/monitor/monitor_create_recover_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -97,6 +99,9 @@ func TestRecoverMonitorCreatedDespiteErrorAdopts(t *testing.T) {
 			if diags.WarningsCount() != 1 {
 				t.Fatalf("expected 1 warning diagnostic, got %d: %v", diags.WarningsCount(), diags)
 			}
+			if !strings.Contains(diags[0].Detail(), strconv.FormatInt(tc.wantID, 10)) {
+				t.Fatalf("expected warning to mention adopted monitor id %d, got: %s", tc.wantID, diags[0].Detail())
+			}
 			if diags.HasError() {
 				t.Fatalf("expected no error diagnostics, got %v", diags)
 			}
@@ -143,6 +148,10 @@ func TestRecoverMonitorCreatedDespiteErrorDoesNotAdoptGeneric5xx(t *testing.T) {
 	}
 	if diags.WarningsCount() != 1 {
 		t.Fatalf("expected 1 hint warning diagnostic, got %d: %v", diags.WarningsCount(), diags)
+	}
+	const wantID = 301
+	if !strings.Contains(diags[0].Detail(), strconv.Itoa(wantID)) {
+		t.Fatalf("expected hint warning to mention candidate monitor id %d, got: %s", wantID, diags[0].Detail())
 	}
 	if diags.HasError() {
 		t.Fatalf("expected no error diagnostics, got %v", diags)

--- a/internal/provider/monitor/monitor_create_recover_test.go
+++ b/internal/provider/monitor/monitor_create_recover_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -63,6 +64,33 @@ func TestRecoverMonitorCreatedDespiteErrorAdopts(t *testing.T) {
 			],"nextCursorId":null}`,
 			wantID: 201,
 		},
+		"404 with HTML-escaped name": {
+			createStatus: http.StatusNotFound,
+			createBody:   `{"message":"Monitor not found","code":"000-004"}`,
+			createReq: &client.CreateMonitorRequest{
+				Name:     "A & B",
+				Type:     client.MonitorType("HEARTBEAT"),
+				Interval: 3600,
+			},
+			listBody: `{"data":[
+				{"id":202,"friendlyName":"A &amp; B","type":"HEARTBEAT","url":"https://heartbeat.uptimerobot.com/token"}
+			],"nextCursorId":null}`,
+			wantID: 202,
+		},
+		"404 on ping create with API-normalized URL": {
+			createStatus: http.StatusNotFound,
+			createBody:   `{"message":"Monitor not found","code":"000-004"}`,
+			createReq: &client.CreateMonitorRequest{
+				Name:     "ping-prod",
+				Type:     client.MonitorType("PING"),
+				URL:      "https://example.com/health",
+				Interval: 300,
+			},
+			listBody: `{"data":[
+				{"id":203,"friendlyName":"ping-prod","type":"PING","url":"example.com/health"}
+			],"nextCursorId":null}`,
+			wantID: 203,
+		},
 	}
 
 	for name, tc := range cases {
@@ -106,6 +134,54 @@ func TestRecoverMonitorCreatedDespiteErrorAdopts(t *testing.T) {
 				t.Fatalf("expected no error diagnostics, got %v", diags)
 			}
 		})
+	}
+}
+
+func TestRecoverMonitorCreatedDespiteErrorWaitsForListVisibility(t *testing.T) {
+	t.Parallel()
+
+	var listCalls atomic.Int32
+	r := newRecoverTestResource(t, func(w http.ResponseWriter, req *http.Request) {
+		switch {
+		case req.Method == http.MethodPost && req.URL.Path == "/monitors":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"Monitor not found","code":"000-004"}`))
+		case req.Method == http.MethodGet && req.URL.Path == "/monitors":
+			if listCalls.Add(1) == 1 {
+				_, _ = w.Write([]byte(`{"data":[],"nextCursorId":null}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":[
+				{"id":204,"friendlyName":"delayed-heartbeat","type":"HEARTBEAT","url":"https://heartbeat.uptimerobot.com/token"}
+			],"nextCursorId":null}`))
+		default:
+			t.Errorf("unexpected request %s %s", req.Method, req.URL.RequestURI())
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+
+	createReq := &client.CreateMonitorRequest{
+		Name:     "delayed-heartbeat",
+		Type:     client.MonitorType("HEARTBEAT"),
+		Interval: 3600,
+	}
+	_, createErr := r.client.CreateMonitor(context.Background(), createReq)
+	if createErr == nil {
+		t.Fatal("expected create to fail, got nil error")
+	}
+
+	var diags diag.Diagnostics
+	adopted := r.recoverMonitorCreatedDespiteError(
+		context.Background(),
+		createReq,
+		createErr,
+		&diags,
+	)
+	if adopted == nil || adopted.ID != 204 {
+		t.Fatalf("expected delayed monitor 204 to be adopted, got %#v", adopted)
+	}
+	if listCalls.Load() < 2 {
+		t.Fatalf("expected recovery to retry the list lookup, got %d call(s)", listCalls.Load())
 	}
 }
 

--- a/internal/provider/monitor/monitor_create_recover_test.go
+++ b/internal/provider/monitor/monitor_create_recover_test.go
@@ -21,51 +21,86 @@ func newRecoverTestResource(t *testing.T, handler http.HandlerFunc) *monitorReso
 	return &monitorResource{client: apiClient}
 }
 
-func TestRecoverMonitorCreatedDespiteError404(t *testing.T) {
+func TestRecoverMonitorCreatedDespiteErrorAdopts(t *testing.T) {
 	t.Parallel()
 
-	r := newRecoverTestResource(t, func(w http.ResponseWriter, req *http.Request) {
-		switch {
-		case req.Method == http.MethodPost && req.URL.Path == "/monitors":
-			w.WriteHeader(http.StatusNotFound)
-			_, _ = w.Write([]byte(`{"message":"Monitor not found","code":"000-004"}`))
-		case req.Method == http.MethodGet && req.URL.Path == "/monitors":
+	cases := map[string]struct {
+		createStatus int
+		createBody   string
+		createReq    *client.CreateMonitorRequest
+		listBody     string
+		wantID       int64
+	}{
+		"404 on heartbeat create": {
+			createStatus: http.StatusNotFound,
+			createBody:   `{"message":"Monitor not found","code":"000-004"}`,
+			createReq: &client.CreateMonitorRequest{
+				Name:     "prod-process-sectionals",
+				Type:     client.MonitorType("HEARTBEAT"),
+				Interval: 3600,
+			},
 			// The API name filter matches substrings, so include a near-match
 			// to prove the recovery only adopts the exact name.
-			_, _ = w.Write([]byte(`{"data":[
+			listBody: `{"data":[
 				{"id":102,"friendlyName":"prod-process-sectionals-extra","type":"HEARTBEAT","url":"https://heartbeat.uptimerobot.com/other"},
 				{"id":101,"friendlyName":"prod-process-sectionals","type":"HEARTBEAT","url":"https://heartbeat.uptimerobot.com/token"}
-			],"nextCursorId":null}`))
-		default:
-			t.Errorf("unexpected request %s %s", req.Method, req.URL.RequestURI())
-			w.WriteHeader(http.StatusInternalServerError)
-		}
-	})
-
-	createReq := &client.CreateMonitorRequest{
-		Name:     "prod-process-sectionals",
-		Type:     client.MonitorType("HEARTBEAT"),
-		Interval: 3600,
+			],"nextCursorId":null}`,
+			wantID: 101,
+		},
+		"5xx on http create with matching url": {
+			createStatus: http.StatusInternalServerError,
+			createBody:   `{"message":"Internal Server Error","statusCode":500}`,
+			createReq: &client.CreateMonitorRequest{
+				Name:     "api-prod",
+				Type:     client.MonitorType("HTTP"),
+				URL:      "https://example.com/health",
+				Interval: 300,
+			},
+			listBody: `{"data":[
+				{"id":201,"friendlyName":"api-prod","type":"HTTP","url":"https://example.com/health"}
+			],"nextCursorId":null}`,
+			wantID: 201,
+		},
 	}
 
-	_, createErr := r.client.CreateMonitor(context.Background(), createReq)
-	if createErr == nil {
-		t.Fatal("expected create to fail, got nil error")
-	}
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	var diags diag.Diagnostics
-	adopted := r.recoverMonitorCreatedDespiteError(context.Background(), createReq, createErr, &diags)
-	if adopted == nil {
-		t.Fatal("expected monitor to be adopted, got nil")
-	}
-	if adopted.ID != 101 {
-		t.Fatalf("expected adopted monitor id 101, got %d", adopted.ID)
-	}
-	if diags.WarningsCount() != 1 {
-		t.Fatalf("expected 1 warning diagnostic, got %d: %v", diags.WarningsCount(), diags)
-	}
-	if diags.HasError() {
-		t.Fatalf("expected no error diagnostics, got %v", diags)
+			r := newRecoverTestResource(t, func(w http.ResponseWriter, req *http.Request) {
+				switch {
+				case req.Method == http.MethodPost && req.URL.Path == "/monitors":
+					w.WriteHeader(tc.createStatus)
+					_, _ = w.Write([]byte(tc.createBody))
+				case req.Method == http.MethodGet && req.URL.Path == "/monitors":
+					_, _ = w.Write([]byte(tc.listBody))
+				default:
+					t.Errorf("unexpected request %s %s", req.Method, req.URL.RequestURI())
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			})
+
+			_, createErr := r.client.CreateMonitor(context.Background(), tc.createReq)
+			if createErr == nil {
+				t.Fatal("expected create to fail, got nil error")
+			}
+
+			var diags diag.Diagnostics
+			adopted := r.recoverMonitorCreatedDespiteError(context.Background(), tc.createReq, createErr, &diags)
+			if adopted == nil {
+				t.Fatal("expected monitor to be adopted, got nil")
+			}
+			if adopted.ID != tc.wantID {
+				t.Fatalf("expected adopted monitor id %d, got %d", tc.wantID, adopted.ID)
+			}
+			if diags.WarningsCount() != 1 {
+				t.Fatalf("expected 1 warning diagnostic, got %d: %v", diags.WarningsCount(), diags)
+			}
+			if diags.HasError() {
+				t.Fatalf("expected no error diagnostics, got %v", diags)
+			}
+		})
 	}
 }
 
@@ -108,21 +143,41 @@ func TestRecoverMonitorCreatedDespiteErrorSkipsCleanValidationErrors(t *testing.
 func TestRecoverMonitorCreatedDespiteErrorRequiresExactlyOneMatch(t *testing.T) {
 	t.Parallel()
 
-	cases := map[string]string{
-		"no exact match": `{"data":[
-			{"id":102,"friendlyName":"prod-process-sectionals-extra","type":"HEARTBEAT","url":""}
-		],"nextCursorId":null}`,
-		"multiple exact matches": `{"data":[
-			{"id":101,"friendlyName":"prod-process-sectionals","type":"HEARTBEAT","url":""},
-			{"id":103,"friendlyName":"prod-process-sectionals","type":"HEARTBEAT","url":""}
-		],"nextCursorId":null}`,
-		"exact name but different type": `{"data":[
-			{"id":104,"friendlyName":"prod-process-sectionals","type":"HTTP","url":"https://example.com"}
-		],"nextCursorId":null}`,
+	cases := map[string]struct {
+		reqType  string
+		reqURL   string
+		listBody string
+	}{
+		"no exact match": {
+			reqType: "HEARTBEAT",
+			listBody: `{"data":[
+				{"id":102,"friendlyName":"prod-process-sectionals-extra","type":"HEARTBEAT","url":""}
+			],"nextCursorId":null}`,
+		},
+		"multiple exact matches": {
+			reqType: "HEARTBEAT",
+			listBody: `{"data":[
+				{"id":101,"friendlyName":"prod-process-sectionals","type":"HEARTBEAT","url":""},
+				{"id":103,"friendlyName":"prod-process-sectionals","type":"HEARTBEAT","url":""}
+			],"nextCursorId":null}`,
+		},
+		"exact name but different type": {
+			reqType: "HEARTBEAT",
+			listBody: `{"data":[
+				{"id":104,"friendlyName":"prod-process-sectionals","type":"HTTP","url":"https://example.com"}
+			],"nextCursorId":null}`,
+		},
+		"exact name and type but different url": {
+			reqType: "HTTP",
+			reqURL:  "https://example.com/health",
+			listBody: `{"data":[
+				{"id":105,"friendlyName":"prod-process-sectionals","type":"HTTP","url":"https://example.com/other"}
+			],"nextCursorId":null}`,
+		},
 	}
 
-	for name, listBody := range cases {
-		listBody := listBody
+	for name, tc := range cases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -132,7 +187,7 @@ func TestRecoverMonitorCreatedDespiteErrorRequiresExactlyOneMatch(t *testing.T) 
 					w.WriteHeader(http.StatusNotFound)
 					_, _ = w.Write([]byte(`{"message":"Monitor not found","code":"000-004"}`))
 				case req.Method == http.MethodGet && req.URL.Path == "/monitors":
-					_, _ = w.Write([]byte(listBody))
+					_, _ = w.Write([]byte(tc.listBody))
 				default:
 					t.Errorf("unexpected request %s %s", req.Method, req.URL.RequestURI())
 					w.WriteHeader(http.StatusInternalServerError)
@@ -141,7 +196,8 @@ func TestRecoverMonitorCreatedDespiteErrorRequiresExactlyOneMatch(t *testing.T) 
 
 			createReq := &client.CreateMonitorRequest{
 				Name:     "prod-process-sectionals",
-				Type:     client.MonitorType("HEARTBEAT"),
+				Type:     client.MonitorType(tc.reqType),
+				URL:      tc.reqURL,
 				Interval: 3600,
 			}
 

--- a/internal/provider/monitor/monitor_crud_create.go
+++ b/internal/provider/monitor/monitor_crud_create.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -37,8 +39,11 @@ func (r *monitorResource) Create(ctx context.Context, req resource.CreateRequest
 	// Create
 	created, err := r.client.CreateMonitor(ctx, createReq)
 	if err != nil {
-		resp.Diagnostics.AddError("Error creating monitor", "Could not create monitor, unexpected error: "+err.Error())
-		return
+		created = r.recoverMonitorCreatedDespiteError(ctx, createReq, err, &resp.Diagnostics)
+		if created == nil {
+			resp.Diagnostics.AddError("Error creating monitor", "Could not create monitor, unexpected error: "+err.Error())
+			return
+		}
 	}
 
 	// Wait to apply in the API
@@ -79,6 +84,58 @@ func (r *monitorResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, final)...)
+}
+
+// recoverMonitorCreatedDespiteError handles create calls that fail with an
+// ambiguous API response (404 or 5xx). POST /monitors is known to persist the
+// monitor and still answer with an error (e.g. "404 Monitor not found
+// (code 000-004)"), which would otherwise orphan the monitor outside of state
+// and make the next apply fail on the duplicate. Look the monitor up by its
+// exact name (plus type, and URL when one was requested) and adopt it only if
+// there is exactly one match.
+func (r *monitorResource) recoverMonitorCreatedDespiteError(
+	ctx context.Context,
+	createReq *client.CreateMonitorRequest,
+	createErr error,
+	diags *diag.Diagnostics,
+) *client.Monitor {
+	status, ok := client.StatusCode(createErr)
+	if !ok || (status != http.StatusNotFound && status < 500) {
+		return nil
+	}
+
+	monitors, err := r.client.GetMonitorsByName(ctx, createReq.Name)
+	if err != nil {
+		return nil
+	}
+
+	var matches []client.Monitor
+	for _, m := range monitors {
+		// The API name filter matches substrings; require an exact match.
+		if m.Name != createReq.Name {
+			continue
+		}
+		if !strings.EqualFold(m.Type, string(createReq.Type)) {
+			continue
+		}
+		if createReq.URL != "" && m.URL != createReq.URL {
+			continue
+		}
+		matches = append(matches, m)
+	}
+	if len(matches) != 1 {
+		return nil
+	}
+
+	adopted := matches[0]
+	diags.AddWarning(
+		"Monitor create reported an error but the monitor was created",
+		fmt.Sprintf(
+			"The API answered the create request for %q with an error (%s) but the monitor was created anyway (id %d); adopting it into state.",
+			createReq.Name, createErr.Error(), adopted.ID,
+		),
+	)
+	return &adopted
 }
 
 // High level validate create plan

--- a/internal/provider/monitor/monitor_crud_create.go
+++ b/internal/provider/monitor/monitor_crud_create.go
@@ -17,7 +17,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/uptimerobot/terraform-provider-uptimerobot/internal/client"
+	"github.com/uptimerobot/terraform-provider-uptimerobot/internal/provider/apiretry"
 )
+
+var monitorCreateRecoveryBackoffs = []time.Duration{
+	250 * time.Millisecond,
+	500 * time.Millisecond,
+	1 * time.Second,
+	2 * time.Second,
+}
 
 func (r *monitorResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan monitorResourceModel
@@ -132,7 +140,13 @@ func (r *monitorResource) recoverMonitorCreatedDespiteError(
 		return nil
 	}
 
-	matches, err := r.findCandidateMonitors(ctx, createReq)
+	var matches []client.Monitor
+	var err error
+	if isAmbiguous404 {
+		matches, err = r.findCandidateMonitorsWithRetry(ctx, createReq)
+	} else {
+		matches, err = r.findCandidateMonitors(ctx, createReq)
+	}
 	if err != nil || len(matches) != 1 {
 		return nil
 	}
@@ -170,20 +184,54 @@ func (r *monitorResource) findCandidateMonitors(ctx context.Context, createReq *
 		return nil, err
 	}
 
+	requestedName := unescapeHTML(createReq.Name)
+	requestedURL := unescapeHTML(createReq.URL)
 	var matches []client.Monitor
 	for _, m := range monitors {
-		if m.Name != createReq.Name {
+		if unescapeHTML(m.Name) != requestedName {
 			continue
 		}
 		if !strings.EqualFold(m.Type, string(createReq.Type)) {
 			continue
 		}
-		if createReq.URL != "" && m.URL != createReq.URL {
+		if requestedURL != "" &&
+			!monitorURLsEquivalentForState(
+				string(createReq.Type),
+				requestedURL,
+				unescapeHTML(m.URL),
+			) {
 			continue
 		}
 		matches = append(matches, m)
 	}
 	return matches, nil
+}
+
+// findCandidateMonitorsWithRetry allows the list read path to catch up after
+// the create endpoint's own read-after-write lookup returned the known
+// ambiguous 404. It never retries the POST.
+func (r *monitorResource) findCandidateMonitorsWithRetry(
+	ctx context.Context,
+	createReq *client.CreateMonitorRequest,
+) ([]client.Monitor, error) {
+	for attempt := 0; ; attempt++ {
+		matches, err := r.findCandidateMonitors(ctx, createReq)
+		if err == nil && len(matches) > 0 {
+			return matches, nil
+		}
+		if err != nil && !apiretry.IsTempServerErr(err) {
+			return nil, err
+		}
+		if attempt >= len(monitorCreateRecoveryBackoffs) {
+			return matches, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(monitorCreateRecoveryBackoffs[attempt]):
+		}
+	}
 }
 
 // High level validate create plan

--- a/internal/provider/monitor/monitor_crud_create.go
+++ b/internal/provider/monitor/monitor_crud_create.go
@@ -38,12 +38,14 @@ func (r *monitorResource) Create(ctx context.Context, req resource.CreateRequest
 
 	// Create
 	created, err := r.client.CreateMonitor(ctx, createReq)
+	adopted := false
 	if err != nil {
 		created = r.recoverMonitorCreatedDespiteError(ctx, createReq, err, &resp.Diagnostics)
 		if created == nil {
 			resp.Diagnostics.AddError("Error creating monitor", "Could not create monitor, unexpected error: "+err.Error())
 			return
 		}
+		adopted = true
 	}
 
 	// Wait to apply in the API
@@ -55,6 +57,21 @@ func (r *monitorResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 	api, err := r.waitMonitorSettled(ctx, created.ID, want, settleTimeout)
 	if err != nil {
+		if adopted {
+			// An adopted monitor's config can't be trusted the way a normal
+			// create can; if it doesn't settle to match what was requested,
+			// fail loudly instead of writing a possibly-mismatched monitor
+			// into state.
+			resp.Diagnostics.AddError(
+				"Adopted monitor does not match requested configuration",
+				fmt.Sprintf(
+					"Monitor %d was adopted after an ambiguous create error, but it did not settle to match the requested configuration: %s. "+
+						"It was not written to state; inspect the monitor in UptimeRobot (and import it manually once it matches) before re-applying.",
+					created.ID, err.Error(),
+				),
+			)
+			return
+		}
 		resp.Diagnostics.AddWarning("Create settled slowly", "Backend took longer to reflect changes; proceeding.")
 		if api == nil {
 			api = created
@@ -86,32 +103,75 @@ func (r *monitorResource) Create(ctx context.Context, req resource.CreateRequest
 	resp.Diagnostics.Append(resp.State.Set(ctx, final)...)
 }
 
-// recoverMonitorCreatedDespiteError handles create calls that fail with an
-// ambiguous API response (404 or 5xx). POST /monitors is known to persist the
-// monitor and still answer with an error (e.g. "404 Monitor not found
-// (code 000-004)"), which would otherwise orphan the monitor outside of state
-// and make the next apply fail on the duplicate. Look the monitor up by its
-// exact name (plus type, and URL when one was requested) and adopt it only if
-// there is exactly one match.
+// recoverMonitorCreatedDespiteError handles create calls that fail with the
+// one known-ambiguous API response: HTTP 404 "Monitor not found" (code
+// 000-004). POST /monitors can persist the monitor and still answer with
+// that error, which would otherwise orphan the monitor outside of state and
+// make the next apply fail on the duplicate. Look the monitor up by its
+// exact name (plus type, and URL when one was requested) and adopt it only
+// if there is exactly one match.
+//
+// Any other error status (including other 5xx responses) is treated as a
+// genuine create failure: the API is known to sometimes persist a monitor
+// with invalid settings (e.g. an out-of-range interval) alongside a 500, and
+// that monitor is not safe to adopt automatically. In that case, if exactly
+// one candidate monitor is found, its ID is surfaced as an import hint only
+// - the create still fails.
 func (r *monitorResource) recoverMonitorCreatedDespiteError(
 	ctx context.Context,
 	createReq *client.CreateMonitorRequest,
 	createErr error,
 	diags *diag.Diagnostics,
 ) *client.Monitor {
-	status, ok := client.StatusCode(createErr)
-	if !ok || (status != http.StatusNotFound && status < 500) {
+	apiErr, ok := client.AsAPIError(createErr)
+	if !ok {
+		return nil
+	}
+	isAmbiguous404 := apiErr.StatusCode == http.StatusNotFound && apiErr.Code == "000-004"
+	if !isAmbiguous404 && apiErr.StatusCode < 500 {
 		return nil
 	}
 
+	matches, err := r.findCandidateMonitors(ctx, createReq)
+	if err != nil || len(matches) != 1 {
+		return nil
+	}
+	candidate := matches[0]
+
+	if !isAmbiguous404 {
+		diags.AddWarning(
+			"A monitor matching this create request was found but not adopted",
+			fmt.Sprintf(
+				"The create request for %q failed (%s). A monitor with the same name and type (and URL, if one was requested) already exists (id %d) and may be the one this request attempted to create. "+
+					"It was not adopted automatically because this isn't the known-ambiguous 404 (code 000-004) case, and its settings can't be trusted to match what was requested. "+
+					"If you confirm it matches, import it manually.",
+				createReq.Name, createErr.Error(), candidate.ID,
+			),
+		)
+		return nil
+	}
+
+	diags.AddWarning(
+		"Monitor create reported an error but the monitor was created",
+		fmt.Sprintf(
+			"The API answered the create request for %q with an error (%s) but the monitor was created anyway (id %d); adopting it into state.",
+			createReq.Name, createErr.Error(), candidate.ID,
+		),
+	)
+	return &candidate
+}
+
+// findCandidateMonitors looks up monitors that could match createReq by
+// exact name (the API's name filter matches substrings), type, and URL (when
+// the request had one).
+func (r *monitorResource) findCandidateMonitors(ctx context.Context, createReq *client.CreateMonitorRequest) ([]client.Monitor, error) {
 	monitors, err := r.client.GetMonitorsByName(ctx, createReq.Name)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	var matches []client.Monitor
 	for _, m := range monitors {
-		// The API name filter matches substrings; require an exact match.
 		if m.Name != createReq.Name {
 			continue
 		}
@@ -123,19 +183,7 @@ func (r *monitorResource) recoverMonitorCreatedDespiteError(
 		}
 		matches = append(matches, m)
 	}
-	if len(matches) != 1 {
-		return nil
-	}
-
-	adopted := matches[0]
-	diags.AddWarning(
-		"Monitor create reported an error but the monitor was created",
-		fmt.Sprintf(
-			"The API answered the create request for %q with an error (%s) but the monitor was created anyway (id %d); adopting it into state.",
-			createReq.Name, createErr.Error(), adopted.ID,
-		),
-	)
-	return &adopted
+	return matches, nil
 }
 
 // High level validate create plan


### PR DESCRIPTION
Fixes #274

## Problem

POST /monitors can persist a monitor and still return 404 "Monitor not found" (code 000-004). Treating that response as a clean create failure leaves the monitor outside Terraform state, and the next apply can fail because the monitor already exists.

## Change

- Preserve wrapped API errors so the provider can inspect the status and API error code.
- Recover only from the known ambiguous 404 / 000-004 response.
- Poll the monitor list with bounded backoff so recovery also tolerates delayed list visibility; the create request itself is never retried.
- Adopt only one exact normalized name/type/URL match, then run the existing settlement checks before writing state.
- Keep other failures as errors. A uniquely matching monitor found after a generic 5xx is reported only as a manual import hint and is never adopted automatically.

## Verification

Unit coverage includes delayed visibility, exact-match uniqueness, normalized names and URLs, generic 5xx non-adoption, validation errors, and wrapped error inspection. The full Go test and vet suites pass. Focused live acceptance tests pass for HTTP create/update, HEARTBEAT create, and name/URL normalization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monitor creation reliability by attempting automatic recovery when the API reports an ambiguous “not found” scenario.
  * If exactly one existing monitor matches the requested name/type (and URL when provided), the provider adopts it so creation can succeed.
  * Recovery waits for list visibility and will not adopt for clean validation errors or generic server failures.
  * If adoption occurs but the monitor fails to settle, the provider stops and does not write it to state.
  * Preserves the original underlying error for clearer diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->