### PR TITLE
fix: reconcile integration settings after create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Fixed
+
+- Reconciled integration notification settings after create when the API initially returns defaults, preventing persistent `enable_notifications_for` drift.
+- Made `ssl_expiration_reminder = false` explicit in integration API payloads and authoritative during refresh.
+
 ## 1.9.1 — 2026-07-01
 
 ### Changed

--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -354,7 +354,7 @@ terraform import uptimerobot_integration.example 123456
 
 ### Required
 
-- `enable_notifications_for` (Number) Enable notifications for specific events (1 for all, 2 for down only, 3 for custom).
+- `enable_notifications_for` (Number) Enable notifications for specific events (1 for up and down, 2 for down only, 3 for up only, 4 for none).
 - `name` (String) The name of the integration.
 - `ssl_expiration_reminder` (Boolean) Whether to enable SSL expiration reminders.
 - `type` (String) The type of the integration (slack, webhook, discord, telegram, pushover, pushbullet, msteams, zapier, pagerduty, googlechat, splunk, mattermost).

--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -335,9 +335,10 @@ resource "uptimerobot_integration" "zapier" {
 
 ## Notification Levels
 
-- `1` - All notifications (up, down, paused, etc.)
+- `1` - Up and down notifications
 - `2` - Down notifications only
-- `3` - Custom notification settings
+- `3` - Up notifications only
+- `4` - No notifications
 
 ## Import
 

--- a/internal/client/integration.go
+++ b/internal/client/integration.go
@@ -57,7 +57,7 @@ type SlackIntegrationData struct {
 	WebhookURL             string `json:"webhookURL,omitempty"`
 	CustomValue            string `json:"customValue,omitempty"`
 	EnableNotificationsFor string `json:"enableNotificationsFor,omitempty"`
-	SSLExpirationReminder  bool   `json:"sslExpirationReminder,omitempty"`
+	SSLExpirationReminder  bool   `json:"sslExpirationReminder"`
 }
 
 // MSTeamsIntegrationData represents the data structure for MS Teams integrations.
@@ -65,7 +65,7 @@ type MSTeamsIntegrationData struct {
 	FriendlyName           string `json:"friendlyName,omitempty"`
 	WebhookURL             string `json:"webhookURL"`
 	EnableNotificationsFor string `json:"enableNotificationsFor,omitempty"`
-	SSLExpirationReminder  bool   `json:"sslExpirationReminder,omitempty"`
+	SSLExpirationReminder  bool   `json:"sslExpirationReminder"`
 }
 
 // GoogleChatIntegrationData represents the data structure for Google Chat integrations.
@@ -74,7 +74,7 @@ type GoogleChatIntegrationData struct {
 	RoomURL                string `json:"roomURL"`
 	CustomMessage          string `json:"customMessage"` // optional (send "" to clear)
 	EnableNotificationsFor string `json:"enableNotificationsFor,omitempty"`
-	SSLExpirationReminder  bool   `json:"sslExpirationReminder,omitempty"`
+	SSLExpirationReminder  bool   `json:"sslExpirationReminder"`
 }
 
 // DiscordIntegrationData represents the data structure for Discord integrations.
@@ -83,7 +83,7 @@ type DiscordIntegrationData struct {
 	WebhookURL             string `json:"webhookURL,omitempty"`
 	CustomValue            string `json:"customValue,omitempty"`
 	EnableNotificationsFor string `json:"enableNotificationsFor,omitempty"`
-	SSLExpirationReminder  bool   `json:"sslExpirationReminder,omitempty"`
+	SSLExpirationReminder  bool   `json:"sslExpirationReminder"`
 }
 
 // WebhookIntegrationData represents the data structure for Webhook integrations.
@@ -92,7 +92,7 @@ type WebhookIntegrationData struct {
 	URLToNotify            string             `json:"urlToNotify"`
 	CustomValue            string             `json:"customValue,omitempty"`
 	EnableNotificationsFor string             `json:"enableNotificationsFor,omitempty"`
-	SSLExpirationReminder  bool               `json:"sslExpirationReminder,omitempty"`
+	SSLExpirationReminder  bool               `json:"sslExpirationReminder"`
 	PostValue              string             `json:"postValue"`
 	SendAsQueryString      bool               `json:"sendAsQueryString,omitempty"`
 	SendAsJSON             bool               `json:"sendAsJSON,omitempty"`
@@ -105,7 +105,7 @@ type ZapierIntegrationData struct {
 	FriendlyName           string `json:"friendlyName,omitempty"`
 	HookURL                string `json:"hookURL"`
 	EnableNotificationsFor string `json:"enableNotificationsFor,omitempty"`
-	SSLExpirationReminder  bool   `json:"sslExpirationReminder,omitempty"`
+	SSLExpirationReminder  bool   `json:"sslExpirationReminder"`
 }
 
 // PushbulletIntegrationData represents the data structure for Pushbullet integrations.
@@ -113,7 +113,7 @@ type PushbulletIntegrationData struct {
 	FriendlyName           string `json:"friendlyName,omitempty"`
 	AccessToken            string `json:"accessToken"`
 	EnableNotificationsFor string `json:"enableNotificationsFor,omitempty"`
-	SSLExpirationReminder  bool   `json:"sslExpirationReminder,omitempty"`
+	SSLExpirationReminder  bool   `json:"sslExpirationReminder"`
 }
 
 // MattermostIntegrationData represents the data structure for Mattermost integrations.
@@ -122,7 +122,7 @@ type MattermostIntegrationData struct {
 	WebhookURL             string  `json:"webhookURL"`
 	CustomValue            *string `json:"customValue,omitempty"`
 	EnableNotificationsFor string  `json:"enableNotificationsFor,omitempty"`
-	SSLExpirationReminder  bool    `json:"sslExpirationReminder,omitempty"`
+	SSLExpirationReminder  bool    `json:"sslExpirationReminder"`
 }
 
 // SplunkIntegrationData represents the data structure for Splunk integrations.
@@ -130,7 +130,7 @@ type SplunkIntegrationData struct {
 	FriendlyName           string `json:"friendlyName,omitempty"`
 	URLToNotify            string `json:"urlToNotify"`
 	EnableNotificationsFor string `json:"enableNotificationsFor,omitempty"`
-	SSLExpirationReminder  bool   `json:"sslExpirationReminder,omitempty"`
+	SSLExpirationReminder  bool   `json:"sslExpirationReminder"`
 }
 
 // TelegramIntegrationData represents the data structure for Telegram integrations.
@@ -139,7 +139,7 @@ type TelegramIntegrationData struct {
 	FriendlyName           string `json:"friendlyName,omitempty"`
 	CustomValue            string `json:"customValue,omitempty"` // chat ID
 	EnableNotificationsFor string `json:"enableNotificationsFor,omitempty"`
-	SSLExpirationReminder  bool   `json:"sslExpirationReminder,omitempty"`
+	SSLExpirationReminder  bool   `json:"sslExpirationReminder"`
 }
 
 // PushoverIntegrationData represents the data structure for Pushover integrations.
@@ -148,7 +148,7 @@ type PushoverIntegrationData struct {
 	UserKey                string `json:"userKey"`
 	Priority               string `json:"priority,omitempty"` //  (Lowest|Low|Normal|High|Emergency)
 	EnableNotificationsFor string `json:"enableNotificationsFor,omitempty"`
-	SSLExpirationReminder  bool   `json:"sslExpirationReminder,omitempty"`
+	SSLExpirationReminder  bool   `json:"sslExpirationReminder"`
 }
 
 // PagerDuty represents the data structure for PagerDuty integrations.
@@ -158,7 +158,7 @@ type PagerDutyIntegrationData struct {
 	Location               *string `json:"location,omitempty"`    // "us" | "eu"
 	AutoResolve            *bool   `json:"autoResolve,omitempty"` // omit unless set
 	EnableNotificationsFor string  `json:"enableNotificationsFor,omitempty"`
-	SSLExpirationReminder  bool    `json:"sslExpirationReminder,omitempty"`
+	SSLExpirationReminder  bool    `json:"sslExpirationReminder"`
 }
 
 // UpdateIntegrationRequest represents the request to update an existing integration.

--- a/internal/client/integration_test.go
+++ b/internal/client/integration_test.go
@@ -2,10 +2,55 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
 )
+
+func TestIntegrationDataIncludesFalseSSLExpirationReminder(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		data any
+	}{
+		{name: "slack", data: SlackIntegrationData{}},
+		{name: "msteams", data: MSTeamsIntegrationData{}},
+		{name: "googlechat", data: GoogleChatIntegrationData{}},
+		{name: "discord", data: DiscordIntegrationData{}},
+		{name: "webhook", data: WebhookIntegrationData{}},
+		{name: "zapier", data: ZapierIntegrationData{}},
+		{name: "pushbullet", data: PushbulletIntegrationData{}},
+		{name: "mattermost", data: MattermostIntegrationData{}},
+		{name: "splunk", data: SplunkIntegrationData{}},
+		{name: "telegram", data: TelegramIntegrationData{}},
+		{name: "pushover", data: PushoverIntegrationData{}},
+		{name: "pagerduty", data: PagerDutyIntegrationData{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			encoded, err := json.Marshal(tt.data)
+			if err != nil {
+				t.Fatalf("marshal integration data: %v", err)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(encoded, &payload); err != nil {
+				t.Fatalf("unmarshal integration data: %v", err)
+			}
+			value, ok := payload["sslExpirationReminder"]
+			if !ok {
+				t.Fatal("expected sslExpirationReminder to be present when false")
+			}
+			if value != false {
+				t.Fatalf("expected false sslExpirationReminder, got %#v", value)
+			}
+		})
+	}
+}
 
 func TestClient_ListIntegrations_WithCursor(t *testing.T) {
 	t.Parallel()

--- a/internal/provider/integration/resource.go
+++ b/internal/provider/integration/resource.go
@@ -207,7 +207,10 @@ func rollbackIntegrationAfterCreateFailure(
 	cause error,
 	diags interface{ AddError(string, string) },
 ) {
-	rollbackErr := apiClient.DeleteIntegration(ctx, id)
+	rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 45*time.Second)
+	defer cancel()
+
+	rollbackErr := apiClient.DeleteIntegration(rollbackCtx, id)
 	if rollbackErr != nil {
 		diags.AddError(
 			"Error finalizing integration after create",
@@ -216,7 +219,7 @@ func rollbackIntegrationAfterCreateFailure(
 		return
 	}
 
-	if waitErr := apiClient.WaitIntegrationDeleted(ctx, id, 30*time.Second); waitErr != nil {
+	if waitErr := apiClient.WaitIntegrationDeleted(rollbackCtx, id, 30*time.Second); waitErr != nil {
 		diags.AddError(
 			"Error finalizing integration after create",
 			fmt.Sprintf("The integration was created (id=%d), reconciliation failed, rollback delete was requested, but deletion was not confirmed: reconciliation=%v rollback_wait=%v", id, cause, waitErr),
@@ -1050,8 +1053,6 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 	state.Type = types.StringValue(TransformIntegrationTypeFromAPI(integration.Type))
 	intType := TransformIntegrationTypeFromAPI(integration.Type)
 
-	state.SSLExpirationReminder = types.BoolValue(integration.SSLExpirationReminder)
-
 	if integrationEchoesValueFromAPI(intType) {
 		if integration.WebhookURL != "" {
 			state.Value = types.StringValue(integration.WebhookURL)
@@ -1061,8 +1062,6 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 			state.Value = types.StringNull() // normalize empty. null on read
 		}
 	}
-
-	state.EnableNotificationsFor = stickyEF(prev.EnableNotificationsFor, integration.EnableNotificationsFor)
 
 	// Handle integration-specific fields based on type
 	switch TransformIntegrationTypeFromAPI(integration.Type) {
@@ -1195,6 +1194,9 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 		state.Location = types.StringNull()
 		state.AutoResolve = types.BoolNull()
 	}
+
+	state.SSLExpirationReminder = types.BoolValue(integration.SSLExpirationReminder)
+	state.EnableNotificationsFor = stickyEF(prev.EnableNotificationsFor, integration.EnableNotificationsFor)
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)

--- a/internal/provider/integration/resource.go
+++ b/internal/provider/integration/resource.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -49,14 +50,14 @@ func convertNotificationsForToString(value int64) string {
 
 // convertNotificationsForFromString converts API string format to integer.
 func convertNotificationsForFromString(value string) int64 {
-	switch value {
-	case "UpAndDown":
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "upanddown":
 		return 1
-	case "Down":
+	case "down":
 		return 2
-	case "Up":
+	case "up":
 		return 3
-	case "None":
+	case "none":
 		return 4
 	default:
 		return 1
@@ -71,13 +72,43 @@ type webhookConfig struct {
 	SendPost  json.RawMessage `json:"sendPost,omitempty"`
 }
 
+type integrationSettleExpectations struct {
+	name                   string
+	customHeaders          *map[string]string
+	enableNotificationsFor string
+	sslExpirationReminder  *bool
+}
+
+func (e integrationSettleExpectations) matches(integration *client.Integration) bool {
+	if integration == nil {
+		return false
+	}
+	if e.name != "" && integration.Name != e.name {
+		return false
+	}
+	if e.customHeaders != nil && !maputil.EqualStringMap(integration.CustomHeaders, *e.customHeaders) {
+		return false
+	}
+	if e.enableNotificationsFor != "" &&
+		!strings.EqualFold(strings.TrimSpace(integration.EnableNotificationsFor), e.enableNotificationsFor) {
+		return false
+	}
+	return e.sslExpirationReminder == nil || integration.SSLExpirationReminder == *e.sslExpirationReminder
+}
+
+func integrationSettingsMatch(integration *client.Integration, enableNotificationsFor string, sslExpirationReminder bool) bool {
+	return integrationSettleExpectations{
+		enableNotificationsFor: enableNotificationsFor,
+		sslExpirationReminder:  &sslExpirationReminder,
+	}.matches(integration)
+}
+
 // waitIntegrationSettled polls integration until expected values are visible
 // in repeated reads. This reduces stale read-after-write drift.
 func (r *integrationResource) waitIntegrationSettled(
 	ctx context.Context,
 	id int64,
-	expectedName string,
-	expectedCustomHeaders *map[string]string,
+	expected integrationSettleExpectations,
 	timeout time.Duration,
 ) (*client.Integration, error) {
 	if timeout <= 0 {
@@ -103,9 +134,7 @@ func (r *integrationResource) waitIntegrationSettled(
 		integration, err := r.client.GetIntegration(ctx, id)
 		if err == nil {
 			last = integration
-			nameOK := expectedName == "" || integration.Name == expectedName
-			customHeadersOK := expectedCustomHeaders == nil || maputil.EqualStringMap(integration.CustomHeaders, *expectedCustomHeaders)
-			if nameOK && customHeadersOK {
+			if expected.matches(integration) {
 				consecutiveMatches++
 				if consecutiveMatches >= requiredConsecutiveMatches {
 					return integration, nil
@@ -120,7 +149,14 @@ func (r *integrationResource) waitIntegrationSettled(
 		select {
 		case <-ctx.Done():
 			if last != nil {
-				return last, fmt.Errorf("timeout waiting for integration to settle; last name=%q custom_header_count=%d: %w", last.Name, len(last.CustomHeaders), ctx.Err())
+				return last, fmt.Errorf(
+					"timeout waiting for integration to settle; last name=%q custom_header_count=%d enable_notifications_for=%q ssl_expiration_reminder=%t: %w",
+					last.Name,
+					len(last.CustomHeaders),
+					last.EnableNotificationsFor,
+					last.SSLExpirationReminder,
+					ctx.Err(),
+				)
 			}
 			return nil, fmt.Errorf("timeout waiting for integration to settle: %w", ctx.Err())
 		case <-time.After(backoff):
@@ -133,6 +169,65 @@ func (r *integrationResource) waitIntegrationSettled(
 			}
 		}
 	}
+}
+
+func (r *integrationResource) updateIntegrationWithRetry(
+	ctx context.Context,
+	id int64,
+	req *client.UpdateIntegrationRequest,
+) (*client.Integration, error) {
+	backoffs := []time.Duration{
+		500 * time.Millisecond, 1 * time.Second, 2 * time.Second, 3 * time.Second, 5 * time.Second,
+	}
+
+	var updated *client.Integration
+	var err error
+	for i := 0; i < len(backoffs); i++ {
+		updated, err = r.client.UpdateIntegration(ctx, id, req)
+		if err == nil {
+			return updated, nil
+		}
+		if !apiretry.IsTempServerErr(err) || i == len(backoffs)-1 {
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(backoffs[i]):
+		}
+	}
+
+	return nil, err
+}
+
+func rollbackIntegrationAfterCreateFailure(
+	ctx context.Context,
+	apiClient *client.Client,
+	id int64,
+	cause error,
+	diags interface{ AddError(string, string) },
+) {
+	rollbackErr := apiClient.DeleteIntegration(ctx, id)
+	if rollbackErr != nil {
+		diags.AddError(
+			"Error finalizing integration after create",
+			fmt.Sprintf("The integration was created (id=%d), reconciliation failed, and rollback delete also failed: reconciliation=%v rollback=%v", id, cause, rollbackErr),
+		)
+		return
+	}
+
+	if waitErr := apiClient.WaitIntegrationDeleted(ctx, id, 30*time.Second); waitErr != nil {
+		diags.AddError(
+			"Error finalizing integration after create",
+			fmt.Sprintf("The integration was created (id=%d), reconciliation failed, rollback delete was requested, but deletion was not confirmed: reconciliation=%v rollback_wait=%v", id, cause, waitErr),
+		)
+		return
+	}
+
+	diags.AddError(
+		"Error finalizing integration after create",
+		"The integration was created but its settings could not be reconciled; the provider rolled it back by deleting it: "+cause.Error(),
+	)
 }
 
 // jsonEquivalentPlanModifier is a custom plan modifier that ignores JSON formatting differences.
@@ -488,7 +583,10 @@ func (r *integrationResource) Schema(_ context.Context, _ resource.SchemaRequest
 			},
 			"enable_notifications_for": schema.Int64Attribute{
 				Required:            true,
-				MarkdownDescription: "Enable notifications for specific events (1 for all, 2 for down only, 3 for custom).",
+				MarkdownDescription: "Enable notifications for specific events (1 for up and down, 2 for down only, 3 for up only, 4 for none).",
+				Validators: []validator.Int64{
+					int64validator.Between(1, 4),
+				},
 			},
 			"ssl_expiration_reminder": schema.BoolAttribute{
 				Required:            true,
@@ -801,13 +899,33 @@ func (r *integrationResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	if t == "webhook" && customHeaders != nil {
-		settled, err := r.waitIntegrationSettled(ctx, newIntegration.ID, plan.Name.ValueString(), customHeaders, 90*time.Second)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Integration create did not settle in time",
-				err.Error(),
-			)
+	expectedNotifications := convertNotificationsForToString(plan.EnableNotificationsFor.ValueInt64())
+	expectedSSLExpirationReminder := plan.SSLExpirationReminder.ValueBool()
+	settingsCorrected := false
+	if !integrationSettingsMatch(newIntegration, expectedNotifications, expectedSSLExpirationReminder) {
+		updated, updateErr := r.updateIntegrationWithRetry(ctx, newIntegration.ID, &client.UpdateIntegrationRequest{
+			Type: integrationTypeAPI,
+			Data: integrationData,
+		})
+		if updateErr != nil {
+			rollbackIntegrationAfterCreateFailure(ctx, r.client, newIntegration.ID, updateErr, &resp.Diagnostics)
+			return
+		}
+		if updated != nil {
+			newIntegration = updated
+		}
+		settingsCorrected = true
+	}
+
+	if settingsCorrected || (t == "webhook" && customHeaders != nil) {
+		settled, settleErr := r.waitIntegrationSettled(ctx, newIntegration.ID, integrationSettleExpectations{
+			name:                   plan.Name.ValueString(),
+			customHeaders:          customHeaders,
+			enableNotificationsFor: expectedNotifications,
+			sslExpirationReminder:  &expectedSSLExpirationReminder,
+		}, 90*time.Second)
+		if settleErr != nil {
+			rollbackIntegrationAfterCreateFailure(ctx, r.client, newIntegration.ID, settleErr, &resp.Diagnostics)
 			return
 		}
 		if settled != nil {
@@ -817,6 +935,8 @@ func (r *integrationResource) Create(ctx context.Context, req resource.CreateReq
 
 	// Map response body to schema and populate Computed attribute values
 	plan.ID = types.StringValue(strconv.FormatInt(newIntegration.ID, 10))
+	plan.EnableNotificationsFor = types.Int64Value(convertNotificationsForFromString(newIntegration.EnableNotificationsFor))
+	plan.SSLExpirationReminder = types.BoolValue(newIntegration.SSLExpirationReminder)
 	if t == "webhook" {
 		if plan.CustomHeaders.IsNull() || plan.CustomHeaders.IsUnknown() {
 			customHeadersState, diags := webhookCustomHeadersState(ctx, plan.CustomHeaders, newIntegration.CustomHeaders)
@@ -917,7 +1037,7 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 	if !state.Name.IsNull() && !state.Name.IsUnknown() {
 		expectedName := state.Name.ValueString()
 		if expectedName != "" && integration.Name != expectedName {
-			if settled, err := r.waitIntegrationSettled(ctx, id, expectedName, nil, 60*time.Second); err == nil && settled != nil {
+			if settled, err := r.waitIntegrationSettled(ctx, id, integrationSettleExpectations{name: expectedName}, 60*time.Second); err == nil && settled != nil {
 				integration = settled
 			} else if settled != nil {
 				integration = settled
@@ -930,9 +1050,7 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 	state.Type = types.StringValue(TransformIntegrationTypeFromAPI(integration.Type))
 	intType := TransformIntegrationTypeFromAPI(integration.Type)
 
-	// Use sticky behavior for SSL expiration reminder to avoid flips when API
-	// returns defaults or transient values.
-	state.SSLExpirationReminder = stickyBool(prev.SSLExpirationReminder, integration.SSLExpirationReminder, false)
+	state.SSLExpirationReminder = types.BoolValue(integration.SSLExpirationReminder)
 
 	if integrationEchoesValueFromAPI(intType) {
 		if integration.WebhookURL != "" {
@@ -985,7 +1103,10 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 				if !prev.Name.IsNull() && !prev.Name.IsUnknown() {
 					expectedName = prev.Name.ValueString()
 				}
-				if settled, err := r.waitIntegrationSettled(ctx, id, expectedName, &expectedHeaders, 60*time.Second); err == nil && settled != nil {
+				if settled, err := r.waitIntegrationSettled(ctx, id, integrationSettleExpectations{
+					name:          expectedName,
+					customHeaders: &expectedHeaders,
+				}, 60*time.Second); err == nil && settled != nil {
 					integration = settled
 				} else if settled != nil {
 					integration = settled
@@ -1287,25 +1408,12 @@ func (r *integrationResource) Update(ctx context.Context, req resource.UpdateReq
 		Data: integrationData,
 	}
 
-	backoffs := []time.Duration{
-		500 * time.Millisecond, 1 * time.Second, 2 * time.Second, 3 * time.Second, 5 * time.Second,
-	}
-	for i := 0; i < len(backoffs); i++ {
-		_, err = r.client.UpdateIntegration(ctx, id, integration)
-		if err == nil {
-			break
-		}
-		if !apiretry.IsTempServerErr(err) || i == len(backoffs)-1 {
-			break
-		}
-		select {
-		case <-ctx.Done():
+	_, err = r.updateIntegrationWithRetry(ctx, id, integration)
+	if err != nil {
+		if ctx.Err() != nil {
 			resp.Diagnostics.AddError("Update cancelled", ctx.Err().Error())
 			return
-		case <-time.After(backoffs[i]):
 		}
-	}
-	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating integration",
 			"Could not update integration, unexpected error: "+err.Error(),
@@ -1313,7 +1421,13 @@ func (r *integrationResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	settled, err := r.waitIntegrationSettled(ctx, id, plan.Name.ValueString(), customHeaders, 90*time.Second)
+	expectedSSLExpirationReminder := plan.SSLExpirationReminder.ValueBool()
+	settled, err := r.waitIntegrationSettled(ctx, id, integrationSettleExpectations{
+		name:                   plan.Name.ValueString(),
+		customHeaders:          customHeaders,
+		enableNotificationsFor: convertNotificationsForToString(plan.EnableNotificationsFor.ValueInt64()),
+		sslExpirationReminder:  &expectedSSLExpirationReminder,
+	}, 90*time.Second)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Integration update did not settle in time",
@@ -1445,12 +1559,7 @@ func stickyEF(prev types.Int64, api string) types.Int64 {
 		}
 		return types.Int64Value(1) // UpAndDown
 	}
-	v := convertNotificationsForFromString(a)
-	if v == 1 && !prev.IsNull() && !prev.IsUnknown() && prev.ValueInt64() != 1 {
-		// API defaulted to UpAndDown. Keep previously configured non-default
-		return prev
-	}
-	return types.Int64Value(v)
+	return types.Int64Value(convertNotificationsForFromString(a))
 }
 
 func pagerDutyLocationFromAPI(integration *client.Integration) (string, bool) {

--- a/internal/provider/integration/resource_acc_test.go
+++ b/internal/provider/integration/resource_acc_test.go
@@ -19,14 +19,14 @@ import (
 
 // Configs
 
-func testAccWebhookIntegrationConfig(name, value string) string {
+func testAccWebhookIntegrationConfig(name, value string, enableNotificationsFor int64, sslExpirationReminder bool) string {
 	return provideracctest.ProviderConfig() + fmt.Sprintf(`
 resource "uptimerobot_integration" "webhook" {
   name                     = %q
   type                     = "webhook"
   value                    = %q
-  enable_notifications_for = 1
-  ssl_expiration_reminder  = true
+  enable_notifications_for = %d
+  ssl_expiration_reminder  = %t
 
   // webhook send options
   send_as_json             = true
@@ -34,7 +34,7 @@ resource "uptimerobot_integration" "webhook" {
   send_as_post_parameters  = false
   post_value               = "{\"message\": \"Alert: $monitorURL is $alertType\"}"
 }
-`, name, value)
+`, name, value, enableNotificationsFor, sslExpirationReminder)
 }
 
 func testAccWebhookIntegrationConfigWithCustomHeaders(name, value string, headers *map[string]string) string {
@@ -116,8 +116,8 @@ func TestAccIntegrationResource(t *testing.T) {
 	name2 := "tfacc-webhook-upd-" + suffix
 	value := fmt.Sprintf("https://httpbin.org/anything?tfacc=%s", suffix)
 
-	cfgCreate := testAccWebhookIntegrationConfig(name1, value)
-	cfgUpdate := testAccWebhookIntegrationConfig(name2, value)
+	cfgCreate := testAccWebhookIntegrationConfig(name1, value, 2, false)
+	cfgUpdate := testAccWebhookIntegrationConfig(name2, value, 3, true)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { provideracctest.PreCheck(t) },
@@ -130,19 +130,21 @@ func TestAccIntegrationResource(t *testing.T) {
 					resource.TestCheckResourceAttr("uptimerobot_integration.webhook", "name", name1),
 					resource.TestCheckResourceAttr("uptimerobot_integration.webhook", "type", "webhook"),
 					resource.TestCheckResourceAttr("uptimerobot_integration.webhook", "value", value),
-					resource.TestCheckResourceAttr("uptimerobot_integration.webhook", "enable_notifications_for", "1"),
-					resource.TestCheckResourceAttr("uptimerobot_integration.webhook", "ssl_expiration_reminder", "true"),
+					resource.TestCheckResourceAttr("uptimerobot_integration.webhook", "enable_notifications_for", "2"),
+					resource.TestCheckResourceAttr("uptimerobot_integration.webhook", "ssl_expiration_reminder", "false"),
 					resource.TestCheckResourceAttr("uptimerobot_integration.webhook", "send_as_json", "true"),
 					resource.TestCheckResourceAttr("uptimerobot_integration.webhook", "send_as_query_string", "false"),
 					resource.TestCheckResourceAttr("uptimerobot_integration.webhook", "send_as_post_parameters", "false"),
 				),
 			},
 			{
-				// update just the name to verify Update works
+				// Update the name and integration settings to verify both paths settle.
 				Config: cfgUpdate,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("uptimerobot_integration.webhook", "name", name2),
 					resource.TestCheckResourceAttr("uptimerobot_integration.webhook", "value", value),
+					resource.TestCheckResourceAttr("uptimerobot_integration.webhook", "enable_notifications_for", "3"),
+					resource.TestCheckResourceAttr("uptimerobot_integration.webhook", "ssl_expiration_reminder", "true"),
 				),
 			},
 			{

--- a/internal/provider/integration/resource_test.go
+++ b/internal/provider/integration/resource_test.go
@@ -150,8 +150,11 @@ func TestRollbackIntegrationAfterCreateFailureDeletesCreatedIntegration(t *testi
 	apiClient := client.NewClient("test-key")
 	apiClient.SetBaseURL(srv.URL)
 
+	parentCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
 	var diags diag.Diagnostics
-	rollbackIntegrationAfterCreateFailure(context.Background(), apiClient, 101, errors.New("update failed"), &diags)
+	rollbackIntegrationAfterCreateFailure(parentCtx, apiClient, 101, errors.New("update failed"), &diags)
 
 	if !deleteCalled {
 		t.Fatal("expected rollback delete to be called")

--- a/internal/provider/integration/resource_test.go
+++ b/internal/provider/integration/resource_test.go
@@ -2,11 +2,15 @@ package integration
 
 import (
 	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/uptimerobot/terraform-provider-uptimerobot/internal/client"
 )
@@ -60,6 +64,106 @@ func TestPagerDutyLocationFromAPI(t *testing.T) {
 				t.Fatalf("value mismatch: got=%q want=%q", gotValue, tt.wantValue)
 			}
 		})
+	}
+}
+
+func TestStickyEFUsesExplicitAPIValue(t *testing.T) {
+	t.Parallel()
+
+	got := stickyEF(types.Int64Value(2), "UpAndDown")
+	if got.IsNull() || got.IsUnknown() {
+		t.Fatal("expected known value")
+	}
+	if got.ValueInt64() != 1 {
+		t.Fatalf("expected API value 1 to replace stale state, got %d", got.ValueInt64())
+	}
+}
+
+func TestIntegrationSettingsMatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		integration *client.Integration
+		want        bool
+	}{
+		{
+			name: "matching",
+			integration: &client.Integration{
+				EnableNotificationsFor: "Down",
+				SSLExpirationReminder:  true,
+			},
+			want: true,
+		},
+		{
+			name: "notification drift",
+			integration: &client.Integration{
+				EnableNotificationsFor: "UpAndDown",
+				SSLExpirationReminder:  true,
+			},
+		},
+		{
+			name: "ssl drift",
+			integration: &client.Integration{
+				EnableNotificationsFor: "Down",
+				SSLExpirationReminder:  false,
+			},
+		},
+		{name: "missing response"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := integrationSettingsMatch(tt.integration, "Down", true); got != tt.want {
+				t.Fatalf("match mismatch: got=%v want=%v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRollbackIntegrationAfterCreateFailureDeletesCreatedIntegration(t *testing.T) {
+	t.Parallel()
+
+	var deleteCalled bool
+	var getCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "DELETE /integrations/101":
+			deleteCalled = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		case "GET /integrations/101":
+			getCalled = true
+			if !deleteCalled {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"id":101}`))
+				return
+			}
+			http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	apiClient := client.NewClient("test-key")
+	apiClient.SetBaseURL(srv.URL)
+
+	var diags diag.Diagnostics
+	rollbackIntegrationAfterCreateFailure(context.Background(), apiClient, 101, errors.New("update failed"), &diags)
+
+	if !deleteCalled {
+		t.Fatal("expected rollback delete to be called")
+	}
+	if !getCalled {
+		t.Fatal("expected rollback wait to confirm deletion")
+	}
+	if !diags.HasError() {
+		t.Fatal("expected diagnostic for original update failure")
+	}
+	if !strings.Contains(diags[0].Detail(), "rolled it back by deleting it") {
+		t.Fatalf("unexpected diagnostic: %#v", diags)
 	}
 }
 

--- a/templates/resources/integration.md.tmpl
+++ b/templates/resources/integration.md.tmpl
@@ -68,9 +68,10 @@ description: |-
 
 ## Notification Levels
 
-- `1` - All notifications (up, down, paused, etc.)
+- `1` - Up and down notifications
 - `2` - Down notifications only
-- `3` - Custom notification settings
+- `3` - Up notifications only
+- `4` - No notifications
 
 ## Import
 


### PR DESCRIPTION
## Summary

- reconcile `enable_notifications_for` and `ssl_expiration_reminder` with PATCH when the create response contains API defaults
- make API values authoritative during refresh so existing drift is visible and correctable
- always serialize `ssl_expiration_reminder = false`, validate notification modes 1-4, and update generated documentation
- roll back a newly created integration if reconciliation cannot complete

## Root cause

The provider trusted the POST response and populated state from the plan. When the public v3 create path defaulted `enableNotificationsFor` to `UpAndDown`, `stickyEF` preserved the planned non-default value and permanently masked the real remote drift.

The companion API root-cause fix is uptimerobot/api-internal#2330. The provider-side reconciliation remains useful during rollout and makes existing affected resources self-healing through normal refresh and apply.

## Impact

New integrations are verified and corrected during create. Existing affected integrations expose the actual API settings on refresh, producing a corrective plan without a state migration.

## Validation

- `go test ./...`
- `go vet ./...`
- `make lint`
- `go generate ./...`
- real public v3 `TestAccIntegrationResource` create, update, empty-plan, import, and destroy flow

Resolves #272.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Integration notification levels now reconcile reliably after creation and refresh, preventing drift from API defaults.
  * SSL expiration reminders now consistently use the API-provided value (including correctly handling `false`) during reads and refreshes.
  * Integration updates now automatically retry on temporary server (5xx) errors.
  * Notification level parsing/validation is more robust (case-insensitive, trimmed) with stricter `1–4` mapping.
* **Documentation**
  * Updated integration documentation to clarify the meanings of notification levels **1–4**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->