### PR TITLE
docs: add public repository hygiene guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,25 @@ Maintainers handle version increment and releases.
 
 Before opening a PR, make sure tests pass locally.
 
+### Public repository hygiene
+
+This repository is public. Treat all repository content and GitHub activity as
+public, including branch names, issues, pull request descriptions, comments,
+reviews, commit messages, CI output, screenshots, and attached logs.
+
+- Do not name or link private repositories, internal pull requests, internal
+  issue trackers, private dashboards, non-public hostnames, or internal
+  deployment details.
+- Do not publish credentials, API keys, customer or account identifiers,
+  unsanitized production data, or raw logs that may contain sensitive data.
+- Public API endpoints, documented behavior, and sanitized error responses are
+  appropriate when they help reproduce or explain a provider issue.
+- Describe dependencies on non-public work generically, for example:
+  "Requires a corresponding server-side API release."
+
+Before publishing or updating a branch, issue, or pull request, review the
+content for private references and sensitive information.
+
 ## Notes:
 - Some acceptance tests can be unstable due to network or API. Re-running is sometimes necessary.
 - Never commit real API keys or logs containing secrets. The provider redacts known secrets in debug output.


### PR DESCRIPTION
## Summary

- document that repository content and GitHub activity are public
- prohibit private repository, internal tracker, infrastructure, credential, customer-data, and unsanitized production-data disclosures
- clarify that public API behavior and sanitized errors are appropriate context
- provide generic wording for dependencies on non-public work

## Why

Public contribution guidance already covered secrets, but it did not address references that can disclose private development or operational context through PR descriptions, comments, commits, CI output, screenshots, or logs.

## Testing

- `git diff --check`
- verified the branch changes only `CONTRIBUTING.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added public repository hygiene guidance for pull requests and repository activity.
  * Clarified that private references, sensitive production data, credentials, API keys, and unsanitized logs must not be included.
  * Added recommendations to review branch, pull request, and issue content before publishing or updating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->