### PR TITLE
docs: prepare v1.9.3 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## Unreleased
 
+## 1.9.3 — 2026-07-21
+
 ### Fixed
 
-- Fixed `uptimerobot_monitor` accepting HEARTBEAT intervals above the API's 2678400-second (31-day) maximum.
+- Recovered newly created `uptimerobot_monitor` resources into state when the API returns an ambiguous not-found response after persisting the monitor, preventing orphaned monitors and duplicate retries.
+- Rejected `uptimerobot_monitor` HEARTBEAT intervals above the API's 2678400-second (31-day) maximum during planning and apply.
 
 ## 1.9.2 — 2026-07-18
 


### PR DESCRIPTION
## Summary

- preserve the `Unreleased` section for future changes
- add the `1.9.3 — 2026-07-21` release section
- include every user-facing change merged after `v1.9.2`: ambiguous monitor-create recovery and HEARTBEAT interval maximum validation

## Verification

- audited the first-parent history and complete file diff from `v1.9.2` through current `main`
- confirmed the two post-release PRs are represented in the changelog
- `git diff --check`