### PR TITLE
fix: don't treat unknown grace_period as missing on HEARTBEAT monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Fixed
+
+- Fixed `uptimerobot_monitor` incorrectly rejecting a HEARTBEAT monitor's `grace_period` as missing when its value comes from a `for_each`/`count` instance (e.g. `grace_period = each.value.grace_period`) and is legitimately unknown at `ValidateConfig` time, not absent.
+
 ## 1.9.1 — 2026-07-01
 
 ### Changed

--- a/internal/provider/monitor/monitor_validate.go
+++ b/internal/provider/monitor/monitor_validate.go
@@ -158,7 +158,10 @@ func validateGracePeriodAndTimeout(
 	switch monitorType {
 	case MonitorTypeHEARTBEAT:
 		// heartbeat MUST use grace_period and MUST NOT use timeout
-		if data.GracePeriod.IsNull() || data.GracePeriod.IsUnknown() {
+		// Do not treat unknown as missing: for_each/count instances aren't
+		// expanded yet during ValidateConfig, so a per-instance grace_period
+		// is legitimately unknown at this point, not absent.
+		if data.GracePeriod.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("grace_period"),
 				"Missing grace_period for heartbeat monitor",

--- a/internal/provider/monitor/monitor_validate_test.go
+++ b/internal/provider/monitor/monitor_validate_test.go
@@ -612,6 +612,42 @@ func TestValidateGracePeriodAndTimeout_PING_AllowsTimeout(t *testing.T) {
 	}
 }
 
+func TestValidateGracePeriodAndTimeout_HEARTBEAT_AllowsUnknownGracePeriodAtPlanTime(t *testing.T) {
+	t.Parallel()
+
+	// A monitor built with for_each/count has an unexpanded grace_period at
+	// ValidateConfig time (e.g. grace_period = each.value.grace_period), so
+	// it arrives as unknown rather than null. That must not be treated as
+	// missing: the real value is known by plan/apply time.
+	resp := &resource.ValidateConfigResponse{}
+	data := &monitorResourceModel{
+		Timeout:     types.Int64Null(),
+		GracePeriod: types.Int64Unknown(),
+	}
+
+	validateGracePeriodAndTimeout(context.TODO(), MonitorTypeHEARTBEAT, data, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected no errors for unknown grace_period on HEARTBEAT monitor, got: %v", resp.Diagnostics)
+	}
+}
+
+func TestValidateGracePeriodAndTimeout_HEARTBEAT_RejectsNullGracePeriod(t *testing.T) {
+	t.Parallel()
+
+	resp := &resource.ValidateConfigResponse{}
+	data := &monitorResourceModel{
+		Timeout:     types.Int64Null(),
+		GracePeriod: types.Int64Null(),
+	}
+
+	validateGracePeriodAndTimeout(context.TODO(), MonitorTypeHEARTBEAT, data, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected an error for null grace_period on HEARTBEAT monitor")
+	}
+}
+
 func TestValidateConfig_SSLDays_AllowsHTTP(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #277

## Summary
- `validateGracePeriodAndTimeout` rejects HEARTBEAT monitors whose `grace_period` is *unknown* at `ValidateConfig` time (e.g. `grace_period = each.value.grace_period` in a `for_each`/`count` resource), treating "not known yet" the same as "left blank."
- This breaks `terraform validate`/`plan` for any HEARTBEAT monitor built from a `for_each` map with a per-instance grace period, even though the value is perfectly valid by apply time.
- Fix: only treat `IsNull()` as "missing" — `IsUnknown()` just means Terraform hasn't expanded the instance yet. This mirrors the pattern already used elsewhere in this file (`validateURL`, `validateAssignedAlertContacts`).

## Repro

```hcl
locals {
  monitors = {
    a = { grace_period = 60 }
  }
}

resource "uptimerobot_monitor" "jobs" {
  for_each     = local.monitors
  type         = "HEARTBEAT"
  grace_period = each.value.grace_period
  ...
}
```

`terraform validate` fails with `Missing grace_period for heartbeat monitor`, even though every instance has a concrete value.

## Test plan
- [x] Added `TestValidateGracePeriodAndTimeout_HEARTBEAT_AllowsUnknownGracePeriodAtPlanTime` — fails without the fix, passes with it.
- [x] Added `TestValidateGracePeriodAndTimeout_HEARTBEAT_RejectsNullGracePeriod` — confirms the real "missing" case still errors.
- [x] `go build ./...`, `go vet`, and the full `internal/provider/monitor` test suite pass.
- [x] Manually verified against a `terraform validate` repro using a locally-built provider via `dev_overrides`: fails on registry v1.9.1, passes with this patch.