### PR TITLE
fix: validate heartbeat interval maximum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 - Fixed `uptimerobot_monitor` incorrectly rejecting a HEARTBEAT monitor's `grace_period` as missing when its value comes from a `for_each`/`count` instance (e.g. `grace_period = each.value.grace_period`) and is legitimately unknown at `ValidateConfig` time, not absent.
+- Fixed `uptimerobot_monitor` accepting HEARTBEAT intervals above the API's 2678400-second (31-day) maximum.
 - Reconciled integration notification settings after create when the API initially returns defaults, preventing persistent `enable_notifications_for` drift.
 - Made `ssl_expiration_reminder = false` explicit in integration API payloads and authoritative during refresh.
 

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -694,7 +694,7 @@ terraform import 'uptimerobot_monitor.monitors["www_production"]' 800123456
 
 ### Required
 
-- `interval` (Number) Interval for the monitoring check (in seconds)
+- `interval` (Number) Interval for the monitoring check (in seconds). HEARTBEAT monitors support at most 2678400 seconds (31 days).
 - `name` (String) Tip: Write names as plain text (do not use HTML entities like `&amp;`). UptimeRobot may return HTML-escaped values; the provider normalizes them to plain text on read/import.
 - `type` (String) Type of the monitor (HTTP, KEYWORD, PING, PORT, HEARTBEAT, DNS, API, UDP)
 

--- a/internal/provider/monitor/monitor_schema.go
+++ b/internal/provider/monitor/monitor_schema.go
@@ -111,7 +111,7 @@ func monitorSchema(version int64, includeApplicationErrorRetries bool) schema.Sc
 				},
 			},
 			"interval": schema.Int64Attribute{
-				Description: "Interval for the monitoring check (in seconds)",
+				Description: "Interval for the monitoring check (in seconds). HEARTBEAT monitors support at most 2678400 seconds (31 days).",
 				Required:    true,
 				Validators: []validator.Int64{
 					int64validator.AtLeast(30),

--- a/internal/provider/monitor/monitor_validate.go
+++ b/internal/provider/monitor/monitor_validate.go
@@ -17,6 +17,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
+const heartbeatMonitorIntervalMax int64 = 31 * 24 * 60 * 60
+
 func (r *monitorResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
 	return []resource.ConfigValidator{
 		resourcevalidator.Conflicting(
@@ -57,6 +59,7 @@ func (r *monitorResource) ValidateConfig(
 
 	t := strings.ToUpper(data.Type.ValueString())
 
+	validateHeartbeatInterval(t, data.Interval, resp)
 	validateURL(ctx, t, &data, resp)
 	validateGracePeriodAndTimeout(ctx, t, &data, resp)
 	validateMethodVsBody(ctx, &data, resp)
@@ -69,6 +72,28 @@ func (r *monitorResource) ValidateConfig(
 	validateKeywordMonitor(ctx, t, &data, resp)
 	validateHTTPPasswordWithoutUserName(ctx, &data, resp)
 
+}
+
+func validateHeartbeatInterval(
+	monitorType string,
+	interval types.Int64,
+	resp *resource.ValidateConfigResponse,
+) {
+	if monitorType != MonitorTypeHEARTBEAT || interval.IsNull() || interval.IsUnknown() {
+		return
+	}
+	if interval.ValueInt64() <= heartbeatMonitorIntervalMax {
+		return
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		path.Root("interval"),
+		"Heartbeat interval exceeds maximum",
+		fmt.Sprintf(
+			"HEARTBEAT monitors support intervals up to %d seconds (31 days).",
+			heartbeatMonitorIntervalMax,
+		),
+	)
 }
 
 func validateNoHTMLEntities(p path.Path, v interface {

--- a/internal/provider/monitor/monitor_validate_test.go
+++ b/internal/provider/monitor/monitor_validate_test.go
@@ -22,6 +22,53 @@ func TestValidateNoHTMLEntities_AllowsPlainText(t *testing.T) {
 	}
 }
 
+func TestValidateHeartbeatInterval(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		monitorType string
+		interval    types.Int64
+		wantError   bool
+	}{
+		{
+			name:        "heartbeat at maximum",
+			monitorType: MonitorTypeHEARTBEAT,
+			interval:    types.Int64Value(heartbeatMonitorIntervalMax),
+		},
+		{
+			name:        "heartbeat above maximum",
+			monitorType: MonitorTypeHEARTBEAT,
+			interval:    types.Int64Value(heartbeatMonitorIntervalMax + 1),
+			wantError:   true,
+		},
+		{
+			name:        "heartbeat unknown during planning",
+			monitorType: MonitorTypeHEARTBEAT,
+			interval:    types.Int64Unknown(),
+		},
+		{
+			name:        "non-heartbeat above heartbeat maximum",
+			monitorType: MonitorTypeHTTP,
+			interval:    types.Int64Value(heartbeatMonitorIntervalMax + 1),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := &resource.ValidateConfigResponse{}
+			validateHeartbeatInterval(tt.monitorType, tt.interval, resp)
+
+			if got := resp.Diagnostics.HasError(); got != tt.wantError {
+				t.Fatalf("HasError() = %t, want %t; diagnostics: %v", got, tt.wantError, resp.Diagnostics)
+			}
+		})
+	}
+}
+
 func TestValidateNoHTMLEntities_RejectsHTMLEntities(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Superseded by #280 after renaming the head branch to `fix/issue-273-heartbeat-interval-max`.